### PR TITLE
[FIX] fix broken menuitem reference for Audit on odoo 9

### DIFF
--- a/auditlog/views/auditlog_view.xml
+++ b/auditlog/views/auditlog_view.xml
@@ -3,7 +3,7 @@
     <data>
 
         <menuitem id="menu_audit" name="Audit"
-            parent="base.menu_reporting" sequence="50"
+            parent="base.menu_custom" sequence="50"
             groups="base.group_system"/>
 
 


### PR DESCRIPTION
The `menu_audit` menu item was broken on odoo 9 even though this module is listed under the 9.0 branch on the repo.

I updated it to fall under `base.menu_custom` instead of `base.menu_reporting`.
