### PR TITLE
8.0 fetchmail folder override hook and email preview

### DIFF
--- a/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
+++ b/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
@@ -117,6 +117,9 @@ class attach_mail_manually(models.TransientModel):
         result = super(attach_mail_manually, self).fields_view_get(
             cr, user, view_id, view_type, context, toolbar, submenu)
 
+        if view_type != 'form':
+            return result
+
         form = result['fields']['mail_ids']['views']['form']
         for folder in self.pool['fetchmail.server.folder'].browse(
                 cr, user, [context.get('default_folder_id')], context):

--- a/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
+++ b/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
@@ -32,6 +32,15 @@ class attach_mail_manually(models.TransientModel):
     mail_ids = fields.One2many(
         'fetchmail.attach.mail.manually.mail', 'wizard_id', 'Emails')
 
+    def _prepare_mail(
+            self, cr, uid, folder, msgid, mail_message, context=None):
+        return {
+            'msgid': msgid,
+            'subject': mail_message.get('subject', ''),
+            'date': mail_message.get('date', ''),
+            'object_id': '%s,-1' % folder.model_id.model,
+        }
+
     def default_get(self, cr, uid, fields_list, context=None):
         if context is None:
             context = {}
@@ -64,12 +73,10 @@ class attach_mail_manually(models.TransientModel):
                     save_original=folder.server_id.original,
                     context=context
                 )
-                defaults['mail_ids'].append((0, 0, {
-                    'msgid': msgid,
-                    'subject': mail_message.get('subject', ''),
-                    'date': mail_message.get('date', ''),
-                    'object_id': '%s,-1' % folder.model_id.model,
-                }))
+                defaults['mail_ids'].append(
+                    (0, 0, self._prepare_mail(
+                        cr, uid, folder, msgid, mail_message, context=context))
+                )
             connection.close()
 
         return defaults

--- a/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
+++ b/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
@@ -91,6 +91,8 @@ class attach_mail_manually(models.TransientModel):
     def attach_mails(self, cr, uid, ids, context=None):
         for this in self.browse(cr, uid, ids, context):
             for mail in this.mail_ids:
+                if not mail.object_id:
+                    continue
                 connection = this.folder_id.server_id.connect()
                 connection.select(this.folder_id.path)
                 result, msgdata = connection.fetch(mail.msgid, '(RFC822)')

--- a/fetchmail_attach_from_folder/wizard/attach_mail_manually.xml
+++ b/fetchmail_attach_from_folder/wizard/attach_mail_manually.xml
@@ -9,11 +9,21 @@
                     <group>
                         <field name="folder_id" />
                         <field name="mail_ids" nolabel="1" colspan="4">
-                            <tree editable="top" create="0">
+                            <tree create="0">
+                                <field name="email_from" />
                                 <field name="subject" />
                                 <field name="date" />
                                 <field name="object_id" />
                             </tree>
+                            <form>
+                                <group>
+                                    <field name="email_from" />
+                                    <field name="subject" />
+                                    <field name="date" />
+                                    <field name="object_id" />
+                                </group>
+                                <field name="body" />
+                            </form>
                         </field>
                     </group>
                     <footer>


### PR DESCRIPTION
This change concerns the functionality of fetchmail_attach_from_folder to attach non matching emails manually. It introduces a hook that allows adding custom values to the mail lines, and creates a proper email preview in a new form view of the mail lines. Previously, only the email subject and date were visible. Includes #282
