### PR TITLE
[IMP] auditlog - Autovacuum logs

### DIFF
--- a/auditlog/README.rst
+++ b/auditlog/README.rst
@@ -1,5 +1,10 @@
-Track user operation on data models
-===================================
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+=================================
+Audit Log - Track user operations
+=================================
 
 This module allows the administrator to log user operations performed on data
 models such as ``create``, ``read``, ``write`` and ``delete``.
@@ -11,12 +16,14 @@ Go to `Reporting / Audit / Rules` to subscribe rules. A rule defines which
 operations to log for a given data model.
 Then, check logs in the `Reporting / Audit / Logs` menu.
 
-During installation, it will migrate any existing data from the `audittrail`
-module (rules and logs).
+A scheduled action exists to delete logs older than 6 months (180 days)
+automatically but is not enabled by default.
+To activate it and/or change the delay, go to the
+`Configuration / Technical / Automation / Scheduled Actions` menu and edit the
+`Auto-vacuum audit logs` entry.
 
-For further information, please visit:
-
- * https://www.odoo.com/forum/help-1
+During installation, a one-time script will migrate any existing data from the
+`audittrail` module (rules and logs).
 
 Known issues / Roadmap
 ======================

--- a/auditlog/__openerp__.py
+++ b/auditlog/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': "Audit Log",
-    'version': "8.0.1.2.0",
+    'version': "8.0.1.3.0",
     'author': "ABF OSIELL,Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'website': "http://www.osiell.com",
@@ -31,6 +31,7 @@
     ],
     'data': [
         'security/ir.model.access.csv',
+        'data/ir_cron.xml',
         'views/auditlog_view.xml',
         'views/http_session_view.xml',
         'views/http_request_view.xml',

--- a/auditlog/data/ir_cron.xml
+++ b/auditlog/data/ir_cron.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="ir_cron_auditlog_autovacuum" model="ir.cron">
+            <field name='name'>Auto-vacuum audit logs</field>
+            <field name='interval_number'>1</field>
+            <field name='interval_type'>days</field>
+            <field name="numbercall">-1</field>
+            <field name="active" eval="False"/>
+            <field name="doall" eval="False"/>
+            <field name="model">auditlog.autovacuum</field>
+            <field name="function">autovacuum</field>
+            <field name="args">(180,)</field>
+        </record>
+
+    </data>
+</openerp>

--- a/auditlog/models/__init__.py
+++ b/auditlog/models/__init__.py
@@ -23,3 +23,4 @@ from . import rule
 from . import http_session
 from . import http_request
 from . import log
+from . import autovacuum

--- a/auditlog/models/autovacuum.py
+++ b/auditlog/models/autovacuum.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# © 2016    ABF OSIELL SARL, Sebastien Alix (http://osiell.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from datetime import datetime, timedelta
+
+from openerp import models, fields, api
+
+
+_logger = logging.getLogger(__name__)
+
+
+class AuditlogAutovacuum(models.TransientModel):
+    _name = 'auditlog.autovacuum'
+    _description = "Auditlog - Delete old logs"
+
+    @api.model
+    def autovacuum(self, days):
+        """Delete all logs older than ``days``. This includes:
+            - CRUD logs (create, read, write, unlink)
+            - HTTP requests
+            - HTTP user sessions
+
+        Called from a cron.
+        """
+        days = (days > 0) and int(days) or 0
+        deadline = datetime.now() - timedelta(days=days)
+        data_models = (
+            'auditlog.log',
+            'auditlog.http.request',
+            'auditlog.http.session',
+        )
+        for data_model in data_models:
+            records = self.env[data_model].search(
+                [('create_date', '<=', fields.Datetime.to_string(deadline))])
+            nb_records = len(records)
+            records.unlink()
+            _logger.info(
+                u"AUTOVACUUM - %s '%s' records deleted",
+                nb_records, data_model)
+        return True

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -18,7 +18,6 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
 from openerp import models, fields
 
 
@@ -54,7 +53,7 @@ class AuditlogLogLine(models.Model):
     field_id = fields.Many2one(
         'ir.model.fields', ondelete='cascade', string=u"Field", required=True)
     log_id = fields.Many2one(
-        'auditlog.log', string=u"Log", ondelete='cascade')
+        'auditlog.log', string=u"Log", ondelete='cascade', index=True)
     old_value = fields.Text(u"Old Value")
     new_value = fields.Text(u"New Value")
     old_value_text = fields.Text(u"Old value Text")

--- a/auditlog/tests/__init__.py
+++ b/auditlog/tests/__init__.py
@@ -19,3 +19,4 @@
 #
 ##############################################################################
 from . import test_auditlog
+from . import test_autovacuum

--- a/auditlog/tests/test_autovacuum.py
+++ b/auditlog/tests/test_autovacuum.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# © 2016    ABF OSIELL SARL, Sebastien Alix (http://osiell.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import time
+
+from openerp.tests.common import TransactionCase
+
+
+class TestAuditlogAutovacuum(TransactionCase):
+
+    def setUp(self):
+        super(TestAuditlogAutovacuum, self).setUp()
+        self.groups_model_id = self.env.ref('base.model_res_groups').id
+        self.groups_rule = self.env['auditlog.rule'].create({
+            'name': 'testrule for groups',
+            'model_id': self.groups_model_id,
+            'log_read': True,
+            'log_create': True,
+            'log_write': True,
+            'log_unlink': True,
+            'state': 'subscribed',
+            'log_type': 'full',
+        })
+
+    def tearDown(self):
+        self.groups_rule.unlink()
+        super(TestAuditlogAutovacuum, self).tearDown()
+
+    def test_autovacuum(self):
+        log_model = self.env['auditlog.log']
+        autovacuum_model = self.env['auditlog.autovacuum']
+        group = self.env['res.groups'].create({
+            'name': 'testgroup1',
+        })
+        nb_logs = log_model.search_count([
+            ('model_id', '=', self.groups_model_id),
+            ('res_id', '=', group.id),
+        ])
+        self.assertGreater(nb_logs, 0)
+        # Milliseconds are ignored by autovacuum, waiting 1s ensure that
+        # the logs generated will be processed by the vacuum
+        time.sleep(1)
+        autovacuum_model.autovacuum(days=0)
+        nb_logs = log_model.search_count([
+            ('model_id', '=', self.groups_model_id),
+            ('res_id', '=', group.id),
+        ])
+        self.assertEqual(nb_logs, 0)


### PR DESCRIPTION
Add a `ir.cron` to delete logs periodically (fixing #187).

The index on the `log_id` field on the `auditlog_log_line` table is required to delete thousands of logs almost instantaneously.

I will bump the version number after the PR #357 is merged.
