### PR TITLE
[FIX] This fixes #73

### DIFF
--- a/base_optional_quick_create/model.py
+++ b/base_optional_quick_create/model.py
@@ -45,7 +45,7 @@ class ir_model(orm.Model):
             if model.avoid_quick_create:
                 model_name = model.model
                 model_obj = self.pool.get(model_name)
-                if not hasattr(model_obj, 'check_quick_create'):
+                if model_obj and not hasattr(model_obj, 'check_quick_create'):
                     model_obj.name_create = self._wrap_name_create(
                         model_obj.name_create,
                         model_name)


### PR DESCRIPTION
Check if the model still exists in the registry before registring the 'check_quick_create' hook
