### PR TITLE
[FIX] mass_editing: Allow to create action for all the proper users

### DIFF
--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -67,7 +67,9 @@ class MassObject(models.Model):
             'target': 'new',
             'auto_refresh': 1,
         }).id
-        vals['ref_ir_value_id'] = self.env['ir.values'].create({
+        # We make sudo as any user with rights in this model should be able
+        # to create the action, not only admin
+        vals['ref_ir_value_id'] = self.env['ir.values'].sudo().create({
             'name': button_name,
             'model': src_obj,
             'key2': 'client_action_multi',


### PR DESCRIPTION
When creating the action for making mass editings, an ir.values record
should be created, but standard rules avoid to do this to any user
different from SUPERUSER_ID. Making `sudo()` is this action allows to
all that can access to mass.object model to create these actions, which
is the expected behavior.
