### PR TITLE
Fix comparator equals when value is returned as a list.

### DIFF
--- a/users_ldap_groups/users_ldap_groups.py
+++ b/users_ldap_groups/users_ldap_groups.py
@@ -40,8 +40,15 @@ class LDAPOperator(models.AbstractModel):
             (value in ldap_entry[1][attribute])
 
     def equals(self, ldap_entry, attribute, value, ldap_config, company):
-        return attribute in ldap_entry[1] and \
-            unicode(value) == unicode(ldap_entry[1][attribute])
+        if attribute in ldap_entry[1]:
+            if isinstance(ldap_entry[1][attribute], list):
+                if len(ldap_entry[1][attribute]) > 1:
+                    return False
+                ldap_value = ldap_entry[1][attribute][0]
+            else:
+                ldap_value = ldap_entry[1][attribute]
+            return unicode(value) == unicode(ldap_value)
+        return False
 
     def query(self, ldap_entry, attribute, value, ldap_config, company):
         query_string = Template(value).safe_substitute(dict(


### PR DESCRIPTION
- At least with an OpenLDAP server, the values returned are always lists even when there is only one value. For example:

```
    {'cn': ['Carlos Lopez'],
     'employeeType': ['employee'],
     'givenName': ['Carlos'],
     'loginShell': ['/bin/bash'],
     }
```
- Therefore, using the operator 'equals' for 'employeeType' == 'employee' will fail because the value is inside a list.
- This patch checks if the value returned is a list and then picks the first field to do the comparision. If the value returned is not a list then it behaves as before.
