### PR TITLE
[FIX] Respect domain set on x2many relational fields

### DIFF
--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -49,20 +49,25 @@ class ModelExtended(models.Model):
                 enabled = self.env.context.get('name_search_extended', True)
                 # Perform extended name search
                 if enabled and operator in ALLOWED_OPS:
+                    field_domain = args or []
                     # Support a list of fields to search on
                     all_names = _get_rec_names(self)
                     # Try regular search on each additional search field
                     for rec_name in all_names[1:]:
-                        domain = [(rec_name, operator, name)]
+                        domain = field_domain + [(rec_name, operator, name)]
                         res = _extend_name_results(self, domain, res, limit)
                     # Try ordered word search on each of the search fields
                     for rec_name in all_names:
-                        domain = [(rec_name, operator, name.replace(' ', '%'))]
+                        domain = field_domain + [
+                            (rec_name, operator, name.replace(' ', '%'))
+                        ]
                         res = _extend_name_results(self, domain, res, limit)
                     # Try unordered word search on each of the search fields
                     for rec_name in all_names:
-                        domain = [(rec_name, operator, x)
-                                  for x in name.split() if x]
+                        domain = field_domain + [
+                            (rec_name, operator, x)
+                            for x in name.split() if x
+                            ]
                         res = _extend_name_results(self, domain, res, limit)
                 return res
             return name_search


### PR DESCRIPTION
The improved base name search in `base_name_search_improved` module doesn't respect the domain set on relational field. Without this fix one gets all matching results from the target model of the relation not only the ones that match the search string **AND** the domain set on the field. 
