### PR TITLE
[MIG] migrate dbfilter_from_header to 10.0

### DIFF
--- a/dbfilter_from_header/README.rst
+++ b/dbfilter_from_header/README.rst
@@ -10,14 +10,35 @@ This addon lets you pass a dbfilter as a HTTP header.
 
 This is interesting for setups where database names can't be mapped to proxied host names.
 
+Installation
+============
+
+To install this module, you only need to add it to your addons, and load it as
+a server-wide module.
+
+This can be done with the ``load`` parameter in ``/etc/odoo.conf`` or with the
+``--load`` command-line parameter
+
+``load = "web, web_kanban, dbfilter_from_header"``
+
 Configuration
 =============
 
-In nginx, use:
+Please keep in mind that the standard odoo dbfilter configuration is still
+applied before looking at the regular expression in the header.
 
-* proxy_set_header X-Odoo-dbfilter [your filter];
+* For nginx, use:
 
-This addon has to be loaded as server-wide module.
+  ``proxy_set_header X-Odoo-dbfilter [your filter regex];``
+
+* For caddy, use:
+
+  ``proxy_header X-Odoo-dbfilter [your filter regex]``
+
+* For Apache, use:
+
+  ``RequestHeader set X-Odoo-dbfilter [your filter regex]``
+
 
 Bug Tracker
 ===========
@@ -25,11 +46,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
-<https://github.com/OCA/
-server-tools/issues/new?body=module:%20
-dbfilter_from_header%0Aversion:%20
-9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
@@ -44,6 +61,7 @@ Contributors
 * Laurent Mignon (aka lmi) <laurent.mignon@acsone.eu>
 * Sandy Carter <sandy.carter@savoirfairelinux.com>
 * Fabio Vilchez <fabio.vilchez@clearcorp.co.cr>
+* Jos De Graeve <Jos.DeGraeve@apertoso.be>
 
 Maintainer
 ----------

--- a/dbfilter_from_header/README.rst
+++ b/dbfilter_from_header/README.rst
@@ -13,9 +13,8 @@ This is interesting for setups where database names can't be mapped to proxied h
 Configuration
 =============
 
-In nginx, use one of:
+In nginx, use:
 
-* proxy_set_header X-OpenERP-dbfilter [your filter];
 * proxy_set_header X-Odoo-dbfilter [your filter];
 
 This addon has to be loaded as server-wide module.

--- a/dbfilter_from_header/__init__.py
+++ b/dbfilter_from_header/__init__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import re
-from openerp import http
+from odoo import http
 
 db_filter_org = http.db_filter
 
@@ -12,12 +12,7 @@ db_filter_org = http.db_filter
 def db_filter(dbs, httprequest=None):
     dbs = db_filter_org(dbs, httprequest)
     httprequest = httprequest or http.request.httprequest
-    db_filter_hdr_odoo = httprequest.environ.get('HTTP_X_ODOO_DBFILTER')
-    db_filter_hdr_openerp = httprequest.environ.get('HTTP_X_OPENERP_DBFILTER')
-    if db_filter_hdr_odoo and db_filter_hdr_openerp:
-        raise RuntimeError("x-odoo-dbfilter and x-openerp-dbfiter "
-                           "are both set")
-    db_filter_hdr = db_filter_hdr_odoo or db_filter_hdr_openerp
+    db_filter_hdr = httprequest.environ.get('HTTP_X_ODOO_DBFILTER')
     if db_filter_hdr:
         dbs = [db for db in dbs if re.match(db_filter_hdr, db)]
     return dbs

--- a/dbfilter_from_header/__manifest__.py
+++ b/dbfilter_from_header/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "dbfilter_from_header",
     "summary": "Filter databases with HTTP headers",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "complexity": "normal",
@@ -21,7 +21,7 @@
     "css": [
     ],
     "auto_install": False,
-    'installable': False,
+    'installable': True,
     "external_dependencies": {
         'python': [],
     },


### PR DESCRIPTION
I have also removed the ability to use HTTP_X_OPENERP_DBFILTER

Due to the fact that with odoo v10, all legacy openerp naming has been removed.

Other than that, the changes are trivial.
