### PR TITLE
Add option to see original error in odoo

### DIFF
--- a/sentry_logger/__openerp__.py
+++ b/sentry_logger/__openerp__.py
@@ -62,7 +62,7 @@ Contributors
     # Categories can be used to filter modules in modules listing
     # Check <odoo>/addons/base/module/module_data.xml of the full list
     'category': 'Extra Tools',
-    'version': '1.0',
+    'version': '1.1',
 
     # any module necessary for this one to work correctly
     'depends': ['web'],
@@ -81,6 +81,10 @@ Contributors
 
     'qweb': [
         'static/src/xml/base.xml',
+    ],
+
+    'css': [
+        'static/src/css/sentry_logger.css',
     ],
 
     'tests': [

--- a/sentry_logger/static/src/css/sentry_logger.css
+++ b/sentry_logger/static/src/css/sentry_logger.css
@@ -1,0 +1,48 @@
+.error_details {
+    display:none;
+    height:auto;
+    margin:0;
+    float: left;
+}
+.show {
+    display: none;
+}
+.hide:target + .show {
+    display: inline;
+}
+.hide:target {
+    display: none;
+}
+.hide:target ~ .error_details {
+    display:inline;
+}
+
+
+/*style the (+) and (-) */
+.hide, .show {
+    width: 20px;
+    height: 20px;
+    border-radius: 20px;
+    font-size: 20px;
+    color: #fff;
+    text-align: center;
+    box-shadow: 1px 1px 2px #000;
+    background: #dddddd;
+    margin-top: 10px;
+    margin-right: 10px;
+    float: left;
+}
+
+.hide:hover, .show:hover {
+    color: #eee;
+    text-shadow: 0 0 1px #666;
+    text-decoration: none;
+    box-shadow: 0 0 4px #222 inset;
+    opacity: 1;
+
+}
+
+.error_details p{
+    height:auto;
+    margin:0;
+}

--- a/sentry_logger/static/src/xml/base.xml
+++ b/sentry_logger/static/src/xml/base.xml
@@ -10,6 +10,14 @@
         <div class="oe_view_nocontent">
 A detailed report has been sent to the technical support team.
         </div>
+        <a href="#hide1" class="hide" id="hide1">+</a>
+        <a href="#show1" class="show" id="show1">-</a>
+        <h3>Details</h3>
+        <div class="error_details">
+          <pre><t t-esc="error.message"/></pre>
+          <hr/>
+          <pre><t t-esc="error.data.debug"/></pre>
+        </div>
       </div>
 
       <!-- Original error message -->


### PR DESCRIPTION
Sometimes you want to be able to see the error in the traceback in odoo even if sentry is connected.
This adds a collapsible box to see the original error with traceback when sentry is enabled.

![capture d ecran de 2015-01-15 15 20 22](https://cloud.githubusercontent.com/assets/1013356/5765752/181bd6bc-9cca-11e4-9ca9-112ba39e4247.png)
![capture d ecran de 2015-01-15 15 20 10](https://cloud.githubusercontent.com/assets/1013356/5765751/181a7880-9cca-11e4-87d3-edc16b24966b.png)
