### PR TITLE
FIX secure_uninstall

### DIFF
--- a/secure_uninstall/README.rst
+++ b/secure_uninstall/README.rst
@@ -40,6 +40,11 @@ Usage
    :target: https://runbot.odoo-community.org/runbot/149/server-tools
 
 
+Known issues / Roadmap
+======================
+* This module can be uninstall properly: needs to be fixed soon
+* This module allowed us to discover this bug in core Odoo https://github.com/odoo/odoo/issues/14452: hoping it will fixed
+
 Bug Tracker
 ===========
 

--- a/secure_uninstall/views/module_view.xml
+++ b/secure_uninstall/views/module_view.xml
@@ -13,7 +13,7 @@
                 <label string="If you want uninstall module, write required password ('secure_uninstall' key in ERP config file)."
                        colspan="4" />
                 <group col="4">
-                    <field name="uninstall_password" password="True" attrs="{'required': 1}"
+                    <field name="uninstall_password" password="True"
                            placeholder="key_provided_by_administrator"/>
                     <span/>
                 </group>


### PR DESCRIPTION
## Steps to reproduce: 
- Install 'secure_uninstall' module
- Try uninstall another module providing a bad key

## Current behavior:
- Module state switch 'to remove' state, then it will finally be uninstalled with future updates of other modules.

## Expected behavior:
- Module state rollback to 'installed' state if uninstall is not authorized.

