### PR TITLE
Add default values for smtp_user and smtp_pass

### DIFF
--- a/mail_environment/env_mail.py
+++ b/mail_environment/env_mail.py
@@ -36,7 +36,11 @@ class IrMail(orm.Model):
             global_section_name = 'outgoing_mail'
 
             # default vals
-            config_vals = {'smtp_port': 587}
+            config_vals = {
+                'smtp_port': 587,
+                'smtp_user': False,
+                'smtp_pass': False
+            }
             if serv_config.has_section(global_section_name):
                 config_vals.update((serv_config.items(global_section_name)))
 


### PR DESCRIPTION
This PR is to avoid having "[]" as default values for login/password in SMTP servers.