### PR TITLE
[9.0][database_cleanup] Do not purge valid menus

### DIFF
--- a/database_cleanup/models/purge_menus.py
+++ b/database_cleanup/models/purge_menus.py
@@ -34,8 +34,10 @@ class CleanupPurgeWizardMenu(models.TransientModel):
                 .search([('action', '!=', False)]):
             if menu.action.type != 'ir.actions.act_window':
                 continue
-            if menu.action.res_model not in self.env or\
-               menu.action.src_model not in self.env:
+            if (menu.action.res_model and menu.action.res_model not in
+                self.env) or \
+                    (menu.action.src_model and menu.action.src_model not in
+                        self.env):
                 res.append((0, 0, {
                     'name': menu.complete_name,
                     'menu_id': menu.id,


### PR DESCRIPTION
This fix prevents the option "Purchase obsolete menu entries" from proposing valid v9 menus from being purged.
