### PR TITLE
Fixes server error in initial user add.

### DIFF
--- a/users_ldap_mail/__openerp__.py
+++ b/users_ldap_mail/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': "LDAP mapping for user name and e-mail",
-    'version': "9.0.1.0.0",
+    'version': "9.0.1.0.1",
     'depends': ["auth_ldap"],
     'author': "Daniel Reis (https://launchpad.com/~dreis-pt),"
               "Odoo Community Association (OCA)",

--- a/users_ldap_mail/users_ldap_model.py
+++ b/users_ldap_mail/users_ldap_model.py
@@ -19,19 +19,22 @@
 #
 ##############################################################################
 
-#from openerp.osv import fields, orm
-from openerp import models, fields, api, _
+from openerp import models, fields
 from openerp import SUPERUSER_ID
 
 import logging
 _logger = logging.getLogger(__name__)
-import pdb
+
 
 class CompanyLDAP(models.Model):
     _inherit = 'res.company.ldap'
 
-    name_attribute = fields.Char('Name Attribute', help="By default 'cn' is used. or ActiveDirectory you might use 'displayName' instead.", default='cn')
-    mail_attribute = fields.Char('Email Attribute', help="LDAP attribute to use to retrieve email address.",default='mail')
+    name_attribute = fields.Char('Name Attribute',
+        help=("By default 'cn' is used. or ActiveDirectory you might use "
+              "'displayName' instead."), default='cn')
+    mail_attribute = fields.Char('Email Attribute', 
+        help="LDAP attribute to use to retrieve email address.",
+        default='mail')
 
     def get_ldap_dicts(self, cr, ids=None):
         """
@@ -51,10 +54,10 @@ class CompanyLDAP(models.Model):
         """, args)
         return cr.dictfetchall()
 
-
     def get_or_create_user(self, cr, uid, conf, login, ldap_entry,
                            context=None):
-        user_id = super(CompanyLDAP, self).get_or_create_user(cr, uid, conf, login, ldap_entry, context)
+        user_id = super(CompanyLDAP, self).get_or_create_user(cr, uid, conf,
+                        login, ldap_entry, context)
 
         mapping = [
             ('name', 'name_attribute'),
@@ -66,10 +69,10 @@ class CompanyLDAP(models.Model):
                 if conf[conf_name]:
                     values[value_key] = ldap_entry[1][conf[conf_name]][0]
             except KeyError:
-                _logger.warning('No LDAP attribute "%s" found for login  "%s"' % (
-                    conf.get(conf_name), values.get('login')))
+                _logger.warning('No LDAP attribute "%s" found for login  "%s"'
+                    % (conf.get(conf_name), values.get('login')))
 
         new_user = self.pool['res.users'].browse(cr, SUPERUSER_ID, user_id)
-        new_user.write( values ) 
+        new_user.write(values) 
 
         return user_id

--- a/users_ldap_mail/users_ldap_model.py
+++ b/users_ldap_mail/users_ldap_model.py
@@ -29,10 +29,13 @@ _logger = logging.getLogger(__name__)
 class CompanyLDAP(models.Model):
     _inherit = 'res.company.ldap'
 
-    name_attribute = fields.Char('Name Attribute',
+    name_attribute = fields.Char(
+        'Name Attribute',
         help=("By default 'cn' is used. or ActiveDirectory you might use "
-              "'displayName' instead."), default='cn')
-    mail_attribute = fields.Char('Email Attribute', 
+              "'displayName' instead."),
+        default='cn')
+    mail_attribute = fields.Char(
+        'Email Attribute',
         help="LDAP attribute to use to retrieve email address.",
         default='mail')
 
@@ -56,8 +59,8 @@ class CompanyLDAP(models.Model):
 
     def get_or_create_user(self, cr, uid, conf, login, ldap_entry,
                            context=None):
-        user_id = super(CompanyLDAP, self).get_or_create_user(cr, uid, conf,
-                        login, ldap_entry, context)
+        user_id = super(CompanyLDAP, self).get_or_create_user(
+            cr, uid, conf, login, ldap_entry, context)
 
         mapping = [
             ('name', 'name_attribute'),
@@ -69,10 +72,11 @@ class CompanyLDAP(models.Model):
                 if conf[conf_name]:
                     values[value_key] = ldap_entry[1][conf[conf_name]][0]
             except KeyError:
-                _logger.warning('No LDAP attribute "%s" found for login  "%s"'
+                _logger.warning(
+                    'No LDAP attribute "%s" found for login  "%s"'
                     % (conf.get(conf_name), values.get('login')))
 
         new_user = self.pool['res.users'].browse(cr, SUPERUSER_ID, user_id)
-        new_user.write(values) 
+        new_user.write(values)
 
         return user_id

--- a/users_ldap_mail/users_ldap_model.py
+++ b/users_ldap_mail/users_ldap_model.py
@@ -19,32 +19,23 @@
 #
 ##############################################################################
 
-from openerp.osv import fields, orm
+#from openerp.osv import fields, orm
+from openerp import models, fields, api, _
+from openerp import SUPERUSER_ID
 
 import logging
-_log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
+import pdb
 
-
-class CompanyLDAP(orm.Model):
+class CompanyLDAP(models.Model):
     _inherit = 'res.company.ldap'
-    _columns = {
-        'name_attribute': fields.char(
-            'Name Attribute', size=64,
-            help="By default 'cn' is used. "
-                 "For ActiveDirectory you might use 'displayName' instead."),
-        'mail_attribute': fields.char(
-            'E-mail attribute', size=64,
-            help="LDAP attribute to use to retrieve em-mail address."),
-    }
 
-    _defaults = {
-        'name_attribute': 'cn',
-        'mail_attribute': 'mail',
-    }
+    name_attribute = fields.Char('Name Attribute', help="By default 'cn' is used. or ActiveDirectory you might use 'displayName' instead.", default='cn')
+    mail_attribute = fields.Char('Email Attribute', help="LDAP attribute to use to retrieve email address.",default='mail')
 
     def get_ldap_dicts(self, cr, ids=None):
         """
-        Copy of auth_ldap's funtion, changing only the SQL, so that it returns
+        Copy of auth_ldap's function, changing only the SQL, so that it returns
         all fields in the table.
         """
         if ids:
@@ -60,18 +51,25 @@ class CompanyLDAP(orm.Model):
         """, args)
         return cr.dictfetchall()
 
-    def map_ldap_attributes(self, cr, uid, conf, login, ldap_entry):
-        values = super(CompanyLDAP, self).map_ldap_attributes(
-            cr, uid, conf, login, ldap_entry)
+
+    def get_or_create_user(self, cr, uid, conf, login, ldap_entry,
+                           context=None):
+        user_id = super(CompanyLDAP, self).get_or_create_user(cr, uid, conf, login, ldap_entry, context)
+
         mapping = [
             ('name', 'name_attribute'),
             ('email', 'mail_attribute'),
         ]
+        values = {}
         for value_key, conf_name in mapping:
             try:
                 if conf[conf_name]:
                     values[value_key] = ldap_entry[1][conf[conf_name]][0]
             except KeyError:
-                _log.warning('No LDAP attribute "%s" found for login  "%s"' % (
+                _logger.warning('No LDAP attribute "%s" found for login  "%s"' % (
                     conf.get(conf_name), values.get('login')))
-        return values
+
+        new_user = self.pool['res.users'].browse(cr, SUPERUSER_ID, user_id)
+        new_user.write( values ) 
+
+        return user_id


### PR DESCRIPTION
When logging in for a new user, I would get a "Record does not exist or has been deleted." error and internal server error even though the user is created. I couldn't find the exact reason, but has something to do with setting values['email'] when the new user is created/copied (setting values['name'] is okay...). I changed the code so that after the new user is copied/created, it is then modified with the other LDAP attributes. I tried for a long time to find out the root cause (something related to object caching it looks like), but I had to cut my losses.

(Sorry I'm a relative GitHub and OCA newbie, so I apologize in advance for any poor decorum for contributing to this repository).   
