### PR TITLE
[master] Tighten type check in domain

### DIFF
--- a/mass_editing/models/ir_model_fields.py
+++ b/mass_editing/models/ir_model_fields.py
@@ -31,12 +31,14 @@ class IrModelFields(orm.Model):
             count=False):
         model_domain = []
         for domain in args:
-            if domain[0] == 'model_id' and domain[2]\
-                    and type(domain[2]) != list:
-                model_domain += [(
-                    'model_id', 'in', map(int, domain[2][1:-1].split(',')))]
+            if (len(domain) > 2 and domain[0] == 'model_id'
+                    and isinstance(domain[2], basestring)):
+                model_domain += [
+                    ('model_id', 'in', map(int, domain[2][1:-1].split(',')))
+                ]
             else:
                 model_domain.append(domain)
         return super(IrModelFields, self).search(
             cr, uid, model_domain, offset=offset, limit=limit, order=order,
-            context=context, count=count)
+            context=context, count=count
+        )


### PR DESCRIPTION
Fixes #15
Check that `domain[2]` is `str` because in some cases it's an `int` and `list`
operations don't work on `int`s.
