### PR TITLE
[9.0][FIX] base_multi_image - New storage backend 'Filestore'

### DIFF
--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -24,7 +24,7 @@ def pre_init_hook_for_submodules(cr, model, field):
     with cr.savepoint():
         table = env[model]._table
         column_exists = table_has_column(cr, table, field)
-        # Extract the binary content directly from the table
+        # fields.Binary(), extract the binary content directly from the table
         if column_exists:
             extract_query = """
                 SELECT id, %%s, 'db', %(field)s
@@ -32,7 +32,7 @@ def pre_init_hook_for_submodules(cr, model, field):
                 WHERE %(field)s IS NOT NULL
             """ % {"table": table, "field": field}
             image_field = 'file_db_store'
-        # Extract the binary content from the ir_attachment table
+        # fields.Binary(attachment=True), get the ir_attachment record ID
         else:
             extract_query = """
                 SELECT res_id, res_model, 'filestore', id
@@ -40,8 +40,6 @@ def pre_init_hook_for_submodules(cr, model, field):
                 WHERE res_field='%(field)s' AND res_model='%(model)s'
             """ % {"model": model, "field": field}
             image_field = 'attachment_id'
-
-        cr.execute(extract_query)
         cr.execute(
             """
                 INSERT INTO base_multi_image_image (

--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -40,7 +40,8 @@ class Image(models.Model):
         readonly=True)
     attachment_id = fields.Many2one(
         'ir.attachment',
-        string='Attachment')
+        string='Attachment',
+        domain="[('index_content', '=', 'image')]")
     file_db_store = fields.Binary(
         'Image stored in database',
         filters='*.png,*.jpg,*.gif')

--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -190,7 +190,7 @@ class Image(models.Model):
                 _('You must provide an attached file for the image.'))
 
     @api.constrains('storage', 'attachment_id')
-    def _check_store(self):
+    def _check_attachment_id(self):
         if self.storage == 'filestore' and not self.attachment_id:
             raise exceptions.ValidationError(
                 _('You must provide an attachment for the image.'))

--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -175,22 +175,22 @@ class Image(models.Model):
     def _check_url(self):
         if self.storage == 'url' and not self.url:
             raise exceptions.ValidationError(
-                'You must provide an URL for the image.')
+                _('You must provide an URL for the image.'))
 
     @api.constrains('storage', 'path')
     def _check_path(self):
         if self.storage == 'file' and not self.path:
             raise exceptions.ValidationError(
-                'You must provide a file path for the image.')
+                _('You must provide a file path for the image.'))
 
     @api.constrains('storage', 'file_db_store')
     def _check_store(self):
         if self.storage == 'db' and not self.file_db_store:
             raise exceptions.ValidationError(
-                'You must provide an attached file for the image.')
+                _('You must provide an attached file for the image.'))
 
     @api.constrains('storage', 'attachment_id')
     def _check_store(self):
         if self.storage == 'filestore' and not self.attachment_id:
             raise exceptions.ValidationError(
-                'You must provide an attachment for the image.')
+                _('You must provide an attachment for the image.'))

--- a/base_multi_image/views/image_view.xml
+++ b/base_multi_image/views/image_view.xml
@@ -50,6 +50,12 @@
                                 'required': [('storage', '=', 'db')],
                             }"
                             filename="filename"/>
+                        <field
+                            name="attachment_id"
+                            attrs="{
+                                'invisible': [('storage', '!=', 'filestore')],
+                                'required': [('storage', '=', 'filestore')],
+                            }"/>
                     </group>
                     <group string="Preview">
                         <field name="image_medium"


### PR DESCRIPTION
New storage backend _Filestore_ to link an existing attachment record + Fix the `pre_init_hook_for_submodules()` function to extract the images from the `ir_attachment` table for binary fields initialized with the `attachment=True` parameter.

Required to fix https://github.com/OCA/product-attribute/pull/161

I'm not quite satisfied with the pre_init_hook function, it works but it is not really elegant and error prone. Any advices?

cc @Yajo @atchuthan @pedrobaeza 
