### PR TITLE
capture stderr as well as stdout when diagnosing

### DIFF
--- a/server_environment/system_info.py
+++ b/server_environment/system_info.py
@@ -30,7 +30,8 @@ from openerp.tools.config import config
 
 def _get_output(cmd):
     bindir = config['root_path']
-    p = subprocess.Popen(cmd, shell=True, cwd=bindir, stdout=subprocess.PIPE)
+    p = subprocess.Popen(cmd, shell=True, cwd=bindir, stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
     return p.communicate()[0].rstrip()
 
 


### PR DESCRIPTION
This fixes OCA/server-tools#125 because in some Ubuntu systems
lsb_release outputs to stderr as well as stdout. This message will be
printed to console, not logged nor shown among server infomation. That
way the message is lost and only pollutes unit tests output.
