### PR TITLE
[FIX] users_ldap_populate: Protect ldap library import

### DIFF
--- a/users_ldap_populate/__openerp__.py
+++ b/users_ldap_populate/__openerp__.py
@@ -41,6 +41,9 @@ object you want to query.
     "depends": [
         'auth_ldap',
     ],
+    'external_dependencies': {
+        'python': ['ldap'],
+    },
     "data": [
         'view/users_ldap.xml',
         'view/populate_wizard.xml',

--- a/users_ldap_populate/model/users_ldap.py
+++ b/users_ldap_populate/model/users_ldap.py
@@ -20,9 +20,15 @@
 ##############################################################################
 
 import re
-from ldap.filter import filter_format
 from openerp.osv import orm
 import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from ldap.filter import filter_format
+except ImportError:
+    _logger.debug('Can not `from ldap.filter import filter_format`.')
 
 
 class CompanyLDAP(orm.Model):


### PR DESCRIPTION
To avoid errors on dependent builds
