### PR TITLE
Improvements for the auth_brute_force module (ban user, custom ban message, automatically unban, de l10n)

### DIFF
--- a/auth_brute_force/README.rst
+++ b/auth_brute_force/README.rst
@@ -7,13 +7,13 @@ Tracks Authentication Attempts and Prevents Brute-force Attacks
 
 This module registers each request done by users trying to authenticate into
 Odoo. If the authentication fails, a counter is increased for the given remote
-IP. After a defined number of attempts, Odoo will ban the remote IP and
-ignore new requests.
+IP or user. After a defined number of attempts, Odoo will ban the remote IP or
+user and ignore new requests.
 This module applies security through obscurity
 (https://en.wikipedia.org/wiki/Security_through_obscurity),
 When a user is banned, the request is now considered as an attack. So, the UI
-will **not** indicate to the user that his IP is banned and the regular message
-'Wrong login/password' is displayed.
+will **not** (unless an error message is set) indicate to the user that his IP
+is banned and the regular message 'Wrong login/password' is displayed.
 
 This module realizes a call to a web API (http://ip-api.com) to try to have
 extra information about remote IP.
@@ -28,19 +28,36 @@ of the user can be wrong, and mainly in the following cases:
 * if the Odoo server is behind an Apache / NGinx proxy without redirection,
   all the request will be have the value '127.0.0.1' for the REMOTE_ADDR key;
 * If some users are behind the same Internet Service Provider, if a user is
-  banned, all the other users will be banned too;
+  banned, all the other users will be banned too. To avoid this you can also
+  change the ban method to ban the user;
 
 Configuration
 -------------
 
-Once installed, you can change the ir.config_parameter value for the key
-'auth_brute_force.max_attempt_qty' (10 by default) that define the max number
-of attempts allowed before the user was banned.
+Once installed, you can change the settings via the ir.config_parameter:
+
+* 'auth_brute_force.max_attempt_qty' (default: 10) - The max number
+  of attempts allowed before the user was banned.
+
+* 'auth_brute_force.attempt_ban_type' (default: ip) - If 'ip' is set then
+  the remote IP is used for checking of failed attempts and is also used
+  for banning. If 'user' is set then only the attempts for the same login
+  name are checked and only the user will be banned.
+
+* 'auth_brute_force.attempt_ban_message' (default: empty) - The message
+  which will be returned if the remote was banned. If the message is empty
+  then the regular message 'Wrong login/password' is displayed.
+
+* 'auth_brute_force.attempt_ban_time' (default: 30) - The minutes after the
+  remote will be unbanned. If set to 0 then the remotes will not be
+  automatically unbanned.
+
 
 Usage
 -----
 
-Admin user have the possibility to unblock a banned IP.
+Admin user have the possibility to unblock a banned IP. A scheduler checks
+per default every minute the banned entries to automatically unban them.
 
 Logging
 -------

--- a/auth_brute_force/__openerp__.py
+++ b/auth_brute_force/__openerp__.py
@@ -35,6 +35,7 @@
     'data': [
         'security/ir_model_access.yml',
         'data/ir_config_parameter.xml',
+        'data/ir_cron.xml',
         'views/view.xml',
         'views/action.xml',
         'views/menu.xml',

--- a/auth_brute_force/controllers/controllers.py
+++ b/auth_brute_force/controllers/controllers.py
@@ -89,9 +89,12 @@ class LoginController(Home):
                     return self.show_banned_message(attempt_ban_message)
             else:
                 # Try to authenticate
+                old_uid = request.uid
                 result = request.session.authenticate(
                     request.session.db, request.params['login'],
                     request.params['password'])
+                if result is False:
+                    request.uid = old_uid
 
             # Log attempt
             cursor.commit()

--- a/auth_brute_force/data/ir_config_parameter.xml
+++ b/auth_brute_force/data/ir_config_parameter.xml
@@ -25,5 +25,20 @@
             <field name="value">10</field>
         </record>
 
+        <record id="attempt_ban_type" model="ir.config_parameter">
+            <field name="key">auth_brute_force.attempt_ban_type</field>
+            <field name="value">ip</field>
+        </record>
+
+        <record id="attempt_ban_message" model="ir.config_parameter">
+            <field name="key">auth_brute_force.attempt_ban_message</field>
+            <field name="value"> </field>
+        </record>
+
+        <record id="attempt_ban_time" model="ir.config_parameter">
+            <field name="key">auth_brute_force.attempt_ban_time</field>
+            <field name="value">30</field>
+        </record>
+
     </data>
 </openerp>

--- a/auth_brute_force/data/ir_cron.xml
+++ b/auth_brute_force/data/ir_cron.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="1">
+
+    <record id="unban_users_scheduler" model="ir.cron">
+      <field name="name">Unban Users</field>
+      <field eval="True" name="active"/>
+      <field name="interval_number">1</field>
+      <field name="interval_type">minutes</field>
+      <field name="numbercall">-1</field>
+      <field name="doall" eval="True"/>
+      <field name="model" eval="'res.banned.remote'"/>
+      <field name="function" eval="'unban_after_ban_time'"/>
+    </record>
+
+  </data>
+</openerp>

--- a/auth_brute_force/i18n/auth_brute_force.pot
+++ b/auth_brute_force/i18n/auth_brute_force.pot
@@ -56,6 +56,14 @@ msgid "Banned"
 msgstr ""
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/de.po
+++ b/auth_brute_force/i18n/de.po
@@ -25,23 +25,23 @@ msgstr "Aktiv"
 #. module: auth_brute_force
 #: field:res.authentication.attempt,attempt_date:0
 msgid "Attempt Date"
-msgstr ""
+msgstr "Datum des Versuchs"
 
 #. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_authentication_attempt
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_authentication_attempt
 msgid "Authentication Attempts"
-msgstr ""
+msgstr "Authentifizierungsversuche"
 
 #. module: auth_brute_force
 #: field:res.authentication.attempt,result:0
 msgid "Authentication Result"
-msgstr ""
+msgstr "Authentifizierungsergebnis"
 
 #. module: auth_brute_force
 #: field:res.banned.remote,ban_date:0
 msgid "Ban Date"
-msgstr ""
+msgstr "Datum des Banns"
 
 #. module: auth_brute_force
 #: code:addons/auth_brute_force/models/res_authentication_attempt.py:34
@@ -49,13 +49,21 @@ msgstr ""
 #: selection:res.authentication.attempt,result:0
 #, python-format
 msgid "Banned"
-msgstr ""
+msgstr "Gebannt"
+
+#. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr "Entbannt"
 
 #. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"
-msgstr ""
+msgstr "Gebannte Benutzer"
 
 #. module: auth_brute_force
 #: field:res.authentication.attempt,create_uid:0
@@ -80,7 +88,7 @@ msgstr "Beschreibung"
 #: selection:res.authentication.attempt,result:0
 #, python-format
 msgid "Failed"
-msgstr ""
+msgstr "Fehlgeschlagen"
 
 #. module: auth_brute_force
 #: field:res.authentication.attempt,id:0 field:res.banned.remote,id:0
@@ -102,31 +110,31 @@ msgstr "Zuletzt aktualisiert am"
 #. module: auth_brute_force
 #: field:res.authentication.attempt,remote:0 field:res.banned.remote,remote:0
 msgid "Remote ID"
-msgstr ""
+msgstr "Externe IP"
 
 #. module: auth_brute_force
 #: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
 msgid "Successful"
-msgstr ""
+msgstr "Erfolgreich"
 
 #. module: auth_brute_force
 #: code:addons/auth_brute_force/models/res_authentication_attempt.py:32
 #: selection:res.authentication.attempt,result:0
 #, python-format
 msgid "Successfull"
-msgstr ""
+msgstr "Erfolgreich"
 
 #. module: auth_brute_force
 #: field:res.authentication.attempt,login:0
 msgid "Tried Login"
-msgstr ""
+msgstr "Versuchter Login"
 
 #. module: auth_brute_force
 #: help:res.banned.remote,active:0
 msgid "Uncheck this box to unban the remote"
-msgstr ""
+msgstr "Deaktivere diese Box, um Externe zu entbannen."
 
 #. module: auth_brute_force
 #: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
 msgid "Without Success"
-msgstr ""
+msgstr "Ohne Erfolg"

--- a/auth_brute_force/i18n/en.po
+++ b/auth_brute_force/i18n/en.po
@@ -57,6 +57,14 @@ msgid "Banned"
 msgstr "Banned"
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr "Unbanned"
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/es.po
+++ b/auth_brute_force/i18n/es.po
@@ -71,6 +71,14 @@ msgid "Banned"
 msgstr ""
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/fi.po
+++ b/auth_brute_force/i18n/fi.po
@@ -64,6 +64,14 @@ msgid "Banned"
 msgstr ""
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/fr.po
+++ b/auth_brute_force/i18n/fr.po
@@ -65,6 +65,14 @@ msgid "Banned"
 msgstr "Banni"
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/it.po
+++ b/auth_brute_force/i18n/it.po
@@ -67,6 +67,14 @@ msgid "Banned"
 msgstr "Interdetto"
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/pt_BR.po
+++ b/auth_brute_force/i18n/pt_BR.po
@@ -63,6 +63,14 @@ msgid "Banned"
 msgstr "Proibido"
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/ru.po
+++ b/auth_brute_force/i18n/ru.po
@@ -52,6 +52,14 @@ msgid "Banned"
 msgstr ""
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/sl.po
+++ b/auth_brute_force/i18n/sl.po
@@ -66,6 +66,14 @@ msgid "Banned"
 msgstr "Prepovedan"
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/tr.po
+++ b/auth_brute_force/i18n/tr.po
@@ -52,6 +52,14 @@ msgid "Banned"
 msgstr ""
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/i18n/zh_CN.po
+++ b/auth_brute_force/i18n/zh_CN.po
@@ -52,6 +52,14 @@ msgid "Banned"
 msgstr ""
 
 #. module: auth_brute_force
+#: code:addons/auth_brute_force/models/res_authentication_attempt.py:35
+#: view:res.authentication.attempt:auth_brute_force.view_res_authentication_attempt_search
+#: selection:res.authentication.attempt,result:0
+#, python-format
+msgid "Unbanned"
+msgstr ""
+
+#. module: auth_brute_force
 #: model:ir.actions.act_window,name:auth_brute_force.action_res_banned_remote
 #: model:ir.ui.menu,name:auth_brute_force.menu_res_banned_remote
 msgid "Banned Remotes"

--- a/auth_brute_force/models/res_banned_remote.py
+++ b/auth_brute_force/models/res_banned_remote.py
@@ -19,11 +19,15 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
+from datetime import datetime, timedelta
 import urllib
 import json
+import logging
 
 from openerp import models, fields, api
+from openerp.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
+
+_logger = logging.getLogger(__name__)
 
 
 class ResBannedRemote(models.Model):
@@ -44,6 +48,8 @@ class ResBannedRemote(models.Model):
         string='Ban Date', required=True, default=_default_ban_date)
 
     remote = fields.Char(string='Remote ID', required=True)
+
+    user_id = fields.Many2one(comodel_name='res.users', string='User')
 
     active = fields.Boolean(
         string='Active', help="Uncheck this box to unban the remote",
@@ -69,3 +75,74 @@ class ResBannedRemote(models.Model):
         for item in self:
             attempt_obj = self.env['res.authentication.attempt']
             item.attempt_ids = attempt_obj.search_last_failed(item.remote).ids
+
+    @api.multi
+    def write(self, vals):
+        # create log entry if the user was unbanned
+        if not vals.get('active', True):
+            self.on_unban()
+        return super(ResBannedRemote, self).write(vals)
+
+    @api.multi
+    def unlink(self):
+        self.on_unban()
+        return super(ResBannedRemote, self).unlink()
+
+    @api.multi
+    def on_unban(self):
+        for rec in self:
+            # avoid log entry if active was already False
+            if not rec.active:
+                continue
+            self.env['res.authentication.attempt'].create({
+                'attempt_date': fields.Datetime.now(),
+                'login': rec.user_id and rec.user_id.login or False,
+                'remote': rec.remote,
+                'user_id': rec.user_id and rec.user_id.id or False,
+                'result': 'unbanned',
+            })
+
+    @api.multi
+    def name_get(self):
+        result = []
+
+        for rec in self:
+            name = rec.remote
+            if rec.user_id:
+                name = '%s / %s' % (rec.remote, rec.user_id.name_get()[0][1])
+            result.append((rec.id, name))
+
+        return result
+
+    @api.model
+    def unban_after_ban_time(self):
+        attempt_ban_time = self.env['ir.config_parameter'].search_read(
+            [('key', '=', 'auth_brute_force.attempt_ban_time')], ['value'])
+
+        # if config parameter doesn't exists: abort
+        if not attempt_ban_time:
+            return True
+
+        try:
+            attempt_ban_time = int(attempt_ban_time[0]['value'])
+        except ValueError:
+            attempt_ban_time = 0
+
+        # if config parameter is not positive: abort
+        if attempt_ban_time <= 0:
+            return True
+
+        unban_before = datetime.now() - timedelta(minutes=attempt_ban_time)
+        unban_before = unban_before.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+        recs = self.search([
+            ('active', '=', True),
+            ('ban_date', '<', unban_before)])
+
+        if recs:
+            recs.write({
+                'active': False,
+            })
+
+            unbanned_names = map(lambda x: x[1], recs.name_get())
+            _logger.info(
+                'Unbanned following remotes: %s' % ', '.join(unbanned_names))

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -27,6 +27,7 @@
                 <tree colors="orange: result == 'failed';red: result == 'banned'">
                     <field name="attempt_date" />
                     <field name="remote" />
+                    <field name="user_id" />
                     <field name="login" />
                     <field name="result" />
                 </tree>
@@ -48,8 +49,9 @@
             <field name="arch" type="xml">
                 <search>
                    <field name="login"/>
-                   <filter name="filter_no_success" string="Without Success" domain="[('result','!=', 'successfull')]"/>
+                   <filter name="filter_no_success" string="Without Success" domain="[('result','not in', ['successfull', 'unbanned'])]"/>
                    <filter name="filter_banned" string="Banned" domain="[('result','=', 'banned')]"/>
+                   <filter name="filter_unbanned" string="Unbanned" domain="[('result','=', 'unbanned')]"/>
                    <filter name="filter_failed" string="Failed" domain="[('result','=', 'failed')]"/>
                    <filter name="filter_successful" string="Successful" domain="[('result','=', 'successfull')]"/>
                 </search>
@@ -62,6 +64,7 @@
             <field name="arch" type="xml">
                 <tree colors="gray: active==False">
                     <field name="remote" />
+                    <field name="user_id" />
                     <field name="ban_date" />
                     <field name="active" invisible="1" />
                 </tree>
@@ -75,6 +78,7 @@
                     <sheet>
                         <group>
                             <field name="remote" />
+                            <field name="user_id" />
                             <field name="ban_date" />
                             <field name="active" />
                             <field name="description" />


### PR DESCRIPTION
I added some improvements to the auth_brute_force module which we need:
- add option to use the user instead of the ip for checking of failed attempts and banning (use ir.config_parameter 'auth_brute_force.attempt_ban_type' and set to 'user', default is 'ip')
- add option to print custom error message (use ir.config_parameter 'auth_brute_force.attempt_ban_message', empty means no custom message)
- add option to automatically unban remotes after time (use ir.config_parameter 'auth_brute_force.attempt_ban_time' to set the minutes, default is 30 minutes, 0 means no automatically unbanning)
- add new attempt type 'unbanned' to log when the remote was unbanned to avoid automatically banning after the remote was unbanned and typed the wrong password again
- added german translations
