### PR TITLE
[9.0][FIX][IMP][base_multi_image] New related field and uninstall hook

### DIFF
--- a/base_multi_image/README.rst
+++ b/base_multi_image/README.rst
@@ -61,8 +61,11 @@ To develop a module based on this one:
   :meth:`~.hooks.uninstall_hook_for_submodules`, like the
   ``product_multi_image`` module does::
 
-    from openerp.addons.base_multi_image.hooks import \
-        pre_init_hook_for_submodules
+    try:
+        from openerp.addons.base_multi_image.hooks import \
+            pre_init_hook_for_submodules
+    except:
+        pass
 
 
     def pre_init_hook(cr):

--- a/base_multi_image/README.rst
+++ b/base_multi_image/README.rst
@@ -57,16 +57,24 @@ To develop a module based on this one:
 
 * If the model you are extending already had an image field, and you want to
   trick Odoo to make those images to multi-image mode, you will need to make
-  use of the provided :meth:`~.hooks.pre_init_hook_for_submodules`, like
-  the ``product_multi_image`` module does::
+  use of the provided :meth:`~.hooks.pre_init_hook_for_submodules` and
+  :meth:`~.hooks.uninstall_hook_for_submodules`, like the
+  ``product_multi_image`` module does::
 
     from openerp.addons.base_multi_image.hooks import \
         pre_init_hook_for_submodules
 
 
     def pre_init_hook(cr):
+        """Transform single into multi images."""
         pre_init_hook_for_submodules(cr, "product.template", "image")
         pre_init_hook_for_submodules(cr, "product.product", "image_variant")
+
+
+    def uninstall_hook(cr, registry):
+        """Remove multi images for models that no longer use them."""
+        uninstall_hook_for_submodules(cr, registry, "product.template")
+        uninstall_hook_for_submodules(cr, registry, "product.product")
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/base_multi_image/__openerp__.py
+++ b/base_multi_image/__openerp__.py
@@ -8,7 +8,7 @@
 {
     "name": "Multiple images base",
     "summary": "Allow multiple images for database objects",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.1.0",
     "author": "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
               "Antiun Ingeniería, S.L., Sodexis, "
               "Odoo Community Association (OCA)",

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -59,6 +59,24 @@ def pre_init_hook_for_submodules(cr, model, field):
         )
 
 
+def uninstall_hook_for_submodules(cr, registry, model):
+    """Remove multi-images for a given model.
+
+    :param openerp.sql_db.Cursor cr:
+        Database cursor.
+
+    :param openerp.modules.registry.RegistryManager registry:
+        Database registry, using v7 api.
+
+    :param str model:
+        Model technical name, like "res.partner". All multi-images for that
+        model will be deleted
+    """
+    Image = registry["base_multi_image.image"]
+    ids = Image.search(cr, SUPERUSER_ID, [("owner_model", "=", model)])
+    Image.unlink(cr, SUPERUSER_ID, ids)
+
+
 def table_has_column(cr, table, field):
     query = """
         SELECT %(field)s

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -35,7 +35,12 @@ def pre_init_hook_for_submodules(cr, model, field):
         # fields.Binary(attachment=True), get the ir_attachment record ID
         else:
             extract_query = """
-                SELECT res_id, res_model, 'filestore', id
+                SELECT
+                    res_id,
+                    res_model,
+                    CONCAT_WS(',', res_model, res_id),
+                    'filestore',
+                    id
                 FROM ir_attachment
                 WHERE res_field='%(field)s' AND res_model='%(model)s'
             """ % {"model": model, "field": field}
@@ -45,6 +50,7 @@ def pre_init_hook_for_submodules(cr, model, field):
                 INSERT INTO base_multi_image_image (
                     owner_id,
                     owner_model,
+                    owner_ref_id,
                     storage,
                     %s
                 )

--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -116,7 +116,7 @@ class Image(models.Model):
         return self._get_image_from_url_cached(self.url)
 
     @api.model
-    @tools.ormcache(skiparg=1)
+    @tools.ormcache("url")
     def _get_image_from_url_cached(self, url):
         """Allow to download an image and cache it by its URL."""
         if url:

--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -24,7 +24,9 @@ class Image(models.Model):
 
     owner_id = fields.Integer(
         "Owner",
-        required=True)
+        required=True,
+        ondelete="cascade",  # This Integer is really a split Many2one
+    )
     owner_model = fields.Char(
         required=True)
     owner_ref_id = fields.Reference(

--- a/base_multi_image/views/image_view.xml
+++ b/base_multi_image/views/image_view.xml
@@ -19,6 +19,7 @@
                         <field name="show_technical" invisible="True"/>
                         <field name="owner_model"/>
                         <field name="owner_id"/>
+                        <field name="owner_ref_id"/>
                         <field name="sequence"/>
                     </group>
                     <group string="Name">


### PR DESCRIPTION
This is both IMP and FIX.

FIX:
- Adding an uninstall hook to remove dangling images when a submodule is uninstalled. **This will require submodules to add it.**

IMP:
- Modernize a couple of calls.
- Add new `owner_ref_id` reference field that allows an admin to go to the image's owner just with 1 click, and more important, allows to set `ir.rule`s for images based on the owner.
- Modify the post init hook to save this information too.

@Tecnativa @carlosdauden
