### PR TITLE
[9.0][FIX][auth_supplier] Right permissions.

### DIFF
--- a/auth_supplier/README.rst
+++ b/auth_supplier/README.rst
@@ -6,8 +6,10 @@
 Auth Supplier
 =============
 
-This module was written to extends the functionality of auth signup
-and allows the user to create an account as a supplier.
+This module was written to extends the functionality of auth signup and allows
+the user to create an account as a supplier, marking him as with permissions
+for a supplier portal (although nothing is implemented for that portal, other
+modules should do that).
 
 Configuration
 =============
@@ -26,9 +28,18 @@ To use this module, you need to:
 
 * Log out.
 * If you have a website, in home page press *Sign in*.
-* Press *Sign up*.
+* Press *Sign up* to go to `the sign up page </web/signup>`_.
 * Select *Supplier* in account type.
 * Fill the form.
+
+If you want to give permissions to anybody for the supplier portal:
+
+#. Go to *Contacts*.
+#. Choose a supplier.
+#. Go to *Action > Portal Access Management*.
+#. Choose *Other Extra Rights / Supplier Portal*.
+#. Choose contacts to be *In Portal*.
+#. Press *Apply*.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -41,7 +52,7 @@ Known issues / Roadmap
   page.
 * When the user signs up as *Customer*, it is not really marked as such in the
   backend, it's just not marked as supplier. Is this expected behavior or bug?
-  `Relevant discussion 
+  `Relevant discussion
   <https://github.com/OCA/server-tools/pull/434#discussion-diff-64883758>`_.
 
 Bug Tracker

--- a/auth_supplier/__openerp__.py
+++ b/auth_supplier/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': "Auth Supplier",
-    'category': 'Tools',
+    'category': 'Portal',
     'version': '9.0.1.0.0',
     'depends': [
         'auth_signup',

--- a/auth_supplier/__openerp__.py
+++ b/auth_supplier/__openerp__.py
@@ -7,7 +7,7 @@
 {
     'name': "Auth Supplier",
     'category': 'Portal',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'depends': [
         'auth_signup',
     ],

--- a/auth_supplier/security/auth_supplier_security.xml
+++ b/auth_supplier/security/auth_supplier_security.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="group_auth_supplier" model="res.groups">
-        <field name="name">Portal Supplier</field>
+        <field name="name">Supplier Portal</field>
         <field name="category_id" ref="base.module_category_extra"/>
         <field name="is_portal" eval="True"/>
     </record>

--- a/auth_supplier/security/auth_supplier_security.xml
+++ b/auth_supplier/security/auth_supplier_security.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record model="ir.module.category" id="module_auth_supplier">
-        <field name="name">Auth Supplier</field>
-        <field name="sequence">100</field>
-    </record>
-
     <record id="group_auth_supplier" model="res.groups">
         <field name="name">Portal Supplier</field>
-        <field name="category_id" ref="module_auth_supplier"/>
+        <field name="category_id" ref="base.module_category_extra"/>
+        <field name="is_portal" eval="True"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
Right now a normal user cannot manage supplier portal access from the wizard because group was not marked as `is_portal`.

With this fix, you can enable supplier portal for a given partner.

BTW some unneeded code has been removed.

@Tecnativa
