### PR TITLE
[8.0][FIX][base_export_manager] Fix "Expected singleton" bug.

### DIFF
--- a/base_export_manager/README.rst
+++ b/base_export_manager/README.rst
@@ -29,6 +29,7 @@ To manage export profiles, you need to:
 * Choose a name.
 * Choose a model (table in the database).
 * Choose the fields to export.
+
   * If you choose a related field, you can choose also up to 3 levels of
     subfields.
   * You can drag & drop to reorder the fields.

--- a/base_export_manager/README.rst
+++ b/base_export_manager/README.rst
@@ -49,6 +49,8 @@ Known issues / Roadmap
 ======================
 
 * Translated labels are not used in final exported file.
+* If your database has dangling export profiles, you could get an error when
+  installing. You will have to manually clean it before.
 
 Bug Tracker
 ===========

--- a/base_export_manager/__init__.py
+++ b/base_export_manager/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from .hooks import post_init_hook

--- a/base_export_manager/__openerp__.py
+++ b/base_export_manager/__openerp__.py
@@ -5,12 +5,11 @@
 {
     'name': "Manage model export profiles",
     'category': 'Personalization',
-    'version': '8.0.2.0.1',
+    'version': '8.0.2.1.0',
     'depends': [
         'web',
     ],
     'data': [
-        'data/ir_exports_data.xml',
         'views/assets.xml',
         'views/ir_exports_view.xml',
     ],
@@ -23,4 +22,5 @@
     'website': 'http://www.antiun.com',
     'license': 'AGPL-3',
     'installable': True,
+    'post_init_hook': 'post_init_hook',
 }

--- a/base_export_manager/data/ir_exports_data.xml
+++ b/base_export_manager/data/ir_exports_data.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
-
-<function model="ir.exports.line" name="_install_base_export_manager"/>
-
-</data>
-</openerp>

--- a/base_export_manager/hooks.py
+++ b/base_export_manager/hooks.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import api, SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+    """Loaded after installing the module.
+
+    ``ir.exports.line.name`` was before a char field, and now it is a computed
+    char field with stored values. We have to inverse it to avoid database
+    inconsistencies.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, dict())
+    env["ir.exports.line"].search([
+        ("field1_id", "=", False),
+        ("export_id", "!=", False),
+        ("name", "!=", False),
+    ])._inverse_name()

--- a/base_export_manager/hooks.py
+++ b/base_export_manager/hooks.py
@@ -11,9 +11,10 @@ def post_init_hook(cr, registry):
     char field with stored values. We have to inverse it to avoid database
     inconsistencies.
     """
-    env = api.Environment(cr, SUPERUSER_ID, dict())
-    env["ir.exports.line"].search([
-        ("field1_id", "=", False),
-        ("export_id", "!=", False),
-        ("name", "!=", False),
-    ])._inverse_name()
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        env["ir.exports.line"].search([
+            ("field1_id", "=", False),
+            ("export_id", "!=", False),
+            ("name", "!=", False),
+        ])._inverse_name()

--- a/base_export_manager/migrations/8.0.2.1.0/post-migrate.py
+++ b/base_export_manager/migrations/8.0.2.1.0/post-migrate.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.addons.base_export_manager import post_init_hook
+
+
+def migrate(cr, version):
+    """When updating, now you need the post_init_hook."""
+    post_init_hook(cr, None)

--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -14,7 +14,6 @@ class IrExportsLine(models.Model):
 
     name = fields.Char(
         required=False,
-        readonly=True,
         store=True,
         compute="_compute_name",
         inverse="_inverse_name",

--- a/base_export_manager/models/ir_exports_line.py
+++ b/base_export_manager/models/ir_exports_line.py
@@ -88,7 +88,6 @@ class IrExportsLine(models.Model):
     @api.depends('name')
     def _compute_label(self):
         """Column label in a user-friendly format and language."""
-        translations = self.env["ir.translation"]
         for s in self:
             parts = list()
             for num in range(1, 4):
@@ -98,13 +97,8 @@ class IrExportsLine(models.Model):
 
                 # Translate label if possible
                 parts.append(
-                    translations.search([
-                        ("type", "=", "field"),
-                        ("lang", "=", self.env.context.get("lang")),
-                        ("name", "=", "%s,%s" % (s.model_n(num).model,
-                                                 field.name)),
-                    ]).value or
-                    field.display_name)
+                    s.env[s.model_n(num).model]._fields[field.name]
+                    .get_description(s.env)["string"])
             s.label = ("%s (%s)" % ("/".join(parts), s.name)
                        if parts and s.name else False)
 

--- a/base_export_manager/static/src/js/main.js
+++ b/base_export_manager/static/src/js/main.js
@@ -2,7 +2,7 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). */
 
 // Check jQuery available
-if (typeof jQuery === 'undefined') { throw new Error('Requires jQuery') }
+if (typeof jQuery === 'undefined') { throw new Error('Requires jQuery'); }
 
 +function ($) {
     'use strict';
@@ -21,12 +21,12 @@ if (typeof jQuery === 'undefined') { throw new Error('Requires jQuery') }
             },
             add_field: function(field_id, string) {
                 var field_list = this.$el.find('#fields_list');
-                if (this.$el.find("#fields_list option[value='" + field_id + "']")
-                        && !this.$el.find("#fields_list option[value='" + field_id + "']").length) {
+                if (this.$el.find("#fields_list option[value='" + field_id + "']") &&
+                        !this.$el.find("#fields_list option[value='" + field_id + "']").length) {
                     field_list.append(new Option(string + ' (' + field_id + ')', field_id));
                 }
             },
         });
-    }
+    };
 
 }(jQuery);

--- a/base_export_manager/tests/__init__.py
+++ b/base_export_manager/tests/__init__.py
@@ -3,4 +3,5 @@
 # © 2015 Antiun Ingeniería S.L. - Jairo Llopis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import test_ir_exports, test_ir_exports_line
+from . import test_ir_exports
+from . import test_ir_exports_line

--- a/base_export_manager/tests/test_ir_exports_line.py
+++ b/base_export_manager/tests/test_ir_exports_line.py
@@ -55,22 +55,24 @@ class TestIrExportsLineCase(TransactionCase):
     def test_inverse_name(self):
         line = self.env['ir.exports.line'].create({
             'export_id': self.export.id,
-            'name': 'parent_id/parent_id/name',
+            'name': 'parent_id/parent_id/parent_id/name',
         })
         self.assertEqual(line.model1_id, self.partner_model)
         self.assertEqual(line.model2_id, self.partner_model)
         self.assertEqual(line.field1_id, self.field_parent_id)
         self.assertEqual(line.field2_id, self.field_parent_id)
-        self.assertEqual(line.field3_id, self.field_name)
+        self.assertEqual(line.field3_id, self.field_parent_id)
+        self.assertEqual(line.field4_id, self.field_name)
 
     def test_compute_name(self):
         line = self.env['ir.exports.line'].create({
             'export_id': self.export.id,
             'field1_id': self.field_parent_id.id,
             'field2_id': self.field_parent_id.id,
-            'field3_id': self.field_name.id,
+            'field3_id': self.field_parent_id.id,
+            'field4_id': self.field_name.id,
         })
-        self.assertEqual(line.name, 'parent_id/parent_id/name')
+        self.assertEqual(line.name, 'parent_id/parent_id/parent_id/name')
 
     def test_write_name_same_root(self):
         self.env['ir.exports.line'].create({

--- a/base_export_manager/tests/test_ir_exports_line.py
+++ b/base_export_manager/tests/test_ir_exports_line.py
@@ -7,7 +7,6 @@ from openerp.exceptions import ValidationError
 
 
 class TestIrExportsLineCase(TransactionCase):
-
     def setUp(self):
         super(TestIrExportsLineCase, self).setUp()
         m_ir_exports = self.env['ir.exports']
@@ -34,3 +33,12 @@ class TestIrExportsLineCase(TransactionCase):
         with self.assertRaises(ValidationError):
             m_ir_exports_line.create({'name': '',
                                       'export_id': self.export.id})
+
+    def test_model_default_by_context(self):
+        """Fields inherit the model_id by context."""
+        line = self.env["ir.exports.line"].with_context(
+            default_model1_id=self.export.model_id.id).create({
+                "name": "name",
+                "export_id": self.export.id,
+            })
+        self.assertEqual(line.model1_id, self.export.model_id)

--- a/base_export_manager/views/ir_exports_view.xml
+++ b/base_export_manager/views/ir_exports_view.xml
@@ -49,7 +49,7 @@
                         <field name="model3_id" invisible="True"/>
                         <field name="model4_id" invisible="True"/>
                         <field name="label"/>
-                        <field name="name" readonly="0"/>
+                        <field name="name"/>
                         <field
                             name="field1_id"
                             required="True"

--- a/base_export_manager/views/ir_exports_view.xml
+++ b/base_export_manager/views/ir_exports_view.xml
@@ -47,33 +47,25 @@
                         <field name="model1_id" invisible="True"/>
                         <field name="model2_id" invisible="True"/>
                         <field name="model3_id" invisible="True"/>
+                        <field name="model4_id" invisible="True"/>
                         <field name="label"/>
-                        <field name="name"/>
+                        <field name="name" readonly="0"/>
                         <field
                             name="field1_id"
                             required="True"
-                            options="{
-                                'no_open': True,
-                                'no_create': True,
-                            }"/>
+                            options="{'no_open': True, 'no_create': True}"/>
                         <field
                             name="field2_id"
-                            attrs="{
-                                'readonly': [('model2_id', '=', False)],
-                            }"
-                            options="{
-                                'no_open': True,
-                                'no_create': True,
-                            }"/>
+                            attrs="{'readonly': [('model2_id', '=', False)]}"
+                            options="{'no_open': True, 'no_create': True}"/>
                         <field
                             name="field3_id"
-                            attrs="{
-                                'readonly': [('model3_id', '=', False)],
-                            }"
-                            options="{
-                                'no_open': True,
-                                'no_create': True,
-                            }"/>
+                            attrs="{'readonly': [('model3_id', '=', False)]}"
+                            options="{'no_open': True, 'no_create': True}"/>
+                        <field
+                            name="field4_id"
+                            attrs="{'readonly': [('model3_id', '=', False)]}"
+                            options="{'no_open': True, 'no_create': True}"/>
                     </tree>
                 </field>
             </group>


### PR DESCRIPTION
If you had a field that got translated in more than 1 addon, you'd possibly get
to this error:

```
  File "/opt/odoo/0079_ahk_openerp/oca/base_export_manager/models/ir_exports_line.py", line 105, in _compute_label
    field.name)),
  File "/opt/odoo/common/openerp/v8/openerp/fields.py", line 825, in __get__
    record.ensure_one()
  File "/opt/odoo/common/openerp/v8/openerp/models.py", line 5355, in ensure_one
    raise except_orm("ValueError", "Expected singleton: %s" % self)
except_orm: ('ValueError', 'Expected singleton: ir.translation(4899, 703976)')
```

With this patch, now we let Odoo return the translated string by using its
standard method to do so, so we have to care for less.

@Tecnativa
