### PR TITLE
Add defer_parent_store_computation module

### DIFF
--- a/defer_parent_store_computation_import/__init__.py
+++ b/defer_parent_store_computation_import/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import ir_import

--- a/defer_parent_store_computation_import/__openerp__.py
+++ b/defer_parent_store_computation_import/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Deferred Parent Computation Import',
+    'description': """
+Deferred Parent Computation Import
+==================================
+
+Add option to import with deferred parent computation.
+
+When importing large amounts of data, the parent store
+computation can have major negative performance issues.
+
+Deferring the parent store computation to the end of the import
+can speed long imports tremendously.
+
+Contributors
+------------
+* Sandy Carter <sandy.carter@savoirfairelinux.com>
+* Pedro M. Baeza <pedro.baeza@gmail.com>
+
+""",
+    'category': 'Uncategorized',
+    'author': "Savoir-faire Linux",
+    'website': "http://www.savoirfairelinux.com",
+    'depends': ['base_import'],
+    'installable': True,
+    'auto_install': False,
+    'data': [
+    ],
+    'qweb': ['static/src/xml/defer_parent_store_computation_import.xml'],
+    'js': ['static/src/js/defer_parent_store_computation_import.js'],
+}

--- a/defer_parent_store_computation_import/i18n/defer_parent_store_computation_import.pot
+++ b/defer_parent_store_computation_import/i18n/defer_parent_store_computation_import.pot
@@ -1,0 +1,33 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* defer_parent_store_computation_import
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-12-19 01:13+0000\n"
+"PO-Revision-Date: 2014-12-19 01:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: defer_parent_store_computation_import
+#: model:ir.model,name:defer_parent_store_computation_import.model_base_import_import
+msgid "base_import.import"
+msgstr ""
+
+#. module: defer_parent_store_computation_import
+#: field:base_import.import,defer_parent_store_computation:0
+msgid "Defer Parent Store Computation"
+msgstr ""
+
+#. module: defer_parent_store_computation_import
+#. openerp-web
+#: code:addons/defer_parent_store_computation_import/static/src/xml/defer_parent_store_computation_import.xml:9
+#, python-format
+msgid "Use deferred parent store computation method"
+msgstr ""

--- a/defer_parent_store_computation_import/i18n/fr.po
+++ b/defer_parent_store_computation_import/i18n/fr.po
@@ -1,0 +1,35 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* defer_parent_store_computation_import
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-12-19 01:13+0000\n"
+"PO-Revision-Date: 2014-12-18 20:16-0500\n"
+"Last-Translator: Sandy Carter <sandy.carter@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.7.1\n"
+
+#. module: defer_parent_store_computation_import
+#: model:ir.model,name:defer_parent_store_computation_import.model_base_import_import
+msgid "base_import.import"
+msgstr ""
+
+#. module: defer_parent_store_computation_import
+#: field:base_import.import,defer_parent_store_computation:0
+msgid "Defer Parent Store Computation"
+msgstr "Reporter la computation de la parenté"
+
+#. module: defer_parent_store_computation_import
+#. openerp-web
+#: code:addons/defer_parent_store_computation_import/static/src/xml/defer_parent_store_computation_import.xml:9
+#, python-format
+msgid "Use deferred parent store computation method"
+msgstr "Utiliser la méthode de reportage de la computation de la parenté"

--- a/defer_parent_store_computation_import/ir_import.py
+++ b/defer_parent_store_computation_import/ir_import.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class ir_import(orm.TransientModel):
+    _inherit = 'base_import.import'
+
+    def do(self, cr, uid, id, fields, options, dryrun=False, context=None):
+        """When importing large amounts of data, the parent store
+        computation can have major negative performance issues.
+
+        Deferring the parent store computation to the end of the import
+        can speed long imports tremendously.
+        """
+
+        defer = options.get('defer')
+
+        if defer:
+            context['defer_parent_store_computation'] = True
+
+        res = super(ir_import, self).do(
+            cr, uid, id, fields, options, dryrun, context=context
+        )
+
+        if not dryrun and defer:
+            record = self.browse(cr, uid, id, context=context)
+            self.pool[record.res_model]._parent_store_compute(cr)
+
+        return res

--- a/defer_parent_store_computation_import/static/src/js/defer_parent_store_computation_import.js
+++ b/defer_parent_store_computation_import/static/src/js/defer_parent_store_computation_import.js
@@ -1,0 +1,15 @@
+openerp.defer_parent_store_computation_import = function (instance) {
+    var QWeb = instance.web.qweb;
+    var _t = instance.web._t;
+    var _lt = instance.web._lt;
+
+    instance.web.DataImport.include({
+        import_options: function () {
+            var options = this._super.apply(this, arguments);
+            options['defer'] =  this.$('input.oe_import_use_deferred_store_computation').prop('checked')
+            return options;
+        },
+    });
+
+};
+

--- a/defer_parent_store_computation_import/static/src/xml/defer_parent_store_computation_import.xml
+++ b/defer_parent_store_computation_import/static/src/xml/defer_parent_store_computation_import.xml
@@ -1,0 +1,14 @@
+<?xml version = "1.0" encoding="utf-8"?>
+<templates>
+
+  <t t-extend="ImportView">
+    <t t-jquery="div.oe_import_box" t-operation="append">
+
+      <input type="checkbox" class="oe_import_use_deferred_store_computation"
+             id="oe_import_use_deferred_store_computation"/>
+      <label for="oe_import_has_header">Use deferred parent store computation method</label>
+
+    </t>
+  </t>
+
+</templates>


### PR DESCRIPTION
Module adds option to import form which allows importing with the
'defer_parent_store_computation' key in context which speeds up imports
tremendously.

As you can see in this graph, trying to import 500 account.accounts not only takes a lot of time, but the performance gets worse after a few accounts have been added. The deferred method (red line) is much much quicker.

![importing accounts three methods](https://cloud.githubusercontent.com/assets/1013356/5498918/2e54a08a-86f4-11e4-8bad-7ed37be665be.png)

Huge credit goes to @pedrobaeza who taught me this trick.

The results can be re-created with these lines with a large `data`:

``` python
# Regular call
account_model.load(cr, uid, fields, data, context=context)

# Chunks method
def chunks(l, n):
    """ Yield successive n-sized chunks from l.
    """
    for i in xrange(0, len(l), n):
        yield l[i:i+n]

for chunk in chunks(data, 100):
    account_model.load(cr, uid, fields, chunk, context=context)


# Deferred parent store method
context['defer_parent_store_computation'] = True
account_model.load(cr, uid, fields, data, context=context)
account_model._parent_store_compute(cr)
```
