### PR TITLE
[FIX] datetime_formatter - Set the correct locale to translate months and days

### DIFF
--- a/datetime_formatter/__openerp__.py
+++ b/datetime_formatter/__openerp__.py
@@ -5,9 +5,10 @@
 {
     "name": "Date & Time Formatter",
     "summary": "Helper functions to give correct format to date[time] fields",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Tools",
     "website": "https://grupoesoc.es",
+    "images": [],
     "author": "Grupo ESOC Ingeniería de Servicios, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/datetime_formatter/models.py
+++ b/datetime_formatter/models.py
@@ -72,7 +72,7 @@ class ResLang(models.Model):
         fail = True
         for ln in tools.get_locales(lang):
             try:
-                locale.setlocale(locale.LC_ALL, str(ln))
+                locale.setlocale(locale.LC_TIME, str(ln))
                 fail = False
                 break
             except locale.Error:
@@ -111,7 +111,8 @@ class ResLang(models.Model):
         # Get the correct lang
         lang = self.best_match(lang)
 
-        # Set the correct locale
+        # Backup the current locale and set the correct one
+        locale_backup = locale.getlocale(locale.LC_TIME)
         self._set_locale(lang.code)
 
         # Get the template
@@ -143,5 +144,6 @@ class ResLang(models.Model):
             value = (datetime.min + timedelta(hours=value)).time()
 
         res = value.strftime(template)
-        tools.resetlocale()
+        # Restore the locale
+        locale.setlocale(locale.LC_TIME, locale_backup)
         return res


### PR DESCRIPTION
This is a common issue with OpenERP/Odoo since a long time: the translation of months and days in non-english dates.
The PR is not a nice fix (a proper fix should be global, and not in this module especially), so it's OK if it is refused.
What do you think?
