### PR TITLE
[FIX] Add base_import as admin_technical_features deps

### DIFF
--- a/admin_technical_features/__openerp__.py
+++ b/admin_technical_features/__openerp__.py
@@ -48,7 +48,7 @@ Module developed and tested with Odoo version 8.0
 For questions, please contact our support services \
 (support@savoirfairelinux.com)
 """,
-    'depends': [],
+    'depends': ['base_import'],
     'external_dependencies': {
         'python': [],
     },


### PR DESCRIPTION
With module admin_technical_features installed, base_import unittests fail with
in the following test:

```
test_shallow (openerp.addons.base_import.tests.test_cases.test_o2m)
```

Having technical features enabled add the following to the dict in
fields:

```
{'fields': [{'fields': [],
   'id': 'parent_id',
   'name': 'id',
   'required': False,
   'string': 'External ID'},
  {'fields': [],
   'id': 'parent_id',
   'name': '.id',
   'required': False,
   'string': 'Database ID'}],
 'id': 'parent_id',
 'name': 'parent_id',
 'required': False,
 'string': 'unknown'}
```

The tests do not catch this because of the way travis tests are run: skipping tests of all base modules to save time.
