### PR TITLE
[FIX] Error logging on create

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -434,9 +434,10 @@ class auditlog_rule(models.Model):
             if field_name in FIELDS_BLACKLIST:
                 continue
             field = self._get_field(log.model_id, field_name)
-            log_vals = self._prepare_log_line_vals_on_create(
-                log, field, new_values)
-            log_line_model.create(log_vals)
+            if field:
+                log_vals = self._prepare_log_line_vals_on_create(
+                    log, field, new_values)
+                log_line_model.create(log_vals)
 
     def _prepare_log_line_vals_on_create(self, log, field, new_values):
         """Prepare the dictionary of values used to create a log line on a


### PR DESCRIPTION
For V8, I installed on my instance, create Rule to log for sale.order. And when create, got following error,

  File "/home/kittiu/workspace/odoo_nstda/nstda_msd/auditlog/models/rule.py", line 324, in create_logs
    self._create_log_line_on_create(log, diff.added(), new_values)
  File "/home/kittiu/workspace/odoo_nstda/nstda_msd/auditlog/models/rule.py", line 438, in _create_log_line_on_create
    log, field, new_values)
  File "/home/kittiu/workspace/odoo_nstda/nstda_msd/auditlog/models/rule.py", line 446, in _prepare_log_line_vals_on_create
    'field_id': field['id'],
TypeError: 'bool' object has no attribute '__getitem__'
