### PR TITLE
FIX onchange method name on mass editting module

### DIFF
--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -49,7 +49,7 @@ class MassObject(orm.Model):
         ('name_uniq', 'unique (name)', _('Name must be unique!')),
     ]
 
-    def onchange_model(self, cr, uid, ids, model_id, context=None):
+    def onchange_model_id(self, cr, uid, ids, model_id, context=None):
         if context is None:
             context = {}
         if not model_id:


### PR DESCRIPTION
on views method is called by "onchange_model_id", on mass_object.py was called "onchange_model" and now renamed to "onchange_model_id"
