### PR TITLE
Fix travis build on 9.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
-  - UNIT_TEST="1"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE=database_cleanup
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE=database_cleanup
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE=database_cleanup
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE=database_cleanup
 
 virtualenv:
   system_site_packages: true

--- a/scheduler_error_mailer/data/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/data/ir_cron_email_tpl.xml
@@ -14,7 +14,7 @@
             <field name="name">Scheduler Error</field>
             <field name="email_from">${object.user_id.email or ''}</field>
             <field name="email_to">${object.user_id.email or ''}</field>
-            <field name="subject">[DB ${ctx.get('dbname')}] Scheduler '${object.name or ''}' FAILED</field>
+            <field name="subject">[DB ${ctx.get('dbname')}] Scheduler '${object.name or ""}' FAILED</field>
             <field name="model_id" ref="base.model_ir_cron"/>
             <field name="auto_delete" eval="True"/>
             <field name="body_html">


### PR DESCRIPTION
the 9.0 branch of the project is red, with really strange errors about computed fields. There have been such errors since the merge of #469 but for some reason they were neither fatal nor breaking the build. 

Splitting `database_cleanup` tests in .travis.yml seems to let the other modules go green, but the tests for database_cleanup are red. 
