### PR TITLE
[database_cleanup] Statistics usage for modules and models.

### DIFF
--- a/database_cleanup/__openerp__.py
+++ b/database_cleanup/__openerp__.py
@@ -32,6 +32,8 @@
         'view/purge_columns.xml',
         'view/purge_tables.xml',
         'view/purge_data.xml',
+        'view/ir_model.xml',
+        'view/ir_module_module.xml',
         'view/menu.xml',
         ],
     'description': """\

--- a/database_cleanup/model/__init__.py
+++ b/database_cleanup/model/__init__.py
@@ -4,3 +4,5 @@ from . import purge_models
 from . import purge_columns
 from . import purge_tables
 from . import purge_data
+from . import ir_model
+from . import ir_module_module

--- a/database_cleanup/model/ir_model.py
+++ b/database_cleanup/model/ir_model.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv, fields
+
+
+class ir_model(osv.osv):
+    _inherit = 'ir.model'
+
+    def compute_stats(self, cr, uid, ids, field_names, arg, context=None):
+        cr.execute("CREATE EXTENSION IF NOT EXISTS pgstattuple;")
+
+        res = {}
+        for model in self.browse(cr, uid, ids, context=context):
+            if model.osv_memory:
+                res[model.id] = {
+                    'stat_table': False,
+                    'stat_type': False,
+                    'stat_bytes': 0,
+                    'stat_count': 0,
+                    'stat_count_data': 0,
+                }
+            else:
+                pool_model = self.pool[model.model]
+                cr.execute("select 'table' from pg_tables"
+                           " where schemaname='public'"
+                           "   and tablename='%s'"
+                           " union "
+                           "select 'view' from pg_views"
+                           " where schemaname='public'"
+                           "   and viewname='%s'"
+                           ";" % (pool_model._table, pool_model._table))
+                q_res = cr.fetchall()
+                no_table = not q_res
+                if not no_table:
+                    type_table = q_res.pop()[0]
+                    if type_table == 'table':
+                        cr.execute(
+                            "select table_len, tuple_count"
+                            " from pgstattuple('%s')"
+                            % pool_model._table)
+                        table_len, tuple_count = cr.fetchall().pop()
+                    else:
+                        cr.execute(
+                            "select count(*) from %s"
+                            % pool_model._table)
+                        table_len, tuple_count = 0, cr.fetchall().pop()[0]
+                else:
+                    table_len, tuple_count = 0, 0
+                if tuple_count:
+                    cr.execute(
+                        "select count(*) from ir_model_data where model='%s'"
+                        % model.model)
+                    tuple_count_data = cr.fetchall().pop()[0]
+                else:
+                    tuple_count_data = 0
+                res[model.id] = {
+                    'stat_table': pool_model._table,
+                    'stat_type': "no_table" if no_table else type_table,
+                    'stat_bytes': 0 if no_table else table_len,
+                    'stat_count': 0 if no_table else tuple_count,
+                    'stat_count_data': 0 if no_table else tuple_count_data,
+                }
+
+        return res
+
+    _columns = {
+        'stat_table': fields.function(
+            compute_stats,
+            string="Table name",
+            type="char",
+            multi="stats"),
+        'stat_type': fields.function(
+            compute_stats,
+            string="Type of table",
+            type="selection",
+            selection=[("no_table", "No table"),
+                       ("table", "Table"),
+                       ("view", "View")],
+            multi="stats"),
+        'stat_bytes': fields.function(
+            compute_stats,
+            string="Size in bytes",
+            type="integer",
+            multi="stats"),
+        'stat_count': fields.function(
+            compute_stats,
+            string="Number of rows",
+            type="integer",
+            multi="stats"),
+        'stat_count_data': fields.function(
+            compute_stats,
+            string="Number of data",
+            type="integer",
+            multi="stats"),
+    }

--- a/database_cleanup/model/ir_module_module.py
+++ b/database_cleanup/model/ir_module_module.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv, fields
+
+
+class ir_module_module(osv.osv):
+    _inherit = 'ir.module.module'
+
+    def compute_stats(self, cr, uid, ids, field_names, arg, context=None):
+        res = {}
+        model_pool = self.pool['ir.model']
+
+        model_ids = model_pool.search(cr, uid, [])
+        model_data = model_pool.read(cr, uid, model_ids, ['modules'])
+        model_modules = {m['id']: map(unicode.strip, m['modules'].split(','))
+                         for m in model_data}
+
+        module_models = {}
+        for model, modules in model_modules.items():
+            for module in modules:
+                if module not in module_models:
+                    module_models[module] = []
+                module_models[module].append(model)
+
+        for module in self.browse(cr, uid, ids, context=context):
+            model_stats = model_pool.read(cr, uid,
+                                          module_models.get(module.name, []),
+                                          ['stat_bytes',
+                                           'stat_count',
+                                           'stat_count_data'])
+
+            res[module.id] = {
+                'stat_bytes': sum(m['stat_bytes'] for m in model_stats),
+                'stat_count': sum(m['stat_count'] for m in model_stats),
+                'stat_count_data': sum(m['stat_count_data']
+                                       for m in model_stats),
+                'stat_dsd': len(module.downstream_dependencies()),
+            }
+            if (lambda m: (m['stat_count'] - m['stat_count_data']) == 0 and
+                not m['stat_dsd'])(
+                    res[module.id]):
+                res[module.id]['stat_status'] = 'removable'
+            elif (lambda m: m['stat_count'] - m['stat_count_data'] < 0
+                  )(res[module.id]):
+                res[module.id]['stat_status'] = 'broken'
+            else:
+                res[module.id]['stat_status'] = 'normal'
+
+            pass
+
+        return res
+
+    _columns = {
+        'stat_bytes': fields.function(
+            compute_stats,
+            string="Size in bytes",
+            type="integer",
+            multi="stats"),
+        'stat_count': fields.function(
+            compute_stats,
+            string="Number of rows",
+            type="integer",
+            multi="stats"),
+        'stat_count_data': fields.function(
+            compute_stats,
+            string="Number of data",
+            type="integer",
+            multi="stats"),
+        'stat_dsd': fields.function(
+            compute_stats,
+            string="Number dependencies",
+            type="integer",
+            multi="stats"),
+        'stat_status': fields.function(
+            compute_stats,
+            string="Status",
+            type="selection",
+            selection=[('removable', 'Removable'),
+                       ('broken', 'Broken'),
+                       ('normal', 'Normal')],
+            multi="stats"),
+    }

--- a/database_cleanup/view/ir_model.xml
+++ b/database_cleanup/view/ir_model.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="stat_models_tree" model="ir.ui.view">
+            <field name="name">ir.model tree stats</field>
+            <field name="model">ir.model</field>
+	    <field name="inherit_id" ref="base.view_model_tree"/>
+            <field name="arch" type="xml">
+		    <field name="osv_memory" position="before">
+			    <field name="stat_table"/>
+			    <field name="stat_type"/>
+			    <field name="stat_bytes"/>
+			    <field name="stat_count"/>
+			    <field name="stat_count_data"/>
+		    </field>
+            </field>
+        </record>
+
+        <record id="stat_models_form" model="ir.ui.view">
+            <field name="name">ir.model form stats</field>
+            <field name="model">ir.model</field>
+	    <field name="inherit_id" ref="base.view_model_form"/>
+            <field name="arch" type="xml">
+		    <notebook position="inside">
+			    <page string="Stats">
+				    <group>
+					    <field name="stat_table"/>
+					    <field name="stat_type"/>
+					    <field name="stat_bytes"/>
+					    <field name="stat_count"/>
+					    <field name="stat_count_data"/>
+				    </group>
+			    </page>
+		    </notebook>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/database_cleanup/view/ir_module_module.xml
+++ b/database_cleanup/view/ir_module_module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="stat_module_tree" model="ir.ui.view">
+            <field name="name">ir.module tree stats</field>
+            <field name="model">ir.module.module</field>
+	    <field name="inherit_id" ref="base.module_tree"/>
+            <field name="arch" type="xml">
+		    <field name="installed_version" position="before">
+			    <field name="stat_bytes"/>
+			    <field name="stat_count"/>
+			    <field name="stat_count_data"/>
+			    <field name="stat_dsd"/>
+			    <field name="stat_status"/>
+		    </field>
+            </field>
+        </record>
+
+        <record id="stat_module_form" model="ir.ui.view">
+            <field name="name">ir.module.module form stats</field>
+            <field name="model">ir.module.module</field>
+	    <field name="inherit_id" ref="base.module_form"/>
+            <field name="arch" type="xml">
+		    <notebook position="inside">
+			    <page string="Stats">
+				    <group>
+					    <field name="stat_bytes"/>
+					    <field name="stat_count"/>
+					    <field name="stat_count_data"/>
+					    <field name="stat_dsd"/>
+					    <field name="stat_status"/>
+				    </group>
+			    </page>
+		    </notebook>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
For database_cleanup (v7.0), this request include statistics for modules and models.

Some stats are database usage in bytes, number of rows, number of data defined in xml. These are visible in the module and model tree views. The Status column shows if the module is safe to remove, or is broken because the data in xml files are not all in the database.  

I use it to clean the database for unused modules, before export.
