### PR TITLE
add base_mail_bcc module

### DIFF
--- a/base_mail_bcc/__init__.py
+++ b/base_mail_bcc/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_mail_server

--- a/base_mail_bcc/__openerp__.py
+++ b/base_mail_bcc/__openerp__.py
@@ -36,9 +36,9 @@ mail.always_bcc_to as a comma-separated list of email addresses.
     """,
     "summary": "Add BCC to all emails",
     'data': [
-	'mail_bcc_data.xml'
     ],
     'demo': [
+       'mail_bcc_demo.xml'
     ],
     'test': [
     ],

--- a/base_mail_bcc/__openerp__.py
+++ b/base_mail_bcc/__openerp__.py
@@ -37,9 +37,7 @@ mail.always_bcc_to as a comma-separated list of email addresses.
     "summary": "Add BCC to all emails",
     'data': [
     ],
-    'demo': [
-       'mail_bcc_demo.xml'
-    ],
+    'demo': ['mail_bcc_demo.xml'],
     'test': [
     ],
     'installable': True,

--- a/base_mail_bcc/__openerp__.py
+++ b/base_mail_bcc/__openerp__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2010-2013 OpenERP s.a. (<http://openerp.com>).
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#    Author Thomas Rehn <thomas.rehn at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "BCC emails",
+    "version": "0.1",
+    "depends": ["base"],
+    'author': 'initOS GmbH & Co. KG',
+    "category": "",
+    'license': 'AGPL-3',
+    "description": """
+    Allows to configure a list of email addresses to which a blind carbon
+copy (BCC) of all emails is sent.
+
+The BCC email addresses can be configured by the system parameter
+mail.always_bcc_to as a comma-separated list of email addresses.
+    """,
+    "summary": "Add BCC to all emails",
+    'data': [
+	'mail_bcc_data.xml'
+    ],
+    'demo': [
+    ],
+    'test': [
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/base_mail_bcc/ir_mail_server.py
+++ b/base_mail_bcc/ir_mail_server.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2010-2013 OpenERP s.a. (<http://openerp.com>).
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#    Author Thomas Rehn <thomas.rehn at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv
+from email.Utils import COMMASPACE
+
+
+class IrMailServer(osv.Model):
+    _inherit = "ir.mail_server"
+
+    def send_email(self, cr, uid, message, mail_server_id=None,
+                   smtp_server=None, smtp_port=None, smtp_user=None,
+                   smtp_password=None, smtp_encryption=None,
+                   smtp_debug=False, context=None):
+
+        "Add global bcc email addresses"
+
+        # These are added here in send_email instead of build_email
+        #  because build_email is independent from the database and does not
+        #  have a cursor as parameter.
+
+        ir_config_parameter = self.pool.get("ir.config_parameter")
+        config_email_bcc = ir_config_parameter.get_param(cr, uid,
+                                                         "mail.always_bcc_to")
+
+        if config_email_bcc:
+            config_email_bcc = config_email_bcc.encode('ascii')
+            if message['Bcc']:
+                message['Bcc'] += COMMASPACE +\
+                    COMMASPACE.join(config_email_bcc.split(','))
+            else:
+                message['Bcc'] = COMMASPACE.join(config_email_bcc.split(','))
+
+        return super(IrMailServer, self)\
+            .send_email(cr, uid, message, mail_server_id, smtp_server,
+                        smtp_port, smtp_user, smtp_password, smtp_encryption,
+                        smtp_debug, context)

--- a/base_mail_bcc/ir_mail_server.py
+++ b/base_mail_bcc/ir_mail_server.py
@@ -45,11 +45,13 @@ class IrMailServer(osv.Model):
 
         if config_email_bcc:
             config_email_bcc = config_email_bcc.encode('ascii')
+            existing_bcc = []
             if message['Bcc']:
-                message['Bcc'] += COMMASPACE +\
-                    COMMASPACE.join(config_email_bcc.split(','))
-            else:
-                message['Bcc'] = COMMASPACE.join(config_email_bcc.split(','))
+                existing_bcc.append(message['Bcc'])
+                del message['Bcc']
+            message['Bcc'] = COMMASPACE.join(
+                existing_bcc + config_email_bcc.split(',')
+            )
 
         return super(IrMailServer, self)\
             .send_email(cr, uid, message, mail_server_id, smtp_server,

--- a/base_mail_bcc/mail_bcc_data.xml
+++ b/base_mail_bcc/mail_bcc_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="mail_bcc" model="ir.config_parameter">
+            <field name="key">mail.always_bcc_to</field>
+            <field name="value"></field>
+        </record>
+    </data>
+</openerp>

--- a/base_mail_bcc/mail_bcc_demo.xml
+++ b/base_mail_bcc/mail_bcc_demo.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record id="mail_bcc" model="ir.config_parameter">
             <field name="key">mail.always_bcc_to</field>
-            <field name="value"></field>
+            <field name="value">root@localhost<field>
         </record>
     </data>
 </openerp>

--- a/base_mail_bcc/mail_bcc_demo.xml
+++ b/base_mail_bcc/mail_bcc_demo.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record id="mail_bcc" model="ir.config_parameter">
             <field name="key">mail.always_bcc_to</field>
-            <field name="value">root@localhost<field>
+            <field name="value">root@localhost</field>
         </record>
     </data>
 </openerp>


### PR DESCRIPTION
Allows to configure a list of email addresses to which a blind carbon
copy (BCC) of all emails is sent.

The BCC email addresses can be configured by the system parameter
mail.always_bcc_to as a comma-separated list of email addresses.
