### PR TITLE
[7.0] Tighten type check in domain

### DIFF
--- a/mass_editing/mass_editing.py
+++ b/mass_editing/mass_editing.py
@@ -33,7 +33,7 @@ class ir_model_fields(orm.Model):
         model_domain = []
         for domain in args:
             if domain[0] == 'model_id' and domain[2]\
-                    and type(domain[2]) != list:
+                    and isinstance(domain[2], basestring):
                 model_domain += [(
                     'model_id', 'in', map(int, domain[2][1:-1].split(',')))]
             else:


### PR DESCRIPTION
Fixes #15 and #24
Check that `domain[2]` is `str` because in some cases it's an `int` and `list`
operations don't work on `int`s.
