### PR TITLE
8 email tpl field fix

### DIFF
--- a/scheduler_error_mailer/ir_cron.py
+++ b/scheduler_error_mailer/ir_cron.py
@@ -35,9 +35,9 @@ class ir_cron(orm.Model):
     _inherit = "ir.cron"
 
     _columns = {
-        'email_template': fields.many2one(
-            'email.template',
+        'email_template_id': fields.many2one('email.template',
             'Error E-mail Template',
+            oldname="email_template",
             help="Select the email template that will be "
                  "sent when this scheduler fails."),
     }
@@ -50,7 +50,7 @@ class ir_cron(orm.Model):
 
         my_cron = self.browse(cr, uid, job_id)
 
-        if my_cron.email_template:
+        if my_cron.email_template_id:
             # we put the job_exception in context to be able to print it inside
             # the email template
             context = {

--- a/scheduler_error_mailer/ir_cron.py
+++ b/scheduler_error_mailer/ir_cron.py
@@ -35,7 +35,8 @@ class ir_cron(orm.Model):
     _inherit = "ir.cron"
 
     _columns = {
-        'email_template_id': fields.many2one('email.template',
+        'email_template_id': fields.many2one(
+            'email.template',
             'Error E-mail Template',
             oldname="email_template",
             help="Select the email template that will be "

--- a/scheduler_error_mailer/ir_cron.xml
+++ b/scheduler_error_mailer/ir_cron.xml
@@ -14,7 +14,7 @@
     <field name="inherit_id" ref="base.ir_cron_view"/>
     <field name="arch" type="xml">
         <field name="doall" position="after">
-            <field name="email_template" />
+            <field name="email_template_id" />
         </field>
     </field>
 </record>

--- a/scheduler_error_mailer/ir_cron_demo.xml
+++ b/scheduler_error_mailer/ir_cron_demo.xml
@@ -17,9 +17,9 @@
     <field name="interval_type">hours</field>
     <field name="numbercall">-1</field> <!-- don't limit the number of calls -->
     <field name="doall" eval="True"/>
-    <field name="email_template" ref="scheduler_error_mailer"/>
     <field name="model">ir.cron</field>
     <field name="function">_test_scheduler_failure</field>
+    <field name="email_template_id" ref="scheduler_error_mailer"/>
 </record>
 
 </data>


### PR DESCRIPTION
Renamed 'email_template' m2o field in 'email_template_id' in scheduler_error_mailer module

Refused for v7, but ok for v8

https://github.com/OCA/server-tools/pull/55

Thanks for your review
