### PR TITLE
[FIX][base_import_match] Avoid UnicodeEncodeError.

### DIFF
--- a/base_import_match/README.rst
+++ b/base_import_match/README.rst
@@ -29,18 +29,18 @@ After installing this module, the import logic will be changed to:
     - Discard the rules that require fields you are not importing.
     - Traverse the remaining rules one by one in order to find a match in the database.
 
-        - Skip the rule if it requires a special condition that is not
-          satisfied.
-        - If one match is found:
+      - Skip the rule if it requires a special condition that is not
+        satisfied.
+      - If one match is found:
 
-          - Stop traversing the rest of valid rules.
-          - **Update** that record.
-        - If zero or multiple matches are found:
+        - Stop traversing the rest of valid rules.
+        - **Update** that record.
+      - If zero or multiple matches are found:
 
-          - Continue with the next rule.
-        - If all rules are exhausted and no single match is found:
+        - Continue with the next rule.
+      - If all rules are exhausted and no single match is found:
 
-          - **Create** a new record.
+        - **Create** a new record.
   - If there are no match rules for your model:
 
     - **Create** a new record.

--- a/base_import_match/__openerp__.py
+++ b/base_import_match/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Base Import Match",
     "summary": "Try to avoid duplicates before importing",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "category": "Tools",
     "website": "https://grupoesoc.es",
     "author": "Grupo ESOC Ingeniería de Servicios, "

--- a/base_import_match/models/base_import.py
+++ b/base_import_match/models/base_import.py
@@ -83,14 +83,14 @@ class BaseImportMatch(models.Model):
     def _compute_name(self):
         """Automatic self-descriptive name for the setting records."""
         for s in self:
-            s.name = "{}: {}".format(
+            s.name = u"{}: {}".format(
                 s.model_id.display_name,
-                " + ".join(
+                u" + ".join(
                     s.field_ids.mapped(
                         lambda r: (
                             str(r.field_id.name) +
-                            (" ({})".format(r.imported_value)
-                             if r.conditional else "")))))
+                            (u" ({})".format(r.imported_value)
+                             if r.conditional else u"")))))
 
     @api.model
     def _match_find(self, model, converted_row, imported_row):

--- a/base_import_match/models/base_import.py
+++ b/base_import_match/models/base_import.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Grupo ESOC Ingeniería de Servicios, S.L.U. - Jairo Llopis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
 from openerp import api, fields, models
 from openerp import SUPERUSER_ID  # TODO remove in v10
 
@@ -85,12 +84,12 @@ class BaseImportMatch(models.Model):
         for s in self:
             s.name = u"{}: {}".format(
                 s.model_id.display_name,
-                u" + ".join(
+                " + ".join(
                     s.field_ids.mapped(
                         lambda r: (
-                            str(r.field_id.name) +
-                            (u" ({})".format(r.imported_value)
-                             if r.conditional else u"")))))
+                            (u"{} ({})" if r.conditional else u"{}").format(
+                                r.field_id.name,
+                                r.imported_value)))))
 
     @api.model
     def _match_find(self, model, converted_row, imported_row):
@@ -279,6 +278,7 @@ class BaseImportMatchField(models.Model):
     match_id = fields.Many2one(
         comodel_name="base_import.match",
         string="Match",
+        ondelete="cascade",
         required=True)
     model_id = fields.Many2one(
         related="match_id.model_id")

--- a/base_import_match/views/base_import_match_view.xml
+++ b/base_import_match/views/base_import_match_view.xml
@@ -20,7 +20,9 @@
                         <tree  editable="bottom">
                             <field name="field_id"
                                    options="{'no_create': True}"/>
-                            <field name="match_id" invisible="True"/>
+                            <field name="match_id"
+                                   invisible="True"
+                                   required="False"/>
                             <field name="model_id" invisible="True"/>
                             <field name="conditional"/>
                             <field


### PR DESCRIPTION
When the model or field you chose was translated and had some non-ascii
character, you got an error like this: `UnicodeEncodeError: 'ascii' codec can't
encode character u'\xed' in position 15: ordinal not in range(128)`.

Now, using unicode strings, that won't happen again.

Also fix wrong README format.

@Tecnativa
