### PR TITLE
[FIX] ie related fields don't have an ir.model.fields entry

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -389,9 +389,10 @@ class auditlog_rule(models.Model):
             if field_name in FIELDS_BLACKLIST:
                 continue
             field = self._get_field(log.model_id, field_name)
-            log_vals = self._prepare_log_line_vals_on_write(
-                log, field, old_values, new_values)
-            log_line_model.create(log_vals)
+            if field:
+                log_vals = self._prepare_log_line_vals_on_write(
+                    log, field, old_values, new_values)
+                log_line_model.create(log_vals)
 
     def _prepare_log_line_vals_on_write(
             self, log, field, old_values, new_values):
@@ -434,9 +435,10 @@ class auditlog_rule(models.Model):
             if field_name in FIELDS_BLACKLIST:
                 continue
             field = self._get_field(log.model_id, field_name)
-            log_vals = self._prepare_log_line_vals_on_create(
-                log, field, new_values)
-            log_line_model.create(log_vals)
+            if field:
+                log_vals = self._prepare_log_line_vals_on_create(
+                    log, field, new_values)
+                log_line_model.create(log_vals)
 
     def _prepare_log_line_vals_on_create(self, log, field, new_values):
         """Prepare the dictionary of values used to create a log line on a

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -358,6 +358,7 @@ class auditlog_rule(models.Model):
             if field_name in FIELDS_BLACKLIST:
                 continue
             field = self._get_field(log.model_id, field_name)
+            # not all fields have an ir.models.field entry (ie. related fields)
             if field:
                 log_vals = self._prepare_log_line_vals_on_read(
                     log, field, read_values)
@@ -389,6 +390,7 @@ class auditlog_rule(models.Model):
             if field_name in FIELDS_BLACKLIST:
                 continue
             field = self._get_field(log.model_id, field_name)
+            # not all fields have an ir.models.field entry (ie. related fields)
             if field:
                 log_vals = self._prepare_log_line_vals_on_write(
                     log, field, old_values, new_values)
@@ -435,6 +437,7 @@ class auditlog_rule(models.Model):
             if field_name in FIELDS_BLACKLIST:
                 continue
             field = self._get_field(log.model_id, field_name)
+            # not all fields have an ir.models.field entry (ie. related fields)
             if field:
                 log_vals = self._prepare_log_line_vals_on_create(
                     log, field, new_values)


### PR DESCRIPTION
The same happens in upstream already for read logging: https://github.com/OCA/server-tools/blob/8.0/auditlog/models/rule.py#L361
