### PR TITLE
[IMP] define a form view for wizard lines

### DIFF
--- a/database_cleanup/view/purge_columns.xml
+++ b/database_cleanup/view/purge_columns.xml
@@ -20,6 +20,18 @@
                                     icon="gtk-cancel" string="Purge this column"
                                     attrs="{'invisible': [('purged', '=', True)]}"/>
                         </tree>
+                        <form string="Purge columns">
+                            <group>
+                                <field name="name" />
+                                <field name="model_id" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this column"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>

--- a/database_cleanup/view/purge_data.xml
+++ b/database_cleanup/view/purge_data.xml
@@ -20,6 +20,18 @@
                                     icon="gtk-cancel" string="Purge this data"
                                     attrs="{'invisible': [('purged', '=', True)]}"/>
                         </tree>
+                        <form string="Purge data">
+                            <group>
+                                <field name="name" />
+                                <field name="data_id" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this data"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>

--- a/database_cleanup/view/purge_models.xml
+++ b/database_cleanup/view/purge_models.xml
@@ -19,6 +19,17 @@
                                     icon="gtk-cancel" string="Purge this model"
                                     attrs="{'invisible': [('purged', '=', True)]}"/>
                         </tree>
+                        <form string="Purge models">
+                            <group>
+                                <field name="name" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this model"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>

--- a/database_cleanup/view/purge_modules.xml
+++ b/database_cleanup/view/purge_modules.xml
@@ -19,6 +19,17 @@
                                     icon="gtk-cancel" string="Purge this module"
                                     attrs="{'invisible': [('purged', '=', True)]}"/>
                         </tree>
+                        <form string="Purge modules">
+                            <group>
+                                <field name="name" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this module"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>

--- a/database_cleanup/view/purge_tables.xml
+++ b/database_cleanup/view/purge_tables.xml
@@ -19,6 +19,17 @@
                                     icon="gtk-cancel" string="Purge this table"
                                     attrs="{'invisible': [('purged', '=', True)]}"/>
                         </tree>
+                        <form string="Purge tables">
+                            <group>
+                                <field name="name" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this table"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>


### PR DESCRIPTION
On a large screen, the purge button is quite far from the record's name, making it quite inconvenient to purge exactly one line. With this, we can simply click on the name, verify we're opening the right object, and purge it.
