### PR TITLE
[8.0] mail_message_name_search

### DIFF
--- a/base_search_fuzzy/views/trgm_index.xml
+++ b/base_search_fuzzy/views/trgm_index.xml
@@ -9,7 +9,8 @@
         <form string="Trigam Index">
           <sheet>
             <group col="4">
-              <field name="field_id" domain="[('ttype', 'in', ['char', 'text'])]"/>
+              <field name="field_id"
+                     domain="[('ttype', 'in', ['char', 'text', 'html'])]"/>
               <field name="index_name"/>
               <field name="index_type"/>
             </group>

--- a/mail_message_name_search/README.rst
+++ b/mail_message_name_search/README.rst
@@ -39,10 +39,6 @@ is available to be searched on.
 Usage
 =====
 
-To use this module, you need to:
-
-#. Go to ...
-
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/server-tools/8.0

--- a/mail_message_name_search/README.rst
+++ b/mail_message_name_search/README.rst
@@ -1,0 +1,84 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================
+Mail message name search
+========================
+
+This module adds the capability to search for mail messages by subject or
+body of the message. This will be useful in models that make intense use of
+messages, like project issues or helpdesk tickets.
+
+In order to be able to search for messages in project issues, for example,
+add the field 'message_ids' to the model's search view.
+
+
+Installation
+============
+
+This module depends on the module 'base_search_fuzzy' to ensure that
+searches on emails are based on indexes. Please read carefully the install
+instructions https://github.com/OCA/server-tools/blob/8.0/base_search_fuzzy/README.rst
+
+This module installs by default the indexes that are required to
+perform the searches on mail messages.
+
+
+Configuration
+=============
+
+In order to properly be able to search for emails in a model, such as
+project issues or helpdesk tickets, you must add the
+field 'message_ids' to the search view of the model that you want to search
+messages on.
+
+The model should inherit from model 'mail.thread', so that the message_ids
+is available to be searched on.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/server-tools/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mail_message_name_search/__init__.py
+++ b/mail_message_name_search/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/mail_message_name_search/__openerp__.py
+++ b/mail_message_name_search/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Mail message name search",
+    "version": "8.0.1.0.0",
+    "author": "Eficent,"
+              "Odoo Community Association (OCA)",
+    "website": "http://www.eficent.com",
+    "category": "CRM",
+    "data": ["data/trgm_index_data.xml"],
+    "depends": ["mail",
+                "base_search_fuzzy"],
+    "license": "AGPL-3",
+    'installable': True,
+}

--- a/mail_message_name_search/data/trgm_index_data.xml
+++ b/mail_message_name_search/data/trgm_index_data.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="subject_gin_idx" model="trgm.index">
+            <field name="index_type">gin</field>
+            <field name="field_id"
+                   search="[('model','=','mail.message'),('name','=','subject')]"/>
+        </record>
+
+        <record id="body_gin_idx" model="trgm.index">
+            <field name="index_type">gin</field>
+            <field name="field_id"
+                   search="[('model','=','mail.message'),('name','=','body')]"/>
+        </record>
+
+        <record id="record_name_gin_idx" model="trgm.index">
+            <field name="index_type">gin</field>
+            <field name="field_id"
+                   search="[('model','=','mail.message'),('name','=','record_name')]"/>
+        </record>
+
+    </data>
+</openerp>

--- a/mail_message_name_search/models/__init__.py
+++ b/mail_message_name_search/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import mail_message

--- a/mail_message_name_search/models/mail_message.py
+++ b/mail_message_name_search/models/mail_message.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, models
+from openerp.osv import expression
+
+
+class MailMessage(models.Model):
+
+    _inherit = 'mail.message'
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        args = args or []
+        domain = ['|', '|', ('record_name', operator, name),
+                  ('subject', operator, name), ('body', operator, name)]
+        if operator in expression.NEGATIVE_TERM_OPERATORS:
+            domain = domain[2:]
+        rec = self.search(domain + args, limit=limit)
+        return rec.name_get()


### PR DESCRIPTION
# 
# Mail message name search

This module adds the capability to search for mail messages by subject or
body of the message. This will be useful in models that make intense use of
messages, like project issues or helpdesk tickets.

In order to be able to search for messages in project issues, for example,
add the field 'message_ids' to the model's search view.
# Installation

This module depends on the module 'base_search_fuzzy' to ensure that
searches on emails are based on indexes. Please read carefully the install
instructions https://github.com/OCA/server-tools/blob/8.0/base_search_fuzzy/README.rst

This module installs by default the indexes that are required to
perform the searches on mail messages.
# Configuration

In order to properly be able to search for emails in a model, such as
project issues or helpdesk tickets, you must add the
field 'message_ids' to the search view of the model that you want to search
messages on.

The model should inherit from model 'mail.thread', so that the message_ids
is available to be searched on.
