### PR TITLE
8.0 avoid a crash in log_forwarded_for_ip (even when the module is not installed)

### DIFF
--- a/log_forwarded_for_ip/__init__.py
+++ b/log_forwarded_for_ip/__init__.py
@@ -12,7 +12,7 @@ class log_forwarded_for_ip_installed(models.AbstractModel):
 address_string_original = WSGIRequestHandler.address_string
 
 def address_string(self):
-    if self.pool.get('log.forwarded.for.ip.installed'):
+    if self.env.get('log.forwarded.for.ip.installed'):
         # Code executed if the module log_forwarded_for_ip is installed
         if self.headers and isinstance(self.headers, dict):
             forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')

--- a/log_forwarded_for_ip/__init__.py
+++ b/log_forwarded_for_ip/__init__.py
@@ -3,25 +3,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from werkzeug.serving import WSGIRequestHandler
-from openerp import models
 
-
-class log_forwarded_for_ip_installed(models.AbstractModel):
-    _name = 'log.forwarded.for.ip.installed'
-
-address_string_original = WSGIRequestHandler.address_string
 
 def address_string(self):
-    if self.env.get('log.forwarded.for.ip.installed'):
-        # Code executed if the module log_forwarded_for_ip is installed
-        if self.headers and isinstance(self.headers, dict):
-            forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
-            if forwarded_for and forwarded_for[0]:
-                return forwarded_for[0]
-        return self.client_address[0]
-    else:
-        # If the module is NOT installed, we execute the original code
-        address_string_original(self)
-    return True
+    if self.headers and isinstance(self.headers, dict):
+        forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
+        if forwarded_for and forwarded_for[0]:
+            return forwarded_for[0]
+    return self.client_address[0]
 
 WSGIRequestHandler.address_string = address_string

--- a/log_forwarded_for_ip/__init__.py
+++ b/log_forwarded_for_ip/__init__.py
@@ -3,13 +3,25 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from werkzeug.serving import WSGIRequestHandler
+from openerp import models
 
+
+class log_forwarded_for_ip_installed(models.AbstractModel):
+    _name = 'log.forwarded.for.ip.installed'
+
+address_string_original = WSGIRequestHandler.address_string
 
 def address_string(self):
-    if self.headers and isinstance(self.headers, dict):
-        forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
-        if forwarded_for and forwarded_for[0]:
-            return forwarded_for[0]
-    return self.client_address[0]
+    if self.pool.get('log.forwarded.for.ip.installed'):
+        # Code executed if the module log_forwarded_for_ip is installed
+        if self.headers and isinstance(self.headers, dict):
+            forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
+            if forwarded_for and forwarded_for[0]:
+                return forwarded_for[0]
+        return self.client_address[0]
+    else:
+        # If the module is NOT installed, we execute the original code
+        address_string_original(self)
+    return True
 
 WSGIRequestHandler.address_string = address_string

--- a/log_forwarded_for_ip/__init__.py
+++ b/log_forwarded_for_ip/__init__.py
@@ -6,10 +6,10 @@ from werkzeug.serving import WSGIRequestHandler
 
 
 def address_string(self):
-    forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
-    if forwarded_for and forwarded_for[0]:
-        return forwarded_for[0]
-    else:
-        return self.client_address[0]
+    if self.headers and isinstance(self.headers, dict):
+        forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
+        if forwarded_for and forwarded_for[0]:
+            return forwarded_for[0]
+    return self.client_address[0]
 
 WSGIRequestHandler.address_string = address_string


### PR DESCRIPTION
I sometimes have this in my odoo logs:

```
2016-01-20 13:49:23,463 440 ERROR prod1 openerp.service.server: Worker (440) Exception occured, exiting...
Traceback (most recent call last):
  File "/home/odoo/erp/odoo/openerp/service/server.py", line 756, in run
    self.process_work()
  File "/home/odoo/erp/odoo/openerp/service/server.py", line 788, in process_work
    self.process_request(client, addr)
  File "/home/odoo/erp/odoo/openerp/service/server.py", line 779, in process_request
    self.server.process_request(client, addr)
  File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 649, in __init__
    self.handle()
  File "/usr/lib/python2.7/dist-packages/werkzeug/serving.py", line 200, in handle
    rv = BaseHTTPRequestHandler.handle(self)
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 340, in handle
    self.handle_one_request()
  File "/usr/lib/python2.7/dist-packages/werkzeug/serving.py", line 234, in handle_one_request
    elif self.parse_request():
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 253, in parse_request
    self.send_error(400, "Bad request version (%r)" % version)
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 364, in send_error
    self.log_error("code %d, message %s", code, message)
  File "/usr/lib/python2.7/dist-packages/werkzeug/serving.py", line 256, in log_error
    self.log('error', *args)
  File "/usr/lib/python2.7/dist-packages/werkzeug/serving.py", line 262, in log
    _log(type, '%s - - [%s] %s\n' % (self.address_string(),
  File "/home/odoo/erp/server-tools/log_forwarded_for_ip/__init__.py", line 9, in address_string
    forwarded_for = self.headers.get('X-Forwarded-For', '').split(',')
AttributeError: 'WSGIRequestHandler' object has no attribute 'headers'
```

and the module  log_forwarded_for_ip is not installed.

So I propose the patch to protect against this kind of crash. Beware that I didn't test this patch.
