### PR TITLE
[FIX][module_prototyper][8.0] model.state - _name vs. _inherit

### DIFF
--- a/module_prototyper/templates/8.0/models/model_name.py.template
+++ b/module_prototyper/templates/8.0/models/model_name.py.template
@@ -6,7 +6,7 @@ from openerp.tools.translate import _
 
 
 class {{ unprefix(name) }}(models.Model):
-    {% if model.state == 'base' %}
+    {% if model.state == 'manual' %}
     _name = "{{ model.model }}"
     {% else %}
     _inherit = "{{ model.model }}"


### PR DESCRIPTION
Swap the `if else` case to decide whether a class
`_inherit`s the model or `_name`s the model.

Currently if you export a field from `product.product`
(or any other `base` model - i.e - any model defined by a module)
then the class will be defined as:

```
class ProductProduct(models.Model):
    _name = 'product.product'

    x_new_field_from_gui = fields.Boolean()
```

This is due to the models `state` being set to `base`
This causes errors when trying to install the exported module

This commit would result in the following behaviour:

Case 1.
I create a new field against the 'base' model 'product.product'.
Given the above scenario, i'd get:

```
class ProductProduct(models.Model):
    _inherit = 'product.product'

    x_new_field_from_gui = fields.Boolean()
```

Case 2:
I create a new 'manual' model through the GUI called `product.product.size`.
I then add the field. Given the above scenario i'd get:

```
class ProductProductSize(models.Model):
    _name = 'product.product.size'

    x_new_field_from_gui = fields.Boolean()
```

Please correct me if I am wrong, or if I have missed something obvious
