### PR TITLE
[8.0] Add fields to super_calendar

### DIFF
--- a/super_calendar_analytic/README.rst
+++ b/super_calendar_analytic/README.rst
@@ -1,0 +1,83 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Super Calendar - Analytic
+=========================
+
+This module was written to extend the functionality of super_calendar. It adds
+a new link to an analytic account.
+
+The user benefits:
+
+- a new link to an analytic account, available on super_calendar configurator lines
+- a search into super_calendar elements by their analytic account
+- a groupby on analytic_id in the tree view
+
+It can also be displayed in calendar view if the user customizes its
+description code during the configuration.
+
+Installation
+============
+
+To install this module, you just need to select the module and insure yourself
+dependencies are available.
+
+Configuration
+=============
+
+No particular configuration to use this module
+
+Usage
+=====
+
+To use this module, you need to get an active super_calendar :
+
+- choose a model with an analytic account field (ie; purchase.order.line)
+- add an analytic account field on your super_calendar configurator line
+- search with an analytic account name
+- groupby on analytic account
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+This series of modules focus on common Odoo elements (partner, product,
+quantity, analytic).
+It would be interesting to have a unique dynamic module, but the initial
+request of the customer and our budget did not allow us to do so.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/server-tools/issues/new?body=module:%20super_calendar_partner%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Agathe Mollé <agathe.molle@savoirfairelinux.com>
+* Bruno Joliveau <bruno.joliveau@savoirfairelinux.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/super_calendar_analytic/__init__.py
+++ b/super_calendar_analytic/__init__.py
@@ -1,0 +1,24 @@
+
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/super_calendar_analytic/__openerp__.py
+++ b/super_calendar_analytic/__openerp__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Super Calendar - Analytic Account',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'summary': 'Add new link to analytic account for search and groupby on '
+               'super_calendar',
+    'author': ('Savoir-faire Linux',
+               'Odoo Community Association (OCA)'),
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'analytic',
+        'super_calendar_partner',
+    ],
+    'data': [
+        'views/super_calendar_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/super_calendar_analytic/i18n/fr.po
+++ b/super_calendar_analytic/i18n/fr.po
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* super_calendar_analytic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-23 20:58+0000\n"
+"PO-Revision-Date: 2015-06-23 17:01-0500\n"
+"Last-Translator: Agathe Mollé <agathe.molle@savoirfairelinux.com>\n"
+"Language-Team: Savoir-faire Linux <support@savoirfairelinux.com>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.5.4\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. module: super_calendar_analytic
+#: view:super.calendar:super_calendar_analytic.super_calendar_search
+#: field:super.calendar,analytic_id:0
+msgid "Analytic Account"
+msgstr "Compte analytique"
+
+#. module: super_calendar_analytic
+#: field:super.calendar.configurator.line,analytic_field_id:0
+msgid "Analytic Account field"
+msgstr "Champ Compte analytique"
+
+#. module: super_calendar_analytic
+#: code:addons/super_calendar_analytic/models/super_calendar.py:63
+#, python-format
+msgid "Error"
+msgstr "Erreur"
+
+#. module: super_calendar_analytic
+#: view:super.calendar:super_calendar_analytic.super_calendar_search
+msgid "Group all elements associated to the same analytic account."
+msgstr "Regrouper tous les éléments associés au même compte analytique."
+
+#. module: super_calendar_analytic
+#: code:addons/super_calendar_analytic/models/super_calendar.py:64
+#, python-format
+msgid ""
+"The 'Analytic Account' field of record %s (%s) does not refer to account."
+"analytic.account"
+msgstr ""
+"Le champ 'Compte analytique' de l'enregistrement %s (%s) ne réfère pas à "
+"account.analytic.account"

--- a/super_calendar_analytic/i18n/super_calendar_analytic.pot
+++ b/super_calendar_analytic/i18n/super_calendar_analytic.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* super_calendar_analytic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-23 20:58+0000\n"
+"PO-Revision-Date: 2015-06-23 20:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: super_calendar_analytic
+#: view:super.calendar:super_calendar_analytic.super_calendar_search
+#: field:super.calendar,analytic_id:0
+msgid "Analytic Account"
+msgstr ""
+
+#. module: super_calendar_analytic
+#: field:super.calendar.configurator.line,analytic_field_id:0
+msgid "Analytic Account field"
+msgstr ""
+
+#. module: super_calendar_analytic
+#: code:addons/super_calendar_analytic/models/super_calendar.py:63
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: super_calendar_analytic
+#: view:super.calendar:super_calendar_analytic.super_calendar_search
+msgid "Group all elements associated to the same analytic account."
+msgstr ""
+
+#. module: super_calendar_analytic
+#: code:addons/super_calendar_analytic/models/super_calendar.py:64
+#, python-format
+msgid "The 'Analytic Account' field of record %s (%s) does not refer to account.analytic.account"
+msgstr ""

--- a/super_calendar_analytic/models/__init__.py
+++ b/super_calendar_analytic/models/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import (
+    super_calendar,
+    super_calendar_configurator,
+    super_calendar_configurator_line,
+)

--- a/super_calendar_analytic/models/super_calendar.py
+++ b/super_calendar_analytic/models/super_calendar.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendar(models.Model):
+    _inherit = 'super.calendar'
+
+    analytic_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Analytic Account',
+        readonly=True,
+    )

--- a/super_calendar_analytic/models/super_calendar_configurator.py
+++ b/super_calendar_analytic/models/super_calendar_configurator.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import _, api, exceptions, models
+
+
+class SuperCalendarConfigurator(models.Model):
+    _inherit = 'super.calendar.configurator'
+
+    @api.multi
+    def _get_record_values_from_line(self, line):
+        res = super(
+            SuperCalendarConfigurator, self
+        )._get_record_values_from_line(line)
+        for record in res:
+            f_analytic = line.analytic_field_id.name
+            if (f_analytic and
+                    record[f_analytic]._model._name !=
+                    'account.analytic.account'):
+                raise exceptions.ValidationError(
+                    _("The 'Analytic Account' field of record %s (%s) "
+                      "does not refer to account.analytic.account")
+                    % (res[record]['name'], line.name.model))
+            res[record]['analytic_id'] = (f_analytic and
+                                          record[f_analytic].id)
+        return res

--- a/super_calendar_analytic/models/super_calendar_configurator_line.py
+++ b/super_calendar_analytic/models/super_calendar_configurator_line.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendarConfiguratorLine(models.Model):
+    _inherit = 'super.calendar.configurator.line'
+
+    analytic_field_id = fields.Many2one(
+        comodel_name='ir.model.fields',
+        string='Analytic Account field',
+        domain="[('ttype', '=', 'many2one'), ('model_id', '=', name)]",
+    )

--- a/super_calendar_analytic/tests/__init__.py
+++ b/super_calendar_analytic/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_super_calendar_configurator

--- a/super_calendar_analytic/tests/test_super_calendar_configurator.py
+++ b/super_calendar_analytic/tests/test_super_calendar_configurator.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests import TransactionCase
+from openerp.exceptions import ValidationError
+
+
+class TestSuperCalendar(TransactionCase):
+
+    def setUp(self):
+        super(TestSuperCalendar, self).setUp()
+
+        self.AnalyticObj = self.env['account.analytic.account']
+        self.SuperCalendarObj = self.env['super.calendar']
+        self.SuperCalendarConfiguratorObj = self.env[
+            'super.calendar.configurator']
+        self.SuperCalendarConfiguratorLineObj = self.env[
+            'super.calendar.configurator.line']
+        self.ModelFieldsObj = self.env['ir.model.fields']
+        self.ModelObj = self.env['ir.model']
+
+        self.parent = self.AnalyticObj.create({
+            'name': 'Parent',
+        })
+        self.analytic = self.AnalyticObj.create({
+            'name': 'Test analytic',
+            'parent_id': self.parent.id
+        })
+
+        self.super_calendar_configurator = \
+            self.SuperCalendarConfiguratorObj.create({
+                'name': 'Analytic',
+            })
+
+        self.analytic_model = self.ModelObj.search([
+            ('model', '=', 'account.analytic.account')
+        ])
+        self.date_start_field = self.ModelFieldsObj.search([
+            ('name', '=', 'create_date'),
+            ('model', '=', 'account.analytic.account'),
+        ])
+        self.description_field = self.ModelFieldsObj.search([
+            ('name', '=', 'name'),
+            ('model', '=', 'account.analytic.account'),
+        ])
+        self.analytic_field = self.ModelFieldsObj.search([
+            ('name', '=', 'parent_id'),
+            ('model', '=', 'account.analytic.account'),
+        ])
+
+        self.super_calendar_configurator_line = \
+            self.SuperCalendarConfiguratorLineObj.create({
+                'name': self.analytic_model.id,
+                'date_start_field_id': self.date_start_field.id,
+                'description_field_id': self.description_field.id,
+                'configurator_id': self.super_calendar_configurator.id,
+            })
+
+    def test_get_record_values_from_line(self):
+        """
+        Test if record values are correctly computed
+        """
+
+        # Test without analytic account
+        values_analytic = self.super_calendar_configurator.\
+            _get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.analytic]
+
+        correctvalues = {
+            'configurator_id': self.super_calendar_configurator.id,
+            'date_start': self.analytic.create_date,
+            'duration': False,
+            'model_id': self.analytic_model.id,
+            'name': self.analytic.name,
+            'res_id': self.analytic_model.model + ',' + str(self.analytic.id),
+            'user_id': False,
+            'analytic_id': False,
+        }
+
+        for key in ['configurator_id', 'date_start', 'duration', 'model_id',
+                    'name', 'res_id', 'user_id', 'analytic_id']:
+            self.assertEqual(
+                values_analytic[key],
+                correctvalues[key]
+            )
+
+        # Add an analytic account
+        self.super_calendar_configurator_line.write({
+            'analytic_field_id': self.analytic_field.id,
+        })
+        values_analytic = self.super_calendar_configurator.\
+            _get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.analytic]
+        correctvalues['analytic_id'] = self.parent.id
+        self.assertEqual(
+            values_analytic['analytic_id'],
+            correctvalues['analytic_id']
+        )
+
+        # Test Exception
+        self.partner_field = self.ModelFieldsObj.search([
+            ('name', '=', 'partner_id'),
+            ('model', '=', 'account.analytic.account')
+        ])
+        self.super_calendar_configurator_line.write({
+            'analytic_field_id': self.partner_field.id,
+        })
+        with self.assertRaises(ValidationError):
+            self.super_calendar_configurator._get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )

--- a/super_calendar_analytic/views/super_calendar_view.xml
+++ b/super_calendar_analytic/views/super_calendar_view.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <!-- Configurator -->
+
+    <record model="ir.ui.view" id="super_calendar_configurator_form">
+       <field name="name">super_calendar_configurator_form</field>
+       <field name="model">super.calendar.configurator</field>
+       <field name="inherit_id" ref="super_calendar_partner.super_calendar_configurator_form"/>
+       <field name="arch" type="xml">
+
+         <field name="partner_field_id" position="after">
+           <field name="analytic_field_id" />
+         </field>
+
+       </field>
+     </record>
+
+
+    <!-- Calendar -->
+
+    <record id="super_calendar_tree" model="ir.ui.view">
+      <field name="name">super_calendar_tree</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_tree"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="analytic_id" />
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_form">
+      <field name="name">super_calendar_form</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_form"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="analytic_id" />
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_search">
+      <field name="name">super_calendar_search</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_search"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="analytic_id" filter_domain="['|',('analytic_id.name','ilike',self),('analytic_id.code','ilike',self)]"/>
+        </field>
+
+        <xpath expr="//filter[@string='Partner']" position="after">
+          <filter string="Analytic Account"
+                  name="group_analytic"
+                  context="{'group_by':'analytic_id'}"
+                  help="Group all elements associated to the same analytic account."/>
+        </xpath>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/super_calendar_partner/README.rst
+++ b/super_calendar_partner/README.rst
@@ -1,0 +1,83 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Super Calendar - Partner
+========================
+
+This module was written to extend the functionality of super_calendar. It adds
+a new link to a partner.
+
+The user benefits:
+
+- a new link to a partner, available on super_calendar configurator lines
+- a search into super_calendar elements by their partner
+- a groupby on partner_id in the tree view
+
+It can also be displayed in calendar view if the user customizes its
+description code during the configuration.
+
+Installation
+============
+
+To install this module, you just need to select the module and insure yourself
+dependencies are available.
+
+Configuration
+=============
+
+No particular configuration to use this module
+
+Usage
+=====
+
+To use this module, you need to get an active super_calendar :
+
+- choose a model with a partner field (ie; sale.order, purchase.order, invoice, etc.)
+- add a partner field on your super_calendar configurator line
+- search with a partner name (or its ref)
+- groupby on partner
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+This series of modules focus on common Odoo elements (partner, product,
+quantity, analytic).
+It would be interesting to have a unique dynamic module, but the initial
+request of the customer and our budget did not allow us to do so.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/server-tools/issues/new?body=module:%20super_calendar_partner%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Agathe Mollé <agathe.molle@savoirfairelinux.com>
+* Bruno Joliveau <bruno.joliveau@savoirfairelinux.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/super_calendar_partner/__init__.py
+++ b/super_calendar_partner/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/super_calendar_partner/__openerp__.py
+++ b/super_calendar_partner/__openerp__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Super Calendar - Partner',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'summary': 'Add new link to partner for search and groupby on '
+               'super_calendar',
+    'author': ('Savoir-faire Linux',
+               'Odoo Community Association (OCA)'),
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'super_calendar',
+    ],
+    'data': [
+        'views/super_calendar_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/super_calendar_partner/i18n/fr.po
+++ b/super_calendar_partner/i18n/fr.po
@@ -1,0 +1,59 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* super_calendar_partner
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-23 20:58+0000\n"
+"PO-Revision-Date: 2015-06-23 17:03-0500\n"
+"Last-Translator: Agathe Mollé <agathe.molle@savoirfairelinux.com>\n"
+"Language-Team: Savoir-faire Linux <support@savoirfairelinux.com>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.5.4\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. module: super_calendar_partner
+#: code:addons/super_calendar_partner/models/super_calendar.py:62
+#, python-format
+msgid "Error"
+msgstr "Erreur"
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_search
+msgid "Group By"
+msgstr "Grouper par"
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_search
+msgid "Group all elements associated to the same partner."
+msgstr "Regrouper tous les éléments associés au même partenaire."
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_form
+#: view:super.calendar.configurator:super_calendar_partner.super_calendar_configurator_form
+msgid "Links"
+msgstr "Liens"
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_search
+#: field:super.calendar,partner_id:0
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: super_calendar_partner
+#: field:super.calendar.configurator.line,partner_field_id:0
+msgid "Partner field"
+msgstr "Champ Partenaire"
+
+#. module: super_calendar_partner
+#: code:addons/super_calendar_partner/models/super_calendar.py:63
+#, python-format
+msgid "The 'Partner' field of record %s (%s) does not refer to res.partner"
+msgstr ""
+"Le champ 'Partenaire' de l'enregistrement %s (%s) ne réfère pas à res.partner"

--- a/super_calendar_partner/i18n/super_calendar_partner.pot
+++ b/super_calendar_partner/i18n/super_calendar_partner.pot
@@ -1,0 +1,55 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* super_calendar_partner
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-23 20:58+0000\n"
+"PO-Revision-Date: 2015-06-23 20:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: super_calendar_partner
+#: code:addons/super_calendar_partner/models/super_calendar.py:62
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_search
+msgid "Group By"
+msgstr ""
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_search
+msgid "Group all elements associated to the same partner."
+msgstr ""
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_form
+#: view:super.calendar.configurator:super_calendar_partner.super_calendar_configurator_form
+msgid "Links"
+msgstr ""
+
+#. module: super_calendar_partner
+#: view:super.calendar:super_calendar_partner.super_calendar_search
+#: field:super.calendar,partner_id:0
+msgid "Partner"
+msgstr ""
+
+#. module: super_calendar_partner
+#: field:super.calendar.configurator.line,partner_field_id:0
+msgid "Partner field"
+msgstr ""
+
+#. module: super_calendar_partner
+#: code:addons/super_calendar_partner/models/super_calendar.py:63
+#, python-format
+msgid "The 'Partner' field of record %s (%s) does not refer to res.partner"
+msgstr ""

--- a/super_calendar_partner/models/__init__.py
+++ b/super_calendar_partner/models/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import (
+    super_calendar,
+    super_calendar_configurator,
+    super_calendar_configurator_line,
+)

--- a/super_calendar_partner/models/super_calendar.py
+++ b/super_calendar_partner/models/super_calendar.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendar(models.Model):
+    _inherit = 'super.calendar'
+
+    partner_id = fields.Many2one(
+        comodel_name='res.partner',
+        string='Partner',
+        readonly=True,
+    )

--- a/super_calendar_partner/models/super_calendar_configurator.py
+++ b/super_calendar_partner/models/super_calendar_configurator.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import _, api, exceptions, models
+
+
+class SuperCalendarConfigurator(models.Model):
+    _inherit = 'super.calendar.configurator'
+
+    @api.multi
+    def _get_record_values_from_line(self, line):
+        res = super(
+            SuperCalendarConfigurator, self
+        )._get_record_values_from_line(line)
+        for record in res:
+            f_partner = line.partner_field_id.name
+            if (f_partner and
+                    record[f_partner]._model._name != 'res.partner'):
+                raise exceptions.ValidationError(
+                    _("The 'Partner' field of record %s (%s) "
+                      "does not refer to res.partner")
+                    % (res[record]['name'], line.name.model))
+            res[record]['partner_id'] = (f_partner and
+                                         record[f_partner].id)
+        return res

--- a/super_calendar_partner/models/super_calendar_configurator_line.py
+++ b/super_calendar_partner/models/super_calendar_configurator_line.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendarConfiguratorLine(models.Model):
+    _inherit = 'super.calendar.configurator.line'
+
+    partner_field_id = fields.Many2one(
+        comodel_name='ir.model.fields',
+        string='Partner field',
+        domain="[('ttype', '=', 'many2one'), ('model_id', '=', name)]",
+    )

--- a/super_calendar_partner/tests/__init__.py
+++ b/super_calendar_partner/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_super_calendar_configurator

--- a/super_calendar_partner/tests/test_super_calendar_configurator.py
+++ b/super_calendar_partner/tests/test_super_calendar_configurator.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests import TransactionCase
+from openerp.exceptions import ValidationError
+
+
+class TestSuperCalendar(TransactionCase):
+
+    def setUp(self):
+        super(TestSuperCalendar, self).setUp()
+
+        self.PartnerObj = self.env['res.partner']
+        self.UserObj = self.env['res.users']
+        self.CountryObj = self.env['res.country']
+        self.SuperCalendarObj = self.env['super.calendar']
+        self.SuperCalendarConfiguratorObj = self.env[
+            'super.calendar.configurator']
+        self.SuperCalendarConfiguratorLineObj = self.env[
+            'super.calendar.configurator.line']
+        self.ModelFieldsObj = self.env['ir.model.fields']
+        self.ModelObj = self.env['ir.model']
+
+        self.partner_A = self.PartnerObj.create({
+            'name': 'Partner A',
+        })
+
+        self.user_A = self.UserObj.create({
+            'name': 'Partner A',
+            'partner_id': self.partner_A.id,
+            'company_id': 1,
+            'login': 'partner_a',
+        })
+
+        self.super_calendar_configurator = \
+            self.SuperCalendarConfiguratorObj.create({
+                'name': 'Users',
+            })
+
+        self.user_model = self.ModelObj.search([
+            ('model', '=', 'res.users')
+        ])
+        self.date_start_field = self.ModelFieldsObj.search([
+            ('name', '=', 'create_date'),
+            ('model', '=', 'res.users'),
+        ])
+        self.description_field = self.ModelFieldsObj.search([
+            ('name', '=', 'login'),
+            ('model', '=', 'res.users'),
+        ])
+        self.partner_field = self.ModelFieldsObj.search([
+            ('name', '=', 'partner_id'),
+            ('model', '=', 'res.users')
+        ])
+
+        self.super_calendar_configurator_line = \
+            self.SuperCalendarConfiguratorLineObj.create({
+                'name': self.user_model.id,
+                'date_start_field_id': self.date_start_field.id,
+                'description_field_id': self.description_field.id,
+                'configurator_id': self.super_calendar_configurator.id,
+                'domain': [('login', '=', self.user_A.login)]
+            })
+
+    def test_get_record_values_from_line(self):
+        """
+        Test if record values are correctly computed
+        """
+
+        # Test without partner
+        values_user_a = {
+            'configurator_id': self.super_calendar_configurator.id,
+            'date_start': self.user_A.create_date,
+            'duration': False,
+            'model_id': self.user_model.id,
+            'name': self.user_A.login,
+            'res_id': self.user_model.model + ',' + str(self.user_A.id),
+            'user_id': False,
+            'partner_id': False,
+        }
+        self.assertEqual(
+            self.super_calendar_configurator._get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.user_A],
+            values_user_a
+        )
+
+        # Add a partner
+        self.super_calendar_configurator_line.write({
+            'partner_field_id': self.partner_field.id,
+        })
+        values_user_a['partner_id'] = self.partner_A.id
+        self.assertEqual(
+            self.super_calendar_configurator._get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.user_A],
+            values_user_a
+        )
+
+        # Test Exception
+        self.company_field = self.ModelFieldsObj.search([
+            ('name', '=', 'company_id'),
+            ('model', '=', 'res.users')
+        ])
+        self.super_calendar_configurator_line.write({
+            'partner_field_id': self.company_field.id,
+        })
+        with self.assertRaises(ValidationError):
+            self.super_calendar_configurator._get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )

--- a/super_calendar_partner/views/super_calendar_view.xml
+++ b/super_calendar_partner/views/super_calendar_view.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <!-- Configurator -->
+
+    <record model="ir.ui.view" id="super_calendar_configurator_form">
+       <field name="name">super_calendar_configurator_form</field>
+       <field name="model">super.calendar.configurator</field>
+       <field name="inherit_id" ref="super_calendar.super_calendar_configurator_form"/>
+       <field name="arch" type="xml">
+
+         <xpath expr="//group[@string='Description']" position="before">
+           <group string="Links">
+             <field name="partner_field_id" />
+           </group>
+         </xpath>
+
+       </field>
+     </record>
+
+
+    <!-- Calendar -->
+
+    <record id="super_calendar_tree" model="ir.ui.view">
+      <field name="name">super_calendar_tree</field>
+      <field name="inherit_id" ref="super_calendar.super_calendar_tree"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="model_id" position="after">
+          <field name="partner_id" />
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_form">
+      <field name="name">super_calendar_form</field>
+      <field name="inherit_id" ref="super_calendar.super_calendar_form"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="res_id" position="after">
+          <group string="Links">
+            <field name="partner_id" />
+          </group>
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_search">
+      <field name="name">super_calendar_search</field>
+      <field name="inherit_id" ref="super_calendar.super_calendar_search"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="user_id" position="after">
+          <field name="partner_id" filter_domain="['|','|',('partner_id.display_name','ilike',self),('partner_id.ref','=',self),('partner_id.email','ilike',self)]"/>
+        </field>
+
+        <xpath expr="//group[@string='Extended Filters...']" position="after">
+          <group expand="1" string="Group By">
+            <filter string="Partner"
+                    name="group_partner"
+                    context="{'group_by':'partner_id'}"
+                    help="Group all elements associated to the same partner."/>
+          </group>
+        </xpath>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/super_calendar_product/README.rst
+++ b/super_calendar_product/README.rst
@@ -1,0 +1,83 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Super Calendar - Product
+========================
+
+This module was written to extend the functionality of super_calendar. It adds
+a new link to a product.
+
+The user benefits:
+
+- a new link to a product, available on super_calendar configurator lines
+- a search into super_calendar elements by their product
+- a groupby on product_id in the tree view
+
+It can also be displayed in calendar view if the user customizes its
+description code during the configuration.
+
+Installation
+============
+
+To install this module, you just need to select the module and insure yourself
+dependencies are available.
+
+Configuration
+=============
+
+No particular configuration to use this module
+
+Usage
+=====
+
+To use this module, you need to get an active super_calendar :
+
+- choose a model with a product field (ie; sale.order.line, purchase.order.line, etc.)
+- add a product field on your super_calendar configurator line
+- search with a product name
+- groupby on product
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+This series of modules focus on common Odoo elements (partner, product,
+quantity, analytic).
+It would be interesting to have a unique dynamic module, but the initial
+request of the customer and our budget did not allow us to do so.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/server-tools/issues/new?body=module:%20super_calendar_partner%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Agathe Mollé <agathe.molle@savoirfairelinux.com>
+* Bruno Joliveau <bruno.joliveau@savoirfairelinux.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/super_calendar_product/__init__.py
+++ b/super_calendar_product/__init__.py
@@ -1,0 +1,24 @@
+
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/super_calendar_product/__openerp__.py
+++ b/super_calendar_product/__openerp__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Super Calendar - Product',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'summary': 'Add new link to product for search and groupby on '
+               'super_calendar',
+    'author': ('Savoir-faire Linux',
+               'Odoo Community Association (OCA)'),
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'product',
+        'super_calendar_partner',
+    ],
+    'data': [
+        'views/super_calendar_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/super_calendar_product/i18n/fr.po
+++ b/super_calendar_product/i18n/fr.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* super_calendar_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-23 21:07+0000\n"
+"PO-Revision-Date: 2015-06-23 17:09-0500\n"
+"Last-Translator: Agathe Mollé <agathe.molle@savoirfairelinux.com>\n"
+"Language-Team: Savoir-faire Linux <support@savoirfairelinux.com>\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.5.4\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. module: super_calendar_product
+#: code:addons/super_calendar_product/models/super_calendar.py:62
+#, python-format
+msgid "Error"
+msgstr "Erreur"
+
+#. module: super_calendar_product
+#: view:super.calendar:super_calendar_product.super_calendar_search
+msgid "Group all elements associated to the same product."
+msgstr "Regrouper tous les éléments associés au même produit."
+
+#. module: super_calendar_product
+#: view:super.calendar:super_calendar_product.super_calendar_search
+#: field:super.calendar,product_id:0
+msgid "Product"
+msgstr "Produit"
+
+#. module: super_calendar_product
+#: field:super.calendar.configurator.line,product_field_id:0
+msgid "Product field"
+msgstr "Champ produit"
+
+#. module: super_calendar_product
+#: code:addons/super_calendar_product/models/super_calendar.py:63
+#, python-format
+msgid "The 'Product' field of record %s (%s) does not refer to product.product"
+msgstr ""
+"Le champ 'Produit' de l'enregistrement %s (%s) ne réfère pas à product."
+"product"

--- a/super_calendar_product/i18n/super_calendar_product.pot
+++ b/super_calendar_product/i18n/super_calendar_product.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* super_calendar_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-23 21:07+0000\n"
+"PO-Revision-Date: 2015-06-23 21:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: super_calendar_product
+#: code:addons/super_calendar_product/models/super_calendar.py:62
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: super_calendar_product
+#: view:super.calendar:super_calendar_product.super_calendar_search
+msgid "Group all elements associated to the same product."
+msgstr ""
+
+#. module: super_calendar_product
+#: view:super.calendar:super_calendar_product.super_calendar_search
+#: field:super.calendar,product_id:0
+msgid "Product"
+msgstr ""
+
+#. module: super_calendar_product
+#: field:super.calendar.configurator.line,product_field_id:0
+msgid "Product field"
+msgstr ""
+
+#. module: super_calendar_product
+#: code:addons/super_calendar_product/models/super_calendar.py:63
+#, python-format
+msgid "The 'Product' field of record %s (%s) does not refer to product.product"
+msgstr ""

--- a/super_calendar_product/models/__init__.py
+++ b/super_calendar_product/models/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import (
+    super_calendar,
+    super_calendar_configurator,
+    super_calendar_configurator_line,
+)

--- a/super_calendar_product/models/super_calendar.py
+++ b/super_calendar_product/models/super_calendar.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendar(models.Model):
+    _inherit = 'super.calendar'
+
+    product_id = fields.Many2one(
+        comodel_name='product.product',
+        string='Product',
+        readonly=True,
+    )

--- a/super_calendar_product/models/super_calendar_configurator.py
+++ b/super_calendar_product/models/super_calendar_configurator.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import _, api, exceptions, models
+
+
+class SuperCalendarConfigurator(models.Model):
+    _inherit = 'super.calendar.configurator'
+
+    @api.multi
+    def _get_record_values_from_line(self, line):
+        res = super(
+            SuperCalendarConfigurator, self
+        )._get_record_values_from_line(line)
+        for record in res:
+            f_product = line.product_field_id.name
+            if (f_product and
+                    record[f_product]._model._name != 'product.product'):
+                raise exceptions.ValidationError(
+                    _("The 'Product' field of record %s (%s) "
+                      "does not refer to product.product")
+                    % (res[record]['name'], line.name.model))
+            res[record]['product_id'] = (f_product and
+                                         record[f_product].id)
+        return res

--- a/super_calendar_product/models/super_calendar_configurator_line.py
+++ b/super_calendar_product/models/super_calendar_configurator_line.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendarConfiguratorLine(models.Model):
+    _inherit = 'super.calendar.configurator.line'
+
+    product_field_id = fields.Many2one(
+        comodel_name='ir.model.fields',
+        string='Product field',
+        domain="[('ttype', '=', 'many2one'), ('model_id', '=', name)]",
+    )

--- a/super_calendar_product/tests/__init__.py
+++ b/super_calendar_product/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_super_calendar_configurator

--- a/super_calendar_product/tests/test_super_calendar_configurator.py
+++ b/super_calendar_product/tests/test_super_calendar_configurator.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests import TransactionCase
+from openerp.exceptions import ValidationError
+
+
+class TestSuperCalendar(TransactionCase):
+
+    def setUp(self):
+        super(TestSuperCalendar, self).setUp()
+
+        self.ProductObj = self.env['product.product']
+        self.PricelistItemObj = self.env['product.pricelist.item']
+        self.SuperCalendarObj = self.env['super.calendar']
+        self.SuperCalendarConfiguratorObj = self.env[
+            'super.calendar.configurator']
+        self.SuperCalendarConfiguratorLineObj = self.env[
+            'super.calendar.configurator.line']
+        self.ModelFieldsObj = self.env['ir.model.fields']
+        self.ModelObj = self.env['ir.model']
+
+        self.product = self.ProductObj.browse(
+            self.ref('product.product_product_consultant')
+        )
+        self.pricelistItem = self.PricelistItemObj.browse(
+            self.ref('product.item0')
+        )
+        self.pricelistItem.write({
+            'product_id': self.product.id
+        })
+
+        self.super_calendar_configurator = \
+            self.SuperCalendarConfiguratorObj.create({
+                'name': 'Pricelist item',
+            })
+
+        self.pricelistItem_model = self.ModelObj.search([
+            ('model', '=', 'product.pricelist.item')
+        ])
+        self.date_start_field = self.ModelFieldsObj.search([
+            ('name', '=', 'create_date'),
+            ('model', '=', 'product.pricelist.item'),
+        ])
+        self.description_field = self.ModelFieldsObj.search([
+            ('name', '=', 'name'),
+            ('model', '=', 'product.pricelist.item'),
+        ])
+        self.product_field = self.ModelFieldsObj.search([
+            ('name', '=', 'product_id'),
+            ('model', '=', 'product.pricelist.item'),
+        ])
+
+        self.super_calendar_configurator_line = \
+            self.SuperCalendarConfiguratorLineObj.create({
+                'name': self.pricelistItem_model.id,
+                'date_start_field_id': self.date_start_field.id,
+                'description_field_id': self.description_field.id,
+                'configurator_id': self.super_calendar_configurator.id,
+            })
+
+    def test_get_record_values_from_line(self):
+        """
+        Test if record values are correctly computed
+        """
+
+        # Test without product
+        values_pricelistitem = self.super_calendar_configurator.\
+            _get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.pricelistItem]
+
+        correctvalues = {
+            'configurator_id': self.super_calendar_configurator.id,
+            'date_start': self.pricelistItem.create_date,
+            'duration': False,
+            'model_id': self.pricelistItem_model.id,
+            'name': self.pricelistItem.name,
+            'res_id': self.pricelistItem_model.model + ',' +
+            str(self.pricelistItem.id),
+            'user_id': False,
+            'product_id': False,
+        }
+
+        for key in ['configurator_id', 'date_start', 'duration', 'model_id',
+                    'name', 'res_id', 'user_id', 'product_id']:
+            self.assertEqual(
+                values_pricelistitem[key],
+                correctvalues[key]
+            )
+
+        # Add a product
+        self.super_calendar_configurator_line.write({
+            'product_field_id': self.product_field.id,
+        })
+        values_pricelistitem = self.super_calendar_configurator.\
+            _get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.pricelistItem]
+        correctvalues['product_id'] = self.product.id
+        self.assertEqual(
+            values_pricelistitem['product_id'],
+            correctvalues['product_id']
+        )
+
+        # Test Exception
+        self.categ_field = self.ModelFieldsObj.search([
+            ('name', '=', 'categ_id'),
+            ('model', '=', 'product.pricelist.item')
+        ])
+        self.super_calendar_configurator_line.write({
+            'product_field_id': self.categ_field.id,
+        })
+        with self.assertRaises(ValidationError):
+            self.super_calendar_configurator._get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )

--- a/super_calendar_product/views/super_calendar_view.xml
+++ b/super_calendar_product/views/super_calendar_view.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <!-- Configurator -->
+
+    <record model="ir.ui.view" id="super_calendar_configurator_form">
+       <field name="name">super_calendar_configurator_form</field>
+       <field name="model">super.calendar.configurator</field>
+       <field name="inherit_id" ref="super_calendar_partner.super_calendar_configurator_form"/>
+       <field name="arch" type="xml">
+
+         <field name="partner_field_id" position="after">
+           <field name="product_field_id" />
+         </field>
+
+       </field>
+     </record>
+
+
+    <!-- Calendar -->
+
+    <record id="super_calendar_tree" model="ir.ui.view">
+      <field name="name">super_calendar_tree</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_tree"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="product_id" />
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_form">
+      <field name="name">super_calendar_form</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_form"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="product_id" />
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_search">
+      <field name="name">super_calendar_search</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_search"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="product_id" filter_domain="['|',('product_id.name','ilike',self),('product_id.default_code','ilike',self)]"/>
+        </field>
+
+        <xpath expr="//filter[@string='Partner']" position="after">
+          <filter string="Product"
+                  name="group_product"
+                  context="{'group_by':'product_id'}"
+                  help="Group all elements associated to the same product."/>
+        </xpath>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>

--- a/super_calendar_quantity/README.rst
+++ b/super_calendar_quantity/README.rst
@@ -1,0 +1,80 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Super Calendar - Quantity
+=========================
+
+This module was written to extend the functionality of super_calendar. It adds
+a information about quantity.
+
+The user benefits:
+
+- a new link to a quantity, available on super_calendar configurator lines
+- a display of quantity in form and tree views
+
+It can also be displayed in calendar view if the user customizes its
+description code during the configuration.
+
+Installation
+============
+
+To install this module, you just need to select the module and insure yourself
+dependencies are available.
+
+Configuration
+=============
+
+No particular configuration to use this module
+
+Usage
+=====
+
+To use this module, you need to get an active super_calendar :
+
+- choose a model with a quantity field (ie; sale.order.line, purchase.order.line, etc.)
+- add a quantity field on your super_calendar configurator line
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+This series of modules focus on common Odoo elements (partner, product,
+quantity, analytic).
+It would be interesting to have a unique dynamic module, but the initial
+request of the customer and our budget did not allow us to do so.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/server-tools/issues/new?body=module:%20super_calendar_partner%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Agathe Mollé <agathe.molle@savoirfairelinux.com>
+* Bruno Joliveau <bruno.joliveau@savoirfairelinux.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/super_calendar_quantity/__init__.py
+++ b/super_calendar_quantity/__init__.py
@@ -1,0 +1,24 @@
+
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/super_calendar_quantity/__openerp__.py
+++ b/super_calendar_quantity/__openerp__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Super Calendar - Quantity',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'summary': 'Add new link to quantity for search and groupby on '
+               'super_calendar',
+    'author': ('Savoir-faire Linux',
+               'Odoo Community Association (OCA)'),
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'depends': [
+        'super_calendar_partner',
+    ],
+    'data': [
+        'views/super_calendar_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'application': False,
+    'auto_install': False,
+}

--- a/super_calendar_quantity/i18n/fr.po
+++ b/super_calendar_quantity/i18n/fr.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* super_calendar_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-22 18:59+0000\n"
+"PO-Revision-Date: 2015-06-22 15:04-0500\n"
+"Last-Translator: Agathe Mollé <agathe.molle@savoirfairelinux.com>\n"
+"Language-Team: Savoir-faire Linux <support@savoirfairelinux.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.5.4\n"
+"Language: fr\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. module: super_calendar_quantity
+#: field:super.calendar,quantity:0
+msgid "Quantity"
+msgstr "Quantité"
+
+#. module: super_calendar_quantity
+#: field:super.calendar.configurator.line,quantity_field_id:0
+msgid "Quantity field"
+msgstr "Champ Quantité"
+
+#. module: super_calendar_quantity
+#: view:super.calendar:super_calendar_quantity.super_calendar_tree
+msgid "Total Quantity"
+msgstr "Quantité totale"

--- a/super_calendar_quantity/i18n/super_calendar_quantity.pot
+++ b/super_calendar_quantity/i18n/super_calendar_quantity.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* super_calendar_quantity
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-22 18:59+0000\n"
+"PO-Revision-Date: 2015-06-22 18:59+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: super_calendar_quantity
+#: field:super.calendar,quantity:0
+msgid "Quantity"
+msgstr ""
+
+#. module: super_calendar_quantity
+#: field:super.calendar.configurator.line,quantity_field_id:0
+msgid "Quantity field"
+msgstr ""
+
+#. module: super_calendar_quantity
+#: view:super.calendar:super_calendar_quantity.super_calendar_tree
+msgid "Total Quantity"
+msgstr ""

--- a/super_calendar_quantity/models/__init__.py
+++ b/super_calendar_quantity/models/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import (
+    super_calendar,
+    super_calendar_configurator,
+    super_calendar_configurator_line,
+)

--- a/super_calendar_quantity/models/super_calendar.py
+++ b/super_calendar_quantity/models/super_calendar.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendar(models.Model):
+    _inherit = 'super.calendar'
+
+    quantity = fields.Float(
+        string='Quantity',
+        readonly=True,
+    )

--- a/super_calendar_quantity/models/super_calendar_configurator.py
+++ b/super_calendar_quantity/models/super_calendar_configurator.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import api, models
+
+
+class SuperCalendarConfigurator(models.Model):
+    _inherit = 'super.calendar.configurator'
+
+    @api.multi
+    def _get_record_values_from_line(self, line):
+        res = super(
+            SuperCalendarConfigurator, self
+        )._get_record_values_from_line(line)
+        for record in res:
+            f_quantity = line.quantity_field_id.name
+            res[record]['quantity'] = (f_quantity and
+                                       record[f_quantity])
+        return res

--- a/super_calendar_quantity/models/super_calendar_configurator_line.py
+++ b/super_calendar_quantity/models/super_calendar_configurator_line.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import fields, models
+
+
+class SuperCalendarConfiguratorLine(models.Model):
+    _inherit = 'super.calendar.configurator.line'
+
+    quantity_field_id = fields.Many2one(
+        comodel_name='ir.model.fields',
+        string='Quantity field',
+        domain=("[('ttype', 'in', ('float', 'integer')),"
+                "('model_id', '=', name)]"),
+    )

--- a/super_calendar_quantity/tests/__init__.py
+++ b/super_calendar_quantity/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_super_calendar_configurator

--- a/super_calendar_quantity/tests/test_super_calendar_configurator.py
+++ b/super_calendar_quantity/tests/test_super_calendar_configurator.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests import TransactionCase
+
+
+class TestSuperCalendar(TransactionCase):
+
+    def setUp(self):
+        super(TestSuperCalendar, self).setUp()
+
+        self.PartnerObj = self.env['res.partner']
+        self.SuperCalendarObj = self.env['super.calendar']
+        self.SuperCalendarConfiguratorObj = self.env[
+            'super.calendar.configurator']
+        self.SuperCalendarConfiguratorLineObj = self.env[
+            'super.calendar.configurator.line']
+        self.ModelFieldsObj = self.env['ir.model.fields']
+        self.ModelObj = self.env['ir.model']
+
+        self.partner = self.PartnerObj.create({
+            'name': 'Test Partner',
+            'credit_limit': 400.0
+        })
+
+        self.super_calendar_configurator = \
+            self.SuperCalendarConfiguratorObj.create({
+                'name': 'Partners',
+            })
+
+        self.partner_model = self.ModelObj.search([
+            ('model', '=', 'res.partner')
+        ])
+        self.date_start_field = self.ModelFieldsObj.search([
+            ('name', '=', 'create_date'),
+            ('model', '=', 'res.partner'),
+        ])
+        self.description_field = self.ModelFieldsObj.search([
+            ('name', '=', 'name'),
+            ('model', '=', 'res.partner'),
+        ])
+        # For a partner, credit_limit is a Float field so we use it to simulate
+        # a quantity
+        self.quantity_field = self.ModelFieldsObj.search([
+            ('name', '=', 'credit_limit'),
+            ('model', '=', 'res.partner'),
+        ])
+
+        self.super_calendar_configurator_line = \
+            self.SuperCalendarConfiguratorLineObj.create({
+                'name': self.partner_model.id,
+                'date_start_field_id': self.date_start_field.id,
+                'description_field_id': self.description_field.id,
+                'configurator_id': self.super_calendar_configurator.id,
+            })
+
+    def test_get_record_values_from_line(self):
+        """
+        Test if record values are correctly computed
+        """
+
+        # Test without quantity
+        values_partner = self.super_calendar_configurator.\
+            _get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.partner]
+
+        correctvalues = {
+            'configurator_id': self.super_calendar_configurator.id,
+            'date_start': self.partner.create_date,
+            'duration': False,
+            'model_id': self.partner_model.id,
+            'name': self.partner.name,
+            'res_id': self.partner_model.model + ',' + str(self.partner.id),
+            'user_id': False,
+            'quantity': False,
+        }
+
+        for key in ['configurator_id', 'date_start', 'duration', 'model_id',
+                    'name', 'res_id', 'user_id', 'quantity']:
+            self.assertEqual(
+                values_partner[key],
+                correctvalues[key]
+            )
+
+        # Add a quantity
+        self.super_calendar_configurator_line.write({
+            'quantity_field_id': self.quantity_field.id,
+        })
+        values_partner = self.super_calendar_configurator.\
+            _get_record_values_from_line(
+                self.super_calendar_configurator.line_ids[0]
+            )[self.partner]
+        correctvalues['quantity'] = self.partner.credit_limit
+        self.assertEqual(
+            values_partner['quantity'],
+            correctvalues['quantity']
+        )

--- a/super_calendar_quantity/views/super_calendar_view.xml
+++ b/super_calendar_quantity/views/super_calendar_view.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <!-- Configurator -->
+
+    <record model="ir.ui.view" id="super_calendar_configurator_form">
+       <field name="name">super_calendar_configurator_form</field>
+       <field name="model">super.calendar.configurator</field>
+       <field name="inherit_id" ref="super_calendar_partner.super_calendar_configurator_form"/>
+       <field name="arch" type="xml">
+
+         <field name="partner_field_id" position="after">
+           <field name="quantity_field_id" />
+         </field>
+
+       </field>
+     </record>
+
+
+    <!-- Calendar -->
+
+    <record id="super_calendar_tree" model="ir.ui.view">
+      <field name="name">super_calendar_tree</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_tree"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="quantity" sum="Total Quantity"/>
+        </field>
+
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="super_calendar_form">
+      <field name="name">super_calendar_form</field>
+      <field name="inherit_id" ref="super_calendar_partner.super_calendar_form"/>
+      <field name="model">super.calendar</field>
+      <field name="arch" type="xml">
+
+        <field name="partner_id" position="after">
+          <field name="quantity" />
+        </field>
+
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
Add 4 modules which respectively add the following fields:
- partner
- product
- quantity
- analytic account

Those fields allow to access to specific fields of each record. For example partner field allows to link to a Many2One field, which should be a res.partner (e.g. Customer, Created by, etc.). A filter is added in the search view and also a Groupby. Except for the quantity field (no search or groupby).

We made 4 distinct module in order to be able to choose which field you want to add to your super_calendar.

![super_calendar_modules](https://cloud.githubusercontent.com/assets/2845857/8317564/86946a94-19cc-11e5-9564-c74c2d139f6c.png)

![super_calendar_tree](https://cloud.githubusercontent.com/assets/2845857/8317565/8694bb34-19cc-11e5-81d2-2b3cb3122cbd.png)

Depends on:
- [x] #139 
