### PR TITLE
[9.0] port - inactive_session_timeout

### DIFF
--- a/inactive_session_timeout/README.rst
+++ b/inactive_session_timeout/README.rst
@@ -31,6 +31,7 @@ Contributors
 ------------
 
 * Cédric Pigeon <cedric.pigeon@acsone.eu>
+* Dhinesh D <dvdhinesh.mail@gmail.com>
 
 Maintainer
 ----------

--- a/inactive_session_timeout/__init__.py
+++ b/inactive_session_timeout/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
+# (c) 2015 ACSONE SA/NV, Dhinesh D
+
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import models

--- a/inactive_session_timeout/__openerp__.py
+++ b/inactive_session_timeout/__openerp__.py
@@ -1,37 +1,20 @@
 # -*- coding: utf-8 -*-
-##############################################################################
+# (c) 2015 ACSONE SA/NV, Dhinesh D
 
-#     This file is part of inactive_session_timeout, an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     inactive_session_timeout is free software: you can redistribute it
-#     and/or modify it under the terms of the GNU Affero General Public License
-#     as published by the Free Software Foundation, either version 3 of
-#     the License, or (at your option) any later version.
-#
-#     inactive_session_timeout is distributed in the hope that it will
-#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#     GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the
-#     GNU Affero General Public License
-#     along with inactive_session_timeout.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
     'name': "Inactive Sessions Timeout",
 
     'summary': """
         This module disable all inactive sessions since a given delay""",
 
-    'author': "ACSONE SA/NV", "Odoo Community Association (OCA)"
+    'author': "ACSONE SA/NV, Dhinesh D, Odoo Community Association (OCA)",
+    'maintainer': 'Odoo Community Association (OCA)',
     'website': "http://acsone.eu",
 
     'category': 'Tools',
-    'version': '8.0.1.0.0',
+    'version': '9.0.1.0.0',
     'license': 'AGPL-3',
 
     'depends': [
@@ -41,5 +24,5 @@
     'data': [
         'data/ir_config_parameter_data.xml'
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/inactive_session_timeout/data/ir_config_parameter_data.xml
+++ b/inactive_session_timeout/data/ir_config_parameter_data.xml
@@ -1,6 +1,10 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<openerp>
+<!-- 
+    (c) 2015 ACSONE SA/NV, Dhinesh D
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
 
+<odoo>
     <data noupdate="1">
         <record id="inactive_session_time_out_delay" model="ir.config_parameter">
             <field name="key">inactive_session_time_out_delay</field>
@@ -14,4 +18,4 @@
             <field name="value">/calendar/notify,/longpolling/poll</field>
         </record>
     </data>
-</openerp>
+</odoo>

--- a/inactive_session_timeout/models/ir_config_parameter.py
+++ b/inactive_session_timeout/models/ir_config_parameter.py
@@ -1,26 +1,8 @@
 # -*- coding: utf-8 -*-
-##############################################################################
+# (c) 2015 ACSONE SA/NV, Dhinesh D
 
-#     This file is part of inactive_session_timeout, an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     inactive_session_timeout is free software: you can redistribute it
-#     and/or modify it under the terms of the GNU Affero General Public License
-#     as published by the Free Software Foundation, either version 3 of
-#     the License, or (at your option) any later version.
-#
-#     inactive_session_timeout is distributed in the hope that it will
-#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#     GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the
-#     GNU Affero General Public License
-#     along with inactive_session_timeout.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import models, api, tools, SUPERUSER_ID
 
 

--- a/inactive_session_timeout/models/res_users.py
+++ b/inactive_session_timeout/models/res_users.py
@@ -1,26 +1,8 @@
 # -*- coding: utf-8 -*-
-##############################################################################
+# (c) 2015 ACSONE SA/NV, Dhinesh D
 
-#     This file is part of inactive_session_timeout, an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     inactive_session_timeout is free software: you can redistribute it
-#     and/or modify it under the terms of the GNU Affero General Public License
-#     as published by the Free Software Foundation, either version 3 of
-#     the License, or (at your option) any later version.
-#
-#     inactive_session_timeout is distributed in the hope that it will
-#     be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#     GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the
-#     GNU Affero General Public License
-#     along with inactive_session_timeout.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import models
 from openerp import http
 

--- a/inactive_session_timeout/tests/__init__.py
+++ b/inactive_session_timeout/tests/__init__.py
@@ -3,5 +3,4 @@
 
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import res_users
-from . import ir_config_parameter
+from . import test_ir_config_parameter

--- a/inactive_session_timeout/tests/test_ir_config_parameter.py
+++ b/inactive_session_timeout/tests/test_ir_config_parameter.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 ACSONE SA/NV, Dhinesh D
+
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import threading
+
+from openerp.tests import common
+import openerp
+
+
+class TestIrConfigParameter(common.TransactionCase):
+
+    def setUp(self):
+        super(TestIrConfigParameter, self).setUp()
+        self.db = openerp.tools.config['db_name']
+        if not self.db and hasattr(threading.current_thread(), 'dbname'):
+            self.db = threading.current_thread().dbname
+        self.param_obj = self.env['ir.config_parameter']
+        self.data_obj = self.env['ir.model.data']
+        self.delay = self.env.ref(
+            'inactive_session_timeout.inactive_session_time_out_delay')
+
+    def test_check_delay(self):
+        delay, urls = self.param_obj.get_session_parameters(self.db)
+        self.assertEqual(delay, int(self.delay.value))
+        self.assertIsInstance(delay, int)
+        self.assertIsInstance(urls, list)


### PR DESCRIPTION
Porting module "inactive_session_timeout" to 9.0
