### PR TITLE
[IMP] auditlog - Full log / Fast log

### DIFF
--- a/auditlog/__openerp__.py
+++ b/auditlog/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': "Audit Log",
-    'version': "8.0.1.1.0",
+    'version': "8.0.1.2.0",
     'author': "ABF OSIELL,Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'website': "http://www.osiell.com",

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -40,7 +40,7 @@ class AuditlogLog(models.Model):
         'auditlog.http.session', string=u"Session")
     http_request_id = fields.Many2one(
         'auditlog.http.request', string=u"HTTP Request")
-    type = fields.Selection(
+    log_type = fields.Selection(
         [('full', u"Full log"),
          ('fast', u"Fast log"),
          ],

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -40,6 +40,11 @@ class AuditlogLog(models.Model):
         'auditlog.http.session', string=u"Session")
     http_request_id = fields.Many2one(
         'auditlog.http.request', string=u"HTTP Request")
+    type = fields.Selection(
+        [('full', u"Full log"),
+         ('fast', u"Fast log"),
+         ],
+        string=u"Type")
 
 
 class AuditlogLogLine(models.Model):

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -232,7 +232,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False).read(list(self._fields)))
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, new_record.ids,
-                'create', None, new_values, {'type': log_type})
+                'create', None, new_values, {'log_type': log_type})
             return new_record
 
         @api.model
@@ -245,7 +245,7 @@ class AuditlogRule(models.Model):
             new_values = {new_record.id: vals2}
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, new_record.ids,
-                'create', None, new_values, {'type': log_type})
+                'create', None, new_values, {'log_type': log_type})
             return new_record
 
         return create_full if self.log_type == 'full' else create_fast
@@ -279,7 +279,7 @@ class AuditlogRule(models.Model):
                 rule_model = env['auditlog.rule']
                 rule_model.sudo().create_logs(
                     env.uid, self._name, ids,
-                    'read', read_values, None, {'type': log_type})
+                    'read', read_values, None, {'log_type': log_type})
             # New API
             else:
                 # If the call came from auditlog itself, skip logging:
@@ -292,7 +292,7 @@ class AuditlogRule(models.Model):
                 rule_model = self.env['auditlog.rule']
                 rule_model.sudo().create_logs(
                     self.env.uid, self._name, self.ids,
-                    'read', read_values, None, {'type': log_type})
+                    'read', read_values, None, {'log_type': log_type})
             return result
         return read
 
@@ -315,7 +315,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False).read(list(self._fields)))
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, self.ids,
-                'write', old_values, new_values, {'type': log_type})
+                'write', old_values, new_values, {'log_type': log_type})
             return result
 
         @api.multi
@@ -332,7 +332,7 @@ class AuditlogRule(models.Model):
             result = write_fast.origin(self, vals, **kwargs)
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, self.ids,
-                'write', old_values, new_values, {'type': log_type})
+                'write', old_values, new_values, {'log_type': log_type})
             return result
 
         return write_full if self.log_type == 'full' else write_fast
@@ -352,7 +352,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False).read(list(self._fields)))
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, self.ids, 'unlink', old_values, None,
-                {'type': log_type})
+                {'log_type': log_type})
             return unlink_full.origin(self, **kwargs)
 
         @api.multi
@@ -361,7 +361,7 @@ class AuditlogRule(models.Model):
             rule_model = self.env['auditlog.rule']
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, self.ids, 'unlink', None, None,
-                {'type': log_type})
+                {'log_type': log_type})
             return unlink_fast.origin(self, **kwargs)
 
         return unlink_full if self.log_type == 'full' else unlink_fast
@@ -487,7 +487,7 @@ class AuditlogRule(models.Model):
             'new_value_text': new_values[log.res_id][field['name']],
         }
         # for *2many fields, log the name_get
-        if log.type == 'full' and field['relation'] \
+        if log.log_type == 'full' and field['relation'] \
                 and '2many' in field['ttype']:
             # Filter IDs to prevent a 'name_get()' call on deleted resources
             existing_ids = self.env[field['relation']]._search(
@@ -533,7 +533,7 @@ class AuditlogRule(models.Model):
             'new_value': new_values[log.res_id][field['name']],
             'new_value_text': new_values[log.res_id][field['name']],
         }
-        if log.type == 'full' and field['relation'] \
+        if log.log_type == 'full' and field['relation'] \
                 and '2many' in field['ttype']:
             new_value_text = self.env[field['relation']].browse(
                 vals['new_value']).name_get()

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -21,23 +21,7 @@
 from openerp.tests.common import TransactionCase
 
 
-class TestAuditlog(TransactionCase):
-    def setUp(self):
-        super(TestAuditlog, self).setUp()
-        self.groups_model_id = self.env.ref('base.model_res_groups').id
-        self.groups_rule = self.env['auditlog.rule'].create({
-            'name': 'testrule for groups',
-            'model_id': self.groups_model_id,
-            'log_read': True,
-            'log_create': True,
-            'log_write': True,
-            'log_unlink': True,
-            'state': 'subscribed',
-        })
-
-    def tearDown(self):
-        self.groups_rule.unlink()
-        super(TestAuditlog, self).tearDown()
+class TestAuditlog(object):
 
     def test_LogCreation(self):
         """First test, caching some data."""
@@ -105,3 +89,45 @@ class TestAuditlog(TransactionCase):
             ('method', '=', 'write'),
             ('res_id', '=', testgroup4.id),
         ]).ensure_one())
+
+
+class TestAuditlogFull(TransactionCase, TestAuditlog):
+
+    def setUp(self):
+        super(TestAuditlogFull, self).setUp()
+        self.groups_model_id = self.env.ref('base.model_res_groups').id
+        self.groups_rule = self.env['auditlog.rule'].create({
+            'name': 'testrule for groups',
+            'model_id': self.groups_model_id,
+            'log_read': True,
+            'log_create': True,
+            'log_write': True,
+            'log_unlink': True,
+            'state': 'subscribed',
+            'log_type': 'full',
+        })
+
+    def tearDown(self):
+        self.groups_rule.unlink()
+        super(TestAuditlogFull, self).tearDown()
+
+
+class TestAuditlogFast(TransactionCase, TestAuditlog):
+
+    def setUp(self):
+        super(TestAuditlogFast, self).setUp()
+        self.groups_model_id = self.env.ref('base.model_res_groups').id
+        self.groups_rule = self.env['auditlog.rule'].create({
+            'name': 'testrule for groups',
+            'model_id': self.groups_model_id,
+            'log_read': True,
+            'log_create': True,
+            'log_write': True,
+            'log_unlink': True,
+            'state': 'subscribed',
+            'log_type': 'fast',
+        })
+
+    def tearDown(self):
+        self.groups_rule.unlink()
+        super(TestAuditlogFast, self).tearDown()

--- a/auditlog/views/auditlog_view.xml
+++ b/auditlog/views/auditlog_view.xml
@@ -26,6 +26,7 @@
                             <group colspan="1">
                                 <field name="name" required="1"/>
                                 <field name="model_id"/>
+                                <field name="log_type"/>
                                 <field name="action_id" readonly="1" groups="base.group_no_one"/>
                             </group>
                             <group colspan="1">
@@ -54,6 +55,7 @@
                 <tree colors="blue:state == 'draft';black:state == 'subscribed'" string="Rules">
                     <field name="name"/>
                     <field name="model_id"/>
+                    <field name="log_type"/>
                     <field name="log_read"/>
                     <field name="log_write"/>
                     <field name="log_unlink"/>
@@ -110,6 +112,7 @@
                                 <field name="create_date" readonly="1"/>
                                 <field name="user_id" readonly="1"/>
                                 <field name="method" readonly="1"/>
+                                <field name="type" readonly="1"/>
                             </group>
                             <group colspan="1">
                                 <field name="model_id" readonly="1"/>

--- a/auditlog/views/auditlog_view.xml
+++ b/auditlog/views/auditlog_view.xml
@@ -112,7 +112,7 @@
                                 <field name="create_date" readonly="1"/>
                                 <field name="user_id" readonly="1"/>
                                 <field name="method" readonly="1"/>
-                                <field name="type" readonly="1"/>
+                                <field name="log_type" readonly="1"/>
                             </group>
                             <group colspan="1">
                                 <field name="model_id" readonly="1"/>


### PR DESCRIPTION
Ability to choose the log type on the rule: Full log (existing one, complete but slow) and Fast log (data input only, faster).

A first implementation was done by @wim-a, available here: https://github.com/osiell/server-tools/commit/1f2152cf5c7b4c6533c96cb1e2f3972a9eccaf01 (see #339)

I rewritten the feature as this implementation was still making `read` operations. Now the _Fast log_ type doesn't trigger `read` or `name_get()` calls anymore.
As a side effect, the logged data is different, e.g. changing a 2many field will log `[(6, 0, [1])]` in the _Fast log_ type and `[(1, u'Name')]` in _Full log_.

Some benchmarks: updating the `category_id` field on 200 partners takes ~17s in _Full log_, and ~3s in _Fast log_ (5x faster).
