### PR TITLE
[FIX] users_ldap_groups - typo on _defaults dict

### DIFF
--- a/users_ldap_groups/__openerp__.py
+++ b/users_ldap_groups/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     "name": "Groups assignment",
-    "version": "1.2",
+    "version": "1.2.1",
     "depends": ["auth_ldap"],
     "author": "Therp BV,Odoo Community Association (OCA)",
     "description": """

--- a/users_ldap_groups/users_ldap_groups.py
+++ b/users_ldap_groups/users_ldap_groups.py
@@ -80,7 +80,7 @@ class CompanyLDAP(orm.Model):
                  'groups are preserved.')
     }
 
-    _default = {
+    _defaults = {
         'only_ldap_groups': False,
     }
 


### PR DESCRIPTION
It does nothing as it is False by default. But still it's wrong.
