### PR TITLE
Add a new module to logout inactive session after a configured delay

### DIFF
--- a/inactive_session_timeout/README.rst
+++ b/inactive_session_timeout/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
 Inactive Sessions Timeout
 =========================
 
@@ -12,6 +15,14 @@ Two system parameters are available:
 
 * inactive_session_time_out_delay: validity of a session in seconds (default = 2 Hours)
 * inactive_session_time_out_ignored_url: technical urls where the check does not occur 
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/server-tools/issues/new?body=module:%20inactive_session_timeout%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Credits
 =======

--- a/inactive_session_timeout/README.rst
+++ b/inactive_session_timeout/README.rst
@@ -1,0 +1,35 @@
+Inactive Sessions Timeout
+=========================
+
+This module was written to be able to kill(logout) all inactive sessions since
+a given delay. On each request the server checks if the session is yet valid
+regarding the expiration delay. If not a clean logout is operated.
+
+Configuration
+=============
+
+Two system parameters are available:
+
+* inactive_session_time_out_delay: validity of a session in seconds (default = 2 Hours)
+* inactive_session_time_out_ignored_url: technical urls where the check does not occur 
+
+Credits
+=======
+
+Contributors
+------------
+
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/inactive_session_timeout/__init__.py
+++ b/inactive_session_timeout/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/inactive_session_timeout/__openerp__.py
+++ b/inactive_session_timeout/__openerp__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of inactive_session_timeout, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     inactive_session_timeout is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     inactive_session_timeout is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with inactive_session_timeout.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Inactive Sessions Timeout",
+
+    'summary': """
+        This module disable all inactive sessions since a given delay""",
+
+    'author': "ACSONE SA/NV",
+    'website': "http://acsone.eu",
+
+    'category': 'Tools',
+    'version': '1.0',
+    'license': 'AGPL-3',
+
+    'depends': [
+        'base',
+    ],
+
+    'data': [
+        'data/ir_config_parameter_data.xml'
+    ]
+}

--- a/inactive_session_timeout/__openerp__.py
+++ b/inactive_session_timeout/__openerp__.py
@@ -27,7 +27,7 @@
     'summary': """
         This module disable all inactive sessions since a given delay""",
 
-    'author': "ACSONE SA/NV",
+    'author': "ACSONE SA/NV", "Odoo Community Association (OCA)"
     'website': "http://acsone.eu",
 
     'category': 'Tools',

--- a/inactive_session_timeout/data/ir_config_parameter_data.xml
+++ b/inactive_session_timeout/data/ir_config_parameter_data.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<openerp>
+
+    <data noupdate="1">
+        <record id="inactive_session_time_out_delay" model="ir.config_parameter">
+            <field name="key">inactive_session_time_out_delay</field>
+            <field name="value">7200</field>
+        </record>
+    </data>
+    
+    <data noupdate="1">
+        <record id="inactive_session_time_out_ignored_url" model="ir.config_parameter">
+            <field name="key">inactive_session_time_out_ignored_url</field>
+            <field name="value">/calendar/notify,/longpolling/poll</field>
+        </record>
+    </data>
+</openerp>

--- a/inactive_session_timeout/models/__init__.py
+++ b/inactive_session_timeout/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import res_users
+from . import ir_config_parameter

--- a/inactive_session_timeout/models/ir_config_parameter.py
+++ b/inactive_session_timeout/models/ir_config_parameter.py
@@ -21,16 +21,14 @@
 #     If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, api
+from openerp import models, api, tools, SUPERUSER_ID
 
-from openerp import tools
-from openerp import SUPERUSER_ID
 
 DELAY_KEY = 'inactive_session_time_out_delay'
 IGNORED_PATH_KEY = 'inactive_session_time_out_ignored_url'
 
 
-class ir_config_parameter(models.Model):
+class IrConfigParameter(models.Model):
     _inherit = 'ir.config_parameter'
 
     @tools.ormcache(skiparg=0)
@@ -50,7 +48,7 @@ class ir_config_parameter(models.Model):
 
     @api.multi
     def write(self, vals, context=None):
-        res = super(ir_config_parameter, self).write(vals)
+        res = super(IrConfigParameter, self).write(vals)
         if self.key in [DELAY_KEY, IGNORED_PATH_KEY]:
             self.get_session_parameters.clear_cache(self)
         return res

--- a/inactive_session_timeout/models/ir_config_parameter.py
+++ b/inactive_session_timeout/models/ir_config_parameter.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of inactive_session_timeout, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     inactive_session_timeout is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     inactive_session_timeout is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with inactive_session_timeout.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, api
+
+from openerp import tools
+from openerp import SUPERUSER_ID
+
+DELAY_KEY = 'inactive_session_time_out_delay'
+IGNORED_PATH_KEY = 'inactive_session_time_out_ignored_url'
+
+
+class ir_config_parameter(models.Model):
+    _inherit = 'ir.config_parameter'
+
+    @tools.ormcache(skiparg=0)
+    def get_session_parameters(self, db):
+        param_model = self.pool['ir.config_parameter']
+        cr = self.pool.cursor()
+        delay = False
+        urls = []
+        try:
+            delay = int(param_model.get_param(
+                cr, SUPERUSER_ID, DELAY_KEY, 7200))
+            urls = param_model.get_param(
+                cr, SUPERUSER_ID, IGNORED_PATH_KEY, '').split(',')
+        finally:
+            cr.close()
+        return delay, urls
+
+    @api.multi
+    def write(self, vals, context=None):
+        res = super(ir_config_parameter, self).write(vals)
+        if self.key in [DELAY_KEY, IGNORED_PATH_KEY]:
+            self.get_session_parameters.clear_cache(self)
+        return res

--- a/inactive_session_timeout/models/res_users.py
+++ b/inactive_session_timeout/models/res_users.py
@@ -32,7 +32,7 @@ from os.path import getmtime
 from time import time
 
 
-class res_users(models.Model):
+class ResUsers(models.Model):
     _inherit = 'res.users'
 
     def _check_session_validity(self, db, uid, passwd):
@@ -57,6 +57,6 @@ class res_users(models.Model):
         return
 
     def check(self, db, uid, passwd):
-        res = super(res_users, self).check(db, uid, passwd)
+        res = super(ResUsers, self).check(db, uid, passwd)
         self._check_session_validity(db, uid, passwd)
         return res

--- a/inactive_session_timeout/models/res_users.py
+++ b/inactive_session_timeout/models/res_users.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+#     This file is part of inactive_session_timeout, an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     inactive_session_timeout is free software: you can redistribute it
+#     and/or modify it under the terms of the GNU Affero General Public License
+#     as published by the Free Software Foundation, either version 3 of
+#     the License, or (at your option) any later version.
+#
+#     inactive_session_timeout is distributed in the hope that it will
+#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the
+#     GNU Affero General Public License
+#     along with inactive_session_timeout.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models
+from openerp import http
+
+from openerp.http import root
+from openerp.http import request
+
+from os import utime
+from os.path import getmtime
+from time import time
+
+
+class res_users(models.Model):
+    _inherit = 'res.users'
+
+    def _check_session_validity(self, db, uid, passwd):
+        if not request:
+            return
+        session = request.session
+        session_store = root.session_store
+        param_obj = self.pool['ir.config_parameter']
+        delay, urls = param_obj.get_session_parameters(db)
+        deadline = time() - delay
+        path = session_store.get_session_filename(session.sid)
+        try:
+            if getmtime(path) < deadline:
+                if session.db and session.uid:
+                    session.logout(keep_db=True)
+            elif http.request.httprequest.path not in urls:
+                # the session is not expired, update the last modification
+                # and access time.
+                utime(path, None)
+        except OSError:
+            pass
+        return
+
+    def check(self, db, uid, passwd):
+        res = super(res_users, self).check(db, uid, passwd)
+        self._check_session_validity(db, uid, passwd)
+        return res


### PR DESCRIPTION
The goal of this PR is to set a validity on a user session.

The validity delay is set in a system parameter and its default value is 2 hours.
If the user do nothing during this delay, his session is automatically logged out and he must re-login.
