### PR TITLE
7.0 Add email_template_dateutil

### DIFF
--- a/email_template_dateutil/__init__.py
+++ b/email_template_dateutil/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import email_template

--- a/email_template_dateutil/__openerp__.py
+++ b/email_template_dateutil/__openerp__.py
@@ -1,0 +1,56 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Email Template Date Utils',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'category': 'Others',
+    'summary': 'Adds extra date functions for email templates',
+    'description': """
+This module adds an extra filter in email templates:
+
+format_date(format) : parses and formats a date or datetime string
+
+Example: ${ object.date_field|format_date('%m/%d/%Y') }
+
+
+Contributors
+------------
+* Vincent Vinet (vincent.vinet@savoirfairelinux.com)
+""",
+    'depends': [
+        'email_template',
+    ],
+    'external_dependencies': {
+        'python': [],
+    },
+    'data': [
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/email_template_dateutil/__openerp__.py
+++ b/email_template_dateutil/__openerp__.py
@@ -32,7 +32,10 @@
     'description': """
 This module adds an extra filter in email templates:
 
-format_date(format) : parses and formats a date or datetime string
+format_date(format, tz=tzname) : parses and formats a date or datetime string.
+    Optional parameter tz allows specifying the timezone to use. Otherwise, the
+    user's timezone or server timezone will be used. If none are found, time is
+    left in UTC
 
 Example: ${ object.date_field|format_date('%m/%d/%Y') }
 

--- a/email_template_dateutil/email_template.py
+++ b/email_template_dateutil/email_template.py
@@ -59,8 +59,8 @@ def format_date(context, dtstr, new_format, tz=None):
             utc_timestamp = utc.localize(date, is_dst=False)  # UTC = no DST
             date = utc_timestamp.astimezone(context_tz)
         except Exception:
-            _logger.debug("failed to compute context/client-specific timestamp, "
-                          "using the UTC value",
+            _logger.debug("failed to compute context/client-specific "
+                          "timestamp, using the UTC value",
                           exc_info=True)
 
     return date.strftime(new_format)

--- a/email_template_dateutil/email_template.py
+++ b/email_template_dateutil/email_template.py
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from datetime import datetime
+
+from openerp.tools import (
+    DEFAULT_SERVER_DATETIME_FORMAT as DTFMT,
+    DEFAULT_SERVER_DATE_FORMAT as DFMT,
+)
+from openerp.addons.email_template import email_template
+
+
+def format_date(dtstr, new_format):
+    if not dtstr:
+        return dtstr
+
+    try:
+        return datetime.strptime(dtstr, DTFMT).strftime(new_format)
+    except ValueError:
+        # Maybe this is a date, not datetime
+        pass
+
+    return datetime.strptime(dtstr, DFMT).strftime(new_format)
+
+
+email_template.mako_template_env.filters.update(
+    format_date=format_date,
+)

--- a/email_template_dateutil/email_template.py
+++ b/email_template_dateutil/email_template.py
@@ -35,33 +35,49 @@ from openerp.addons.email_template import email_template
 
 
 @contextfilter
-def format_date(context, dtstr, new_format, tz=None):
+def format_date(context, dtstr, new_format=None, tz=None):
     if not dtstr:
         return dtstr
+
+    if not new_format:
+        if context.get("user") and context["user"].lang:
+            user = context["user"]
+            lang_obj = user.pool["res.lang"]
+            cr, uid = user._cr, user._uid
+            lang = lang_obj.search(cr, uid, [
+                ('code', '=', user.lang)
+            ])
+            if lang:
+                new_format = lang_obj.browse(cr, uid, lang[0]).date_format
+
+    new_format = new_format or DFMT
 
     try:
         date = datetime.strptime(dtstr, DTFMT)
     except ValueError:
         # Maybe this is a date, not datetime
         date = datetime.strptime(dtstr, DFMT)
-
-    if tz:
-        tz_name = tz
-    elif context.get("user") and context["user"].tz:
-        tz_name = context["user"].tz
     else:
-        tz_name = context.get("ctx", {}).get("tz")
+        # If this was a date, calculating timezones will give unexpected
+        # results. Any timezone with a negative offset will be the day
+        # before, since (midnight - anything) is the previous day
+        if tz:
+            tz_name = tz
+        elif context.get("user") and context["user"].tz:
+            tz_name = context["user"].tz
+        else:
+            tz_name = context.get("ctx", {}).get("tz")
 
-    if tz_name:
-        try:
-            utc = pytz.timezone('UTC')
-            context_tz = pytz.timezone(tz_name)
-            utc_timestamp = utc.localize(date, is_dst=False)  # UTC = no DST
-            date = utc_timestamp.astimezone(context_tz)
-        except Exception:
-            _logger.debug("failed to compute context/client-specific "
-                          "timestamp, using the UTC value",
-                          exc_info=True)
+        if tz_name:
+            try:
+                utc = pytz.timezone('UTC')
+                context_tz = pytz.timezone(tz_name)
+                utc_timestamp = utc.localize(date, is_dst=False)  # UTC = no DST
+                date = utc_timestamp.astimezone(context_tz)
+            except Exception:
+                _logger.debug("failed to compute context/client-specific "
+                              "timestamp, using the UTC value",
+                              exc_info=True)
 
     return date.strftime(new_format)
 

--- a/email_template_dateutil/email_template.py
+++ b/email_template_dateutil/email_template.py
@@ -72,7 +72,7 @@ def format_date(context, dtstr, new_format=None, tz=None):
             try:
                 utc = pytz.timezone('UTC')
                 context_tz = pytz.timezone(tz_name)
-                utc_timestamp = utc.localize(date, is_dst=False)  # UTC = no DST
+                utc_timestamp = utc.localize(date, is_dst=False)
                 date = utc_timestamp.astimezone(context_tz)
             except Exception:
                 _logger.debug("failed to compute context/client-specific "


### PR DESCRIPTION
This module adds a format_date filter in the Jinja2 environment for mail templates, allowing you to do
${object.invoice_date|format_date("%m/%d/%Y")} to have the date in the format you want, and converted into the user timezone.
