### PR TITLE
[IMP] allow to select lines to purge in a tree view

### DIFF
--- a/database_cleanup/model/purge_wizard.py
+++ b/database_cleanup/model/purge_wizard.py
@@ -73,6 +73,15 @@ class PurgeWizard(orm.AbstractModel):
             },
         }
 
+    def select_lines(self, cr, uid, ids, context=None):
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Select lines to purge',
+            'views': [(False, 'tree'), (False, 'form')],
+            'res_model': self._columns['purge_line_ids']._obj,
+            'domain': [('wizard_id', 'in', ids)],
+        }
+
     _columns = {
         'name': fields.char('Name', size=64, readonly=True),
         }

--- a/database_cleanup/view/purge_columns.xml
+++ b/database_cleanup/view/purge_columns.xml
@@ -35,19 +35,7 @@
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_column" />
-            <field name="code">
-wizard_id = self.create(cr, uid, {}, context=context)
-action = {
-    'type': 'ir.actions.act_window',
-    'views': [(False, 'form')],
-    'res_model': 'cleanup.purge.wizard.column',
-    'res_id': wizard_id,
-    'flags': {
-        'action_buttons': False,
-        'sidebar': False,
-    },
-}
-            </field>
+            <field name="code">action = self.get_wizard_action(cr, uid, context=context)</field>
         </record>
 
         <record id="purge_column_line_tree" model="ir.ui.view">
@@ -69,9 +57,7 @@ action = {
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_column" />
-            <field name="code">
-self.purge(cr, uid, context.get('active_ids', []), context)
-            </field>
+            <field name="code">self.purge(cr, uid, context.get('active_ids', []), context)</field>
         </record>
 
         <record id="action_purge_column_line_value" model="ir.values">

--- a/database_cleanup/view/purge_columns.xml
+++ b/database_cleanup/view/purge_columns.xml
@@ -11,15 +11,20 @@
                         <field name="name"/>
                     </h1>
                     <button type="object" name="purge_all" string="Purge all columns" />
+                    <button type="object" name="select_lines" string="Select lines" />
                     <field name="purge_line_ids" colspan="4" nolabel="1">
-                        <tree string="Purge columns">
-                            <field name="name" />
-                            <field name="model_id" />
-                            <field name="purged" invisible="0" />
-                            <button type="object" name="purge"
-                                    icon="gtk-cancel" string="Purge this column"
-                                    attrs="{'invisible': [('purged', '=', True)]}"/>
-                        </tree>
+                        <form string="Purge columns">
+                            <group>
+                                <field name="name" />
+                                <field name="model_id" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this column"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>
@@ -45,5 +50,36 @@ action = {
             </field>
         </record>
 
+        <record id="purge_column_line_tree" model="ir.ui.view">
+            <field name="model">cleanup.purge.line.column</field>
+            <field name="arch" type="xml">
+                <tree string="Purge columns">
+                    <field name="name" />
+                    <field name="model_id" />
+                    <field name="purged" invisible="0" />
+                    <button type="object" name="purge"
+                        icon="gtk-cancel" string="Purge this column"
+                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_purge_column_line" model="ir.actions.server">
+            <field name="name">Purge</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_column" />
+            <field name="code">
+self.purge(cr, uid, context.get('active_ids', []), context)
+            </field>
+        </record>
+
+        <record id="action_purge_column_line_value" model="ir.values">
+            <field name="name">Purge</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">cleanup.purge.line.column</field>
+            <field name="value" eval="'ir.actions.server,%d' % ref('database_cleanup.action_purge_column_line')" />
+        </record>
     </data>
 </openerp>

--- a/database_cleanup/view/purge_data.xml
+++ b/database_cleanup/view/purge_data.xml
@@ -35,19 +35,7 @@
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_data" />
-            <field name="code">
-wizard_id = self.create(cr, uid, {}, context=context)
-action = {
-    'type': 'ir.actions.act_window',
-    'views': [(False, 'form')],
-    'res_model': 'cleanup.purge.wizard.data',
-    'res_id': wizard_id,
-    'flags': {
-        'action_buttons': False,
-        'sidebar': False,
-    },
-}
-            </field>
+            <field name="code">action = self.get_wizard_action(cr, uid, context=context)</field>
         </record>
 
         <record id="purge_data_line_tree" model="ir.ui.view">
@@ -69,9 +57,7 @@ action = {
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_data" />
-            <field name="code">
-self.purge(cr, uid, context.get('active_ids', []), context)
-            </field>
+            <field name="code">self.purge(cr, uid, context.get('active_ids', []), context)</field>
         </record>
 
         <record id="action_purge_data_line_value" model="ir.values">

--- a/database_cleanup/view/purge_data.xml
+++ b/database_cleanup/view/purge_data.xml
@@ -11,15 +11,20 @@
                         <field name="name"/>
                     </h1>
                     <button type="object" name="purge_all" string="Purge all data" />
+                    <button type="object" name="select_lines" string="Select lines" />
                     <field name="purge_line_ids" colspan="4" nolabel="1">
-                        <tree string="Purge data">
-                            <field name="name" />
-                            <field name="data_id" />
-                            <field name="purged" invisible="0" />
-                            <button type="object" name="purge"
-                                    icon="gtk-cancel" string="Purge this data"
-                                    attrs="{'invisible': [('purged', '=', True)]}"/>
-                        </tree>
+                        <form string="Purge data">
+                            <group>
+                                <field name="name" />
+                                <field name="data_id" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this data"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>
@@ -45,5 +50,36 @@ action = {
             </field>
         </record>
 
+        <record id="purge_data_line_tree" model="ir.ui.view">
+            <field name="model">cleanup.purge.line.data</field>
+            <field name="arch" type="xml">
+                <tree string="Purge data">
+                    <field name="name" />
+                    <field name="data_id" />
+                    <field name="purged" invisible="0" />
+                    <button type="object" name="purge"
+                        icon="gtk-cancel" string="Purge this data"
+                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_purge_data_line" model="ir.actions.server">
+            <field name="name">Purge</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_data" />
+            <field name="code">
+self.purge(cr, uid, context.get('active_ids', []), context)
+            </field>
+        </record>
+
+        <record id="action_purge_data_line_value" model="ir.values">
+            <field name="name">Purge</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">cleanup.purge.line.data</field>
+            <field name="value" eval="'ir.actions.server,%d' % ref('database_cleanup.action_purge_data_line')" />
+        </record>
     </data>
 </openerp>

--- a/database_cleanup/view/purge_menus.xml
+++ b/database_cleanup/view/purge_menus.xml
@@ -10,18 +10,24 @@
                         <field name="name"/>
                     </h1>
                     <button type="object" name="purge_all" string="Purge all menus" />
+                    <button type="object" name="select_lines" string="Select lines" />
                     <field name="purge_line_ids">
-                        <tree>
-                            <field name="name" />
-                            <field name="purged" invisible="0" />
-                            <button type="object" name="purge"
-                                    icon="gtk-cancel" string="Purge this model"
+                        <form>
+                            <group>
+                                <field name="name" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                    icon="gtk-cancel" string="Purge this menu"
                                     attrs="{'invisible': [('purged', '=', True)]}"/>
-                        </tree>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>
         </record>
+
         <record id="action_purge_menus" model="ir.actions.server">
             <field name="name">Purge menus</field>
             <field name="type">ir.actions.server</field>
@@ -29,5 +35,35 @@
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_menu" />
             <field name="code">action = self.get_wizard_action(cr, uid, context=context)</field>
         </record>
+
+        <record id="purge_menu_line_tree" model="ir.ui.view">
+            <field name="model">cleanup.purge.line.menu</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name" />
+                    <field name="purged" invisible="0" />
+                    <button type="object" name="purge"
+                        icon="gtk-cancel" string="Purge this model"
+                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_purge_menu_line" model="ir.actions.server">
+            <field name="name">Purge</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_menu" />
+            <field name="code">self.purge(cr, uid, context.get('active_ids', []), context)</field>
+        </record>
+
+        <record id="action_purge_menu_line_value" model="ir.values">
+            <field name="name">Purge</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">cleanup.purge.line.menu</field>
+            <field name="value" eval="'ir.actions.server,%d' % ref('database_cleanup.action_purge_menu_line')" />
+        </record>
+
     </data>
 </openerp>

--- a/database_cleanup/view/purge_models.xml
+++ b/database_cleanup/view/purge_models.xml
@@ -34,19 +34,7 @@
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_model" />
-            <field name="code">
-wizard_id = self.create(cr, uid, {}, context=context)
-action = {
-    'type': 'ir.actions.act_window',
-    'views': [(False, 'form')],
-    'res_model': 'cleanup.purge.wizard.model',
-    'res_id': wizard_id,
-    'flags': {
-        'action_buttons': False,
-        'sidebar': False,
-    },
-}
-            </field>
+            <field name="code">action = self.get_wizard_action(cr, uid, context=context)</field>
         </record>
 
         <record id="purge_model_line_tree" model="ir.ui.view">
@@ -67,9 +55,7 @@ action = {
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_model" />
-            <field name="code">
-self.purge(cr, uid, context.get('active_ids', []), context)
-            </field>
+            <field name="code">self.purge(cr, uid, context.get('active_ids', []), context)</field>
         </record>
 
         <record id="action_purge_model_line_value" model="ir.values">

--- a/database_cleanup/view/purge_models.xml
+++ b/database_cleanup/view/purge_models.xml
@@ -11,14 +11,19 @@
                         <field name="name"/>
                     </h1>
                     <button type="object" name="purge_all" string="Purge all models" />
+                    <button type="object" name="select_lines" string="Select lines" />
                     <field name="purge_line_ids" colspan="4" nolabel="1">
-                        <tree string="Purge models">
-                            <field name="name" />
-                            <field name="purged" invisible="0" />
-                            <button type="object" name="purge"
-                                    icon="gtk-cancel" string="Purge this model"
-                                    attrs="{'invisible': [('purged', '=', True)]}"/>
-                        </tree>
+                        <form string="Purge models">
+                            <group>
+                                <field name="name" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this model"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>
@@ -42,6 +47,37 @@ action = {
     },
 }
             </field>
+        </record>
+
+        <record id="purge_model_line_tree" model="ir.ui.view">
+            <field name="model">cleanup.purge.line.model</field>
+            <field name="arch" type="xml">
+                <tree string="Purge models">
+                    <field name="name" />
+                    <field name="purged" invisible="0" />
+                    <button type="object" name="purge"
+                        icon="gtk-cancel" string="Purge this model"
+                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_purge_model_line" model="ir.actions.server">
+            <field name="name">Purge</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_model" />
+            <field name="code">
+self.purge(cr, uid, context.get('active_ids', []), context)
+            </field>
+        </record>
+
+        <record id="action_purge_model_line_value" model="ir.values">
+            <field name="name">Purge</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">cleanup.purge.line.model</field>
+            <field name="value" eval="'ir.actions.server,%d' % ref('database_cleanup.action_purge_model_line')" />
         </record>
 
     </data>

--- a/database_cleanup/view/purge_modules.xml
+++ b/database_cleanup/view/purge_modules.xml
@@ -34,19 +34,7 @@
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_module" />
-            <field name="code">
-wizard_id = self.create(cr, uid, {}, context=context)
-action = {
-    'type': 'ir.actions.act_window',
-    'views': [(False, 'form')],
-    'res_model': 'cleanup.purge.wizard.module',
-    'res_id': wizard_id,
-    'flags': {
-        'action_buttons': False,
-        'sidebar': False,
-    },
-}
-            </field>
+            <field name="code">action = self.get_wizard_action(cr, uid, context=context)</field>
         </record>
 
         <record id="purge_module_line_tree" model="ir.ui.view">
@@ -67,9 +55,7 @@ action = {
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_module" />
-            <field name="code">
-self.purge(cr, uid, context.get('active_ids', []), context)
-            </field>
+            <field name="code">self.purge(cr, uid, context.get('active_ids', []), context)</field>
         </record>
 
         <record id="action_purge_module_line_value" model="ir.values">

--- a/database_cleanup/view/purge_modules.xml
+++ b/database_cleanup/view/purge_modules.xml
@@ -11,14 +11,19 @@
                         <field name="name"/>
                     </h1>
                     <button type="object" name="purge_all" string="Purge all modules" />
+                    <button type="object" name="select_lines" string="Select lines" />
                     <field name="purge_line_ids" colspan="4" nolabel="1">
-                        <tree string="Purge modules">
-                            <field name="name" />
-                            <field name="purged" invisible="0" />
-                            <button type="object" name="purge"
-                                    icon="gtk-cancel" string="Purge this module"
-                                    attrs="{'invisible': [('purged', '=', True)]}"/>
-                        </tree>
+                        <form string="Purge modules">
+                            <group>
+                                <field name="name" />
+                                <field name="purged" invisible="0" />
+                            </group>
+                            <footer>
+                                <button type="object" name="purge"
+                                        icon="gtk-cancel" string="Purge this module"
+                                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                            </footer>
+                        </form>
                     </field>
                 </form>
             </field>
@@ -42,6 +47,37 @@ action = {
     },
 }
             </field>
+        </record>
+
+        <record id="purge_module_line_tree" model="ir.ui.view">
+            <field name="model">cleanup.purge.line.module</field>
+            <field name="arch" type="xml">
+                <tree string="Purge modules">
+                    <field name="name" />
+                    <field name="purged" invisible="0" />
+                    <button type="object" name="purge"
+                        icon="gtk-cancel" string="Purge this module"
+                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_purge_module_line" model="ir.actions.server">
+            <field name="name">Purge</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_module" />
+            <field name="code">
+self.purge(cr, uid, context.get('active_ids', []), context)
+            </field>
+        </record>
+
+        <record id="action_purge_module_line_value" model="ir.values">
+            <field name="name">Purge</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">cleanup.purge.line.module</field>
+            <field name="value" eval="'ir.actions.server,%d' % ref('database_cleanup.action_purge_module_line')" />
         </record>
 
     </data>

--- a/database_cleanup/view/purge_tables.xml
+++ b/database_cleanup/view/purge_tables.xml
@@ -11,6 +11,7 @@
                         <field name="name"/>
                     </h1>
                     <button type="object" name="purge_all" string="Purge all tables" />
+                    <button type="object" name="select_lines" string="Select lines" />
                     <field name="purge_line_ids" colspan="4" nolabel="1">
                         <tree string="Purge tables">
                             <field name="name" />
@@ -44,5 +45,35 @@ action = {
             </field>
         </record>
 
+        <record id="purge_table_line_tree" model="ir.ui.view">
+            <field name="model">cleanup.purge.line.table</field>
+            <field name="arch" type="xml">
+                <tree string="Purge tables">
+                    <field name="name" />
+                    <field name="purged" invisible="0" />
+                    <button type="object" name="purge"
+                        icon="gtk-cancel" string="Purge this table"
+                        attrs="{'invisible': [('purged', '=', True)]}"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_purge_table_line" model="ir.actions.server">
+            <field name="name">Purge</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_table" />
+            <field name="code">
+self.purge(cr, uid, context.get('active_ids', []), context)
+            </field>
+        </record>
+
+        <record id="action_purge_table_line_value" model="ir.values">
+            <field name="name">Purge</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">cleanup.purge.line.table</field>
+            <field name="value" eval="'ir.actions.server,%d' % ref('database_cleanup.action_purge_table_line')" />
+        </record>
     </data>
 </openerp>

--- a/database_cleanup/view/purge_tables.xml
+++ b/database_cleanup/view/purge_tables.xml
@@ -30,19 +30,7 @@
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_table" />
-            <field name="code">
-wizard_id = self.create(cr, uid, {}, context=context)
-action = {
-    'type': 'ir.actions.act_window',
-    'views': [(False, 'form')],
-    'res_model': 'cleanup.purge.wizard.table',
-    'res_id': wizard_id,
-    'flags': {
-        'action_buttons': False,
-        'sidebar': False,
-    },
-}
-            </field>
+            <field name="code">action = self.get_wizard_action(cr, uid, context=context)</field>
         </record>
 
         <record id="purge_table_line_tree" model="ir.ui.view">
@@ -63,9 +51,7 @@ action = {
             <field name="type">ir.actions.server</field>
             <field name="state">code</field>
             <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_table" />
-            <field name="code">
-self.purge(cr, uid, context.get('active_ids', []), context)
-            </field>
+            <field name="code">self.purge(cr, uid, context.get('active_ids', []), context)</field>
         </record>
 
         <record id="action_purge_table_line_value" model="ir.values">


### PR DESCRIPTION
When there are thousands of lines to review (data entries are a likely candidate for that) and you don't feel lucky enough to simply purge everything, reviewing is quite impossible in the one2many view. This PR adds a button to show the lines in a tree view. Then we can filter the way we want and only purge a selections. Feels much safer.

This supersedes #176 
