### PR TITLE
[IMP] base_suspend_security: Monkey patch BaseModel in _setup_complete

### DIFF
--- a/base_suspend_security/README.rst
+++ b/base_suspend_security/README.rst
@@ -39,6 +39,7 @@ Contributors
 ------------
 
 * Holger Brunn <hbrunn@therp.nl>
+* Laurent Mignon <laurent.mignon@acsone.eu>
 
 Maintainer
 ----------

--- a/base_suspend_security/models/ir_rule.py
+++ b/base_suspend_security/models/ir_rule.py
@@ -30,9 +30,9 @@ class IrRule(models.Model):
             return [], [], ['"%s"' % self.pool[model_name]._table]
         return super(IrRule, self).domain_get(model_name, mode=mode)
 
-    def _register_hook(self, cr):
+    def _setup_complete(self, cr, uid):
         if not hasattr(models.BaseModel, SUSPEND_METHOD):
             setattr(models.BaseModel, SUSPEND_METHOD,
                     lambda self: self.sudo(
                         user=BaseSuspendSecurityUid(self.env.uid)))
-        return super(IrRule, self)._register_hook(cr)
+        return super(IrRule, self)._setup_complete(cr, uid)

--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -24,7 +24,6 @@ from openerp.tests.common import TransactionCase
 class TestBaseSuspendSecurity(TransactionCase):
     def test_base_suspend_security(self):
         # tests are called before register_hook
-        self.env['ir.rule']._register_hook()
         user_id = self.env.ref('base.user_demo').id
         other_company = self.env['res.company'].create({
             'name': 'other company',


### PR DESCRIPTION
Monkey patch BaseModel in _setup_complete so the suspend_security method is available in tests without calling the _register_hook
Indeed tests are run after the call to `_setup_complete` and before the call to `_register_hook`.
Thanks to this change we should no longer write `self.env['ir.rule']._register_hook()` in the `setUp`method of our tests.
