### PR TITLE
[FIX] server_environment setup.py cannot find odoo-addon-server_environment_files

### DIFF
--- a/setup/server_environment/setup.py
+++ b/setup/server_environment/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'depends_override': {
+            # server_environment_file does not exist as a packaged addon,
+            # as it must be provided locally
+            'server_environment_files': '',
+        },
+    },
 )


### PR DESCRIPTION
Backport from v9
