### PR TITLE
Fix server_environment module imports

### DIFF
--- a/server_environment/__init__.py
+++ b/server_environment/__init__.py
@@ -18,4 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from .serv_config import serv_config, setboolean
+from . import serv_config

--- a/server_environment/__openerp__.py
+++ b/server_environment/__openerp__.py
@@ -22,7 +22,7 @@
 {
     "name": "server configuration environment files",
     "version": "1.1",
-    "depends": ["base", "server_environment_files"],
+    "depends": ["base"],
     "author": "Camptocamp",
     "description": """\
 Environment file pattern for OpenERP

--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -29,29 +29,35 @@ from openerp.tools.config import config as system_base_config
 
 from .system_info import get_server_environment
 
-from openerp.addons import server_environment_files
-_dir = os.path.dirname(server_environment_files.__file__)
+try:
+    from openerp.addons import server_environment_files
+except ImportError:
+    _dir = False
+else:
+    _dir = os.path.dirname(server_environment_files.__file__)
 
-# Same dict as RawConfigParser._boolean_states
-_boolean_states = {'1': True, 'yes': True, 'true': True, 'on': True,
-                   '0': False, 'no': False, 'false': False, 'off': False}
+if _dir:
+    # Same dict as RawConfigParser._boolean_states
+    _boolean_states = {
+        '1': True, 'yes': True, 'true': True, 'on': True,
+        '0': False, 'no': False, 'false': False, 'off': False}
 
-if not system_base_config.get('running_env', False):
-    raise Exception(
-        "The parameter 'running_env' has not be set neither in base config "
-        "file option -c or in openerprc.\n"
-        "We strongly recommend against using the rc file but instead use an "
-        "explicit config file with this content:\n"
-        "[options]\nrunning_env = dev"
-    )
+    if not system_base_config.get('running_env', False):
+        raise Exception(
+            "The parameter 'running_env' has not be set neither in "
+            "base config file option -c or in openerprc.\n"
+            "We strongly recommend against using the rc file but "
+            "instead use an explicit config file with this content:\n"
+            "[options]\nrunning_env = dev"
+        )
 
-ck_path = os.path.join(_dir, system_base_config['running_env'])
+    ck_path = os.path.join(_dir, system_base_config['running_env'])
 
-if not os.path.exists(ck_path):
-    raise Exception(
-        "Provided server environment does not exist, "
-        "please add a folder %s" % ck_path
-    )
+    if not os.path.exists(ck_path):
+        raise Exception(
+            "Provided server environment does not exist, "
+            "please add a folder %s" % ck_path
+        )
 
 
 def setboolean(obj, attr, _bool=None):
@@ -101,7 +107,8 @@ def _load_config():
 
     return config_p
 
-serv_config = _load_config()
+if _dir:
+    serv_config = _load_config()
 
 
 class _Defaults(dict):


### PR DESCRIPTION
Quick fix to make `./odoo.py help` work without errors when the
server_environment_files modules does not exist.
Fixes #89.
