### PR TITLE
[IMP] hide unnecessary buttons in wizard

### DIFF
--- a/database_cleanup/model/purge_data.py
+++ b/database_cleanup/model/purge_data.py
@@ -82,8 +82,8 @@ class CleanupPurgeWizardData(orm.TransientModel):
                 SELECT id FROM ir_model_data
                 WHERE model = %%s
                 AND res_id IS NOT NULL
-                AND res_id NOT IN (
-                    SELECT id FROM %s)
+                AND NOT EXISTS (
+                    SELECT id FROM %s WHERE id=ir_model_data.res_id)
                 """ % self.pool[model]._table, (model,))
             data_ids += [data_row[0] for data_row in cr.fetchall()]
         data_ids += data_pool.search(

--- a/database_cleanup/model/purge_wizard.py
+++ b/database_cleanup/model/purge_wizard.py
@@ -26,6 +26,7 @@ from openerp.osv import orm, fields
 class CleanupPurgeLine(orm.AbstractModel):
     """ Abstract base class for the purge wizard lines """
     _name = 'cleanup.purge.line'
+    _order = 'name'
     _columns = {
         'name': fields.char('Name', size=256, readonly=True),
         'purged': fields.boolean('Purged', readonly=True),

--- a/database_cleanup/view/purge_columns.xml
+++ b/database_cleanup/view/purge_columns.xml
@@ -25,12 +25,24 @@
             </field>
         </record>
 
-        <record id="action_purge_columns" model="ir.actions.act_window">
+        <record id="action_purge_columns" model="ir.actions.server">
             <field name="name">Purge columns</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">cleanup.purge.wizard.column</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_column" />
+            <field name="code">
+wizard_id = self.create(cr, uid, {}, context=context)
+action = {
+    'type': 'ir.actions.act_window',
+    'views': [(False, 'form')],
+    'res_model': 'cleanup.purge.wizard.column',
+    'res_id': wizard_id,
+    'flags': {
+        'action_buttons': False,
+        'sidebar': False,
+    },
+}
+            </field>
         </record>
 
     </data>

--- a/database_cleanup/view/purge_data.xml
+++ b/database_cleanup/view/purge_data.xml
@@ -25,12 +25,24 @@
             </field>
         </record>
 
-        <record id="action_purge_data" model="ir.actions.act_window">
+        <record id="action_purge_data" model="ir.actions.server">
             <field name="name">Purge data entries that refer to missing resources</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">cleanup.purge.wizard.data</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_data" />
+            <field name="code">
+wizard_id = self.create(cr, uid, {}, context=context)
+action = {
+    'type': 'ir.actions.act_window',
+    'views': [(False, 'form')],
+    'res_model': 'cleanup.purge.wizard.data',
+    'res_id': wizard_id,
+    'flags': {
+        'action_buttons': False,
+        'sidebar': False,
+    },
+}
+            </field>
         </record>
 
     </data>

--- a/database_cleanup/view/purge_models.xml
+++ b/database_cleanup/view/purge_models.xml
@@ -24,12 +24,24 @@
             </field>
         </record>
 
-        <record id="action_purge_models" model="ir.actions.act_window">
+        <record id="action_purge_models" model="ir.actions.server">
             <field name="name">Purge models</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">cleanup.purge.wizard.model</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_model" />
+            <field name="code">
+wizard_id = self.create(cr, uid, {}, context=context)
+action = {
+    'type': 'ir.actions.act_window',
+    'views': [(False, 'form')],
+    'res_model': 'cleanup.purge.wizard.model',
+    'res_id': wizard_id,
+    'flags': {
+        'action_buttons': False,
+        'sidebar': False,
+    },
+}
+            </field>
         </record>
 
     </data>

--- a/database_cleanup/view/purge_modules.xml
+++ b/database_cleanup/view/purge_modules.xml
@@ -24,12 +24,24 @@
             </field>
         </record>
 
-        <record id="action_purge_modules" model="ir.actions.act_window">
+        <record id="action_purge_modules" model="ir.actions.server">
             <field name="name">Purge modules</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">cleanup.purge.wizard.module</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_module" />
+            <field name="code">
+wizard_id = self.create(cr, uid, {}, context=context)
+action = {
+    'type': 'ir.actions.act_window',
+    'views': [(False, 'form')],
+    'res_model': 'cleanup.purge.wizard.module',
+    'res_id': wizard_id,
+    'flags': {
+        'action_buttons': False,
+        'sidebar': False,
+    },
+}
+            </field>
         </record>
 
     </data>

--- a/database_cleanup/view/purge_tables.xml
+++ b/database_cleanup/view/purge_tables.xml
@@ -24,12 +24,24 @@
             </field>
         </record>
 
-        <record id="action_purge_tables" model="ir.actions.act_window">
+        <record id="action_purge_tables" model="ir.actions.server">
             <field name="name">Purge tables</field>
-            <field name="type">ir.actions.act_window</field>
-            <field name="res_model">cleanup.purge.wizard.table</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_table" />
+            <field name="code">
+wizard_id = self.create(cr, uid, {}, context=context)
+action = {
+    'type': 'ir.actions.act_window',
+    'views': [(False, 'form')],
+    'res_model': 'cleanup.purge.wizard.table',
+    'res_id': wizard_id,
+    'flags': {
+        'action_buttons': False,
+        'sidebar': False,
+    },
+}
+            </field>
         </record>
 
     </data>


### PR DESCRIPTION
I propose to rewrite all wizard actions to server actions, because this way we can present the user a saved record. The way it is currently, purging one model is only possible after saving, which is confusing. Also, we have the possibility to hide all unnecessary buttons (save/delete/attachments).
