### PR TITLE
[Add] New module: Disable field translation globally per model

### DIFF
--- a/base_no_translation/README.rst
+++ b/base_no_translation/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Disable model translation
+=========================
+
+Provides means to globally disable translation of field contents for
+all fields on a per Model base.
+Overrides `translate=True` of all fields of a model (including inherited
+custom fields of other models).
+
+For example to disable translation of all product data (description etc.).
+Inherit from `product.product` (and `product.template`) and set class
+attribute `self._disable_field_translations` of the model to False.
+
+
+Installation
+============
+
+No specific requirements.
+
+
+Configuration
+=============
+
+To disable translation of all fields for a given model you need to inherit
+that model and set class attribute `self._disable_field_translations`
+of the model to True.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/serevr-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Peter Hahn <peter.hahn@initos.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_no_translation/__init__.py
+++ b/base_no_translation/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 initOS GmbH http://www.initos.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import model

--- a/base_no_translation/__openerp__.py
+++ b/base_no_translation/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2016 initOS GmbH http://www.initos.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Disable model translation',
+    'summary': 'Disable translation of field contents per model.',
+    'version': '8.0.1.0.1',
+    'category': 'Uncategorized',
+    'website': 'https://odoo-community.org/',
+    'author': 'Peter Hahn, initOS GmbH, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'depends': [
+        'base',
+    ],
+    'installable': True,
+}

--- a/base_no_translation/model.py
+++ b/base_no_translation/model.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016 initOS GmbH http://www.initos.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models
+
+
+class ModelExtended(models.Model):
+    _inherit = 'ir.model'
+
+    def _register_hook(self, cr):
+        for m in self.pool.models.itervalues():
+            if getattr(m, '_disable_field_translations', False):
+                for f in m._fields.itervalues():
+                    if hasattr(f, 'translate') and f.translate:
+                        f.translate = False
+                    if getattr(f, 'column', False) and f.column.translate:
+                        f.column.translate = False
+
+        return super(ModelExtended, self)._register_hook(cr)


### PR DESCRIPTION
For _data only_ models like products it often doesn't makes much sense to translate stuff. Translating field contents of these models (e.g. product description) often causes unnecessary trouble and isn't  necessary. 
This module provides means to disable translation of field contents for all fields on per model base. This includes fields of model customizations inherited from other modules. 

The case I made it for is that some of our customers with small to medium businesses do not want to translate content models like products and stuff because it's more work to maintain for them. But still they want system models like menus and stuff to get translated.

Of course we could override fields with `translate=False` options, but this is cumbersome if we also want to use other customizations that e.g. introduce new fields. 

The problem with translatable fields and your language is not the default language and you edit data, you change only your translation and not the original data. So removing the translation makes it for the user easy that you have this data only in one language.

Also some customers have multi-cultural employees but only sell on the german market, so their employees want to use the user interface in their language, but the product data for example should be consistent independent of the interface language the employee who edited last has set. 
