### PR TITLE
Remove auto_install on fetchmail_attach_from_folder

### DIFF
--- a/fetchmail_attach_from_folder/__openerp__.py
+++ b/fetchmail_attach_from_folder/__openerp__.py
@@ -35,5 +35,5 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
-    'active': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
The key 'active' is deprecated and is a synonym for 'auto_install'.
This addon should not be automatically installed.
