### PR TITLE
[FIX] auto_backup: Empty dump using sftp backup option (#428 issue)

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -6,7 +6,6 @@
 
 import os
 import shutil
-import tempfile
 import traceback
 from contextlib import contextmanager
 from datetime import datetime, timedelta
@@ -165,8 +164,7 @@ class DbBackup(models.Model):
             if backup:
                 cached = open(backup)
             else:
-                cached = tempfile.TemporaryFile()
-                db.dump_db(self.env.cr.dbname, cached)
+                cached = db.dump_db(self.env.cr.dbname, None)
 
             with cached:
                 for rec in sftp:


### PR DESCRIPTION
Fix for issue: [8.0][auto_backup] Empty dump using sftp backup option #428
