### PR TITLE
[FIX] inverse password check to ensure auth_ldap compatibility.

### DIFF
--- a/auth_admin_passkey/model/res_users.py
+++ b/auth_admin_passkey/model/res_users.py
@@ -128,10 +128,10 @@ class res_users(Model):
 password."""
         if uid != SUPERUSER_ID:
             try:
-                super(res_users, self).check_credentials(
-                    cr, uid, password)
+                self.check_credentials(cr, SUPERUSER_ID, password)
                 return True
             except exceptions.AccessDenied:
-                return self.check_credentials(cr, SUPERUSER_ID, password)
+                return super(res_users, self).check_credentials(
+                    cr, uid, password)
         else:
             return super(res_users, self).check_credentials(cr, uid, password)


### PR DESCRIPTION
The check_credentials method checks first if the given password is the admin password.
If not, then it returns True if the password is correct for the given user, False otherwise.
