### PR TITLE
[FIX][cron_run_manually] active_test cannot be propagated to the method to execute

### DIFF
--- a/cron_run_manually/ir_cron.py
+++ b/cron_run_manually/ir_cron.py
@@ -60,9 +60,14 @@ class Cron(models.Model):
 
         _logger.info('Job `%s` triggered from form', self.name)
 
+        # Do not propagate active_test to the method to execute
+        ctx = dict(self.env.context)
+        ctx.pop('active_test', None)
+
         # Execute the cron job
-        method = getattr(self.sudo(self.user_id).env[self.model],
-                         self.function)
+        method = getattr(
+            self.with_context(ctx).sudo(self.user_id).env[self.model],
+            self.function)
         args = safe_eval('tuple(%s)' % (self.args or ''))
         return method(*args)
 


### PR DESCRIPTION
`ir.cron` model uses a special way to handle the `active` flag allowing to `search()` inactive documents whereas it is usually not the case. This feature is assumed by setting the `active_test` key to `False` in the context of the `ir.cron` window action.

This mechanism should only concern the `ir.cron` model itself, not models on which jobs will be executed.

The PR simply removes the `active_test` key from the context before launching the job.
