### PR TITLE
Upgrade Gravatar module to v9, make installable, and add tests

### DIFF
--- a/base_user_gravatar/README.rst
+++ b/base_user_gravatar/README.rst
@@ -3,18 +3,18 @@
    :alt: License: AGPL-3
 
 ==========================
-Synchronize Gravatar image
+Synchronize Gravatar Image
 ==========================
 
-Use your Gravatar image in to your Odoo
+Use your Gravatar image in your Odoo
 
 Usage
 =====
 
 To configure this module, you need to:
 
-* edit user profile
-* press "Get Gravatar image" button
+* Edit user profile
+* Press "Get Gravatar image" button
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -35,6 +35,7 @@ Contributors
 ------------
 
 * Endika Iglesias <endika2@gmail.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/base_user_gravatar/__init__.py
+++ b/base_user_gravatar/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import tests

--- a/base_user_gravatar/__openerp__.py
+++ b/base_user_gravatar/__openerp__.py
@@ -3,14 +3,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'Synchronize Gravatar image',
-    'version': '8.0.1.0.0',
-    'author': 'Endika Iglesias, Odoo Community Association (OCA)',
+    'name': 'Synchronize Gravatar Image',
+    'version': '9.0.1.0.0',
+    'author': 'LasLabs, Endika Iglesias, Odoo Community Association (OCA)',
     'category': 'Tools',
     'website': 'http://www.endikaiglesias.com/',
     "license": "AGPL-3",
     "application": False,
-    'installable': False,
+    'installable': True,
     'depends': ['base'],
     'data': [
         'views/res_users_view.xml',

--- a/base_user_gravatar/models/res_users.py
+++ b/base_user_gravatar/models/res_users.py
@@ -24,15 +24,18 @@ class ResUsers(models.Model):
         except urllib2.HTTPError:
             raise UserError(_('Sorry Gravatar not found.'))
 
-    @api.one
+    @api.multi
     def get_gravatar_image(self):
-        email = str(self.email) or ''
-        fail_example = self._get_gravatar_base64('fail@email.gravatar')
-        user_gravatar = self._get_gravatar_base64(email)
-        if fail_example != user_gravatar:
-            self.write({'image': user_gravatar})
-        else:
-            raise UserError(
-                _("There is no Gravatar image for this email (%s)" % (
-                    email)))
+        for rec_id in self:
+            email = str(rec_id.email) or ''
+            fail_example = self._get_gravatar_base64('fail@email.gravatar')
+            user_gravatar = self._get_gravatar_base64(email)
+            if fail_example != user_gravatar:
+                rec_id.write({'image': user_gravatar})
+            else:
+                raise UserError(_(
+                    "There is no Gravatar image for this email (%s)" % (
+                        email
+                    )
+                ))
         return True

--- a/base_user_gravatar/tests/__init__.py
+++ b/base_user_gravatar/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_res_users

--- a/base_user_gravatar/tests/test_res_users.py
+++ b/base_user_gravatar/tests/test_res_users.py
@@ -1,23 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author: Dave Lasley <dave@laslabs.com>
-#    Copyright: 2016-TODAY LasLabs, Inc. [https://laslabs.com]
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2016-TODAY LasLabs, Inc. [https://laslabs.com]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp.tests.common import TransactionCase
 from openerp.addons.base_user_gravatar.models.res_users import ResUsers
@@ -50,7 +33,7 @@ class TestResUsers(TransactionCase):
 
     @mock.patch('%s.urllib2' % MODULE_LOCATION)
     def test_get_gravatar_base64_opens_correct_uri(self, mk, ):
-        ''' Test that gravatar is pinged for image '''
+        """ Test that gravatar is pinged for image """
         self.model_obj._get_gravatar_base64(self.partner_vals['email'])
         expect = hashlib.md5(self.partner_vals['email']).hexdigest()
         mk.urlopen.assert_called_once_with(self.url.format(expect))
@@ -58,7 +41,7 @@ class TestResUsers(TransactionCase):
     @mock.patch('%s.base64' % MODULE_LOCATION)
     @mock.patch('%s.urllib2' % MODULE_LOCATION)
     def test_get_gravatar_base64_returns_encoded_image(self, mk, b64_mk, ):
-        ''' Test that image result is read '''
+        """ Test that image result is read """
         expect = 'Expect'
         b64_mk.encodestring.return_value = expect
         result = self.model_obj._get_gravatar_base64(
@@ -67,7 +50,7 @@ class TestResUsers(TransactionCase):
         self.assertEquals(expect, result)
 
     def test_get_gravatar_image_writes_image(self, ):
-        ''' Test that the resulting gravatar is written to user '''
+        """ Test that the resulting gravatar is written to user """
         with mock.patch.object(ResUsers, 'write') as write_mk:
             user_id = self._test_record()
             with mock.patch.object(user_id, '_get_gravatar_base64') as mk:

--- a/base_user_gravatar/tests/test_res_users.py
+++ b/base_user_gravatar/tests/test_res_users.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Dave Lasley <dave@laslabs.com>
+#    Copyright: 2016-TODAY LasLabs, Inc. [https://laslabs.com]
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tests.common import TransactionCase
+from openerp.addons.base_user_gravatar.models.res_users import ResUsers
+import mock
+import hashlib
+
+
+MODULE_LOCATION = 'openerp.addons.base_user_gravatar.models.res_users'
+
+
+class TestResUsers(TransactionCase):
+
+    def setUp(self, *args, **kwargs):
+        super(TestResUsers, self).setUp()
+        self.model_obj = self.env['res.users']
+        self.partner_vals = {
+            'name': 'Test',
+            'email': 'test@example.com',
+        }
+        self.vals = {
+            'name': 'Test',
+            'login': 'test_login',
+        }
+        self.url = 'http://www.gravatar.com/avatar/{}?s=200'
+
+    def _test_record(self, ):
+        partner_id = self.env['res.partner'].create(self.partner_vals)
+        self.vals['partner_id'] = partner_id.id
+        return self.env['res.users'].create(self.vals)
+
+    @mock.patch('%s.urllib2' % MODULE_LOCATION)
+    def test_get_gravatar_base64_opens_correct_uri(self, mk, ):
+        ''' Test that gravatar is pinged for image '''
+        self.model_obj._get_gravatar_base64(self.partner_vals['email'])
+        expect = hashlib.md5(self.partner_vals['email']).hexdigest()
+        mk.urlopen.assert_called_once_with(self.url.format(expect))
+
+    @mock.patch('%s.base64' % MODULE_LOCATION)
+    @mock.patch('%s.urllib2' % MODULE_LOCATION)
+    def test_get_gravatar_base64_returns_encoded_image(self, mk, b64_mk, ):
+        ''' Test that image result is read '''
+        expect = 'Expect'
+        b64_mk.encodestring.return_value = expect
+        result = self.model_obj._get_gravatar_base64(
+            self.partner_vals['email']
+        )
+        self.assertEquals(expect, result)
+
+    def test_get_gravatar_image_writes_image(self, ):
+        ''' Test that the resulting gravatar is written to user '''
+        with mock.patch.object(ResUsers, 'write') as write_mk:
+            user_id = self._test_record()
+            with mock.patch.object(user_id, '_get_gravatar_base64') as mk:
+                expect = 'Expect'
+                mk.side_effect = ['Fail', expect]
+                user_id.get_gravatar_image()
+                write_mk.assert_called_once_with({'image': expect})


### PR DESCRIPTION
Hi All!

This PR removes deprecated `api.one` in the Gravatar module, adds tests, and a few styling changes in the ReadMe.

Not sure how to get Transifex to pass. I tried signing up, but it's still complaining so I ignored it.
