### PR TITLE
[IMP] load server environment options from odoo rcfile too

### DIFF
--- a/server_environment/README.rst
+++ b/server_environment/README.rst
@@ -44,10 +44,14 @@ You should then edit the settings you need in the
 `server_environment_files_sample` can be used as an example:
 
 * values common to all / most environments can be stored in the
-  `default/` directory using the .ini file syntax
+  `default/` directory using the .ini file syntax;
 * each environment you need to define is stored in its own directory
-  and can override or extend default values. Values associated to keys
-  containing 'passw' are only displayed in the 'dev' environment.
+  and can override or extend default values;
+* finally, you can override or extend values in the main configuration
+  file of you instance.
+
+Values associated to keys
+containing 'passw' are only displayed in the 'dev' environment.
 
 Usage
 =====

--- a/server_environment/__openerp__.py
+++ b/server_environment/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     "name": "server configuration environment files",
-    "version": "9.0.1.1.0",
+    "version": "9.0.1.2.0",
     "depends": ["base", "server_environment_files"],
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "summary": "move some configurations out of the database",

--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -98,6 +98,8 @@ def _load_config():
         config_p.read(conf_files)
     except Exception as e:
         raise Exception('Cannot read config files "%s":  %s' % (conf_files, e))
+    config_p.read(system_base_config.rcfile)
+    config_p.remove_section('options')
 
     return config_p
 


### PR DESCRIPTION
This allows delivering the code with default configuration options for
all environments in the server_environment_file module, while letting
the administrator override some configuration entries in the regular
odoo configuration file.
