### PR TITLE
Make import_odbc installable

### DIFF
--- a/import_odbc/__openerp__.py
+++ b/import_odbc/__openerp__.py
@@ -95,8 +95,8 @@ Contributors
         'import_odbc_demo.xml',
     ],
     'test': [],
-    'installable': False,
-    'active': False,
+    'installable': True,
+    'auto_install': False,
 }
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
As mentioned in migration  https://github.com/OCA/server-tools/issues/168 and pr https://github.com/OCA/server-tools/pull/41, This module should be installable.
