### PR TITLE
[FIX] use a nonserialized cursor for updating user groups

### DIFF
--- a/auth_dynamic_groups/model/res_users.py
+++ b/auth_dynamic_groups/model/res_users.py
@@ -19,7 +19,6 @@
 #
 ##############################################################################
 from openerp.models import Model
-from openerp.modules.registry import RegistryManager
 from openerp import SUPERUSER_ID
 
 
@@ -36,19 +35,21 @@ class res_users(Model):
 
     def update_dynamic_groups(self, uid, db):
         cr = self.pool._db.cursor(serialized=False)
-        user = self.pool.get('res.users').browse(cr, SUPERUSER_ID, uid)
         groups_obj = self.pool.get('res.groups')
-        user.write(
-            {
-                'groups_id': [
-                    (4, dynamic_group.id)
-                    if dynamic_group.eval_dynamic_group_condition(uid=uid)
-                    else (3, dynamic_group.id)
-                    for dynamic_group in groups_obj.browse(
-                        cr, SUPERUSER_ID,
-                        groups_obj.search(cr, SUPERUSER_ID,
-                                          [('is_dynamic', '=', True)]))
-                ],
-            })
-        cr.commit()
-        cr.close()
+        try:
+            dynamic_groups = groups_obj.browse(
+                cr, SUPERUSER_ID, groups_obj.search(
+                    cr, SUPERUSER_ID, [('is_dynamic', '=', True)]))
+            cr.execute(
+                'delete from res_groups_users_rel where uid=%s and gid in %s',
+                (uid, tuple(dynamic_groups.ids)))
+            for dynamic_group in dynamic_groups:
+                if dynamic_group.eval_dynamic_group_condition(uid=uid):
+                    cr.execute(
+                        'insert into res_groups_users_rel (uid, gid) values '
+                        '(%s, %s)',
+                        (uid, dynamic_group.id))
+            self.invalidate_cache(cr, uid, ['groups_id'], [uid])
+            cr.commit()
+        finally:
+            cr.close()

--- a/auth_dynamic_groups/model/res_users.py
+++ b/auth_dynamic_groups/model/res_users.py
@@ -35,10 +35,9 @@ class res_users(Model):
         return uid
 
     def update_dynamic_groups(self, uid, db):
-        pool = RegistryManager.get(db)
-        cr = pool._db.cursor()
-        user = pool.get('res.users').browse(cr, SUPERUSER_ID, uid)
-        groups_obj = pool.get('res.groups')
+        cr = self.pool._db.cursor(serialized=True)
+        user = self.pool.get('res.users').browse(cr, SUPERUSER_ID, uid)
+        groups_obj = self.pool.get('res.groups')
         user.write(
             {
                 'groups_id': [

--- a/auth_dynamic_groups/model/res_users.py
+++ b/auth_dynamic_groups/model/res_users.py
@@ -28,7 +28,7 @@ class res_users(Model):
     def _login(self, db, login, password):
         uid = super(res_users, self)._login(db, login, password)
 
-        if uid:
+        if uid and uid != SUPERUSER_ID:
             self.update_dynamic_groups(uid, db)
 
         return uid

--- a/auth_dynamic_groups/model/res_users.py
+++ b/auth_dynamic_groups/model/res_users.py
@@ -35,7 +35,7 @@ class res_users(Model):
         return uid
 
     def update_dynamic_groups(self, uid, db):
-        cr = self.pool._db.cursor(serialized=True)
+        cr = self.pool._db.cursor(serialized=False)
         user = self.pool.get('res.users').browse(cr, SUPERUSER_ID, uid)
         groups_obj = self.pool.get('res.groups')
         user.write(


### PR DESCRIPTION
Doing this in a serialized transaction can cause deadlocks, and we don't need serialization here
