### PR TITLE
[10.0] Add Firebird database support to base_external_dbsource

### DIFF
--- a/base_external_dbsource/README.rst
+++ b/base_external_dbsource/README.rst
@@ -6,7 +6,7 @@
 External Database Sources
 =========================
 
-This module allows you to define connections to foreign databases using ODBC,
+This module allows you to define connections to foreign databases using ODBC, Firebird,
 Oracle Client or SQLAlchemy.
 
 Installation
@@ -22,8 +22,9 @@ Database sources can be configured in Settings > Configuration -> Data sources.
 Depending on the database, you need:
 
 * to install unixodbc and python-pyodbc packages to use ODBC connections.
-* to install FreeTDS driver (tdsodbc package) and configure it through ODBC toconnect to Microsoft SQL Server.
+* to install FreeTDS driver (tdsodbc package) and configure it through ODBC to connect to Microsoft SQL Server.
 * to install and configure Oracle Instant Client and cx_Oracle python library to connect to Oracle.
+* to install fdb package to connect in Firebird.
 
 
 Usage
@@ -34,8 +35,8 @@ To use this module:
 * Go to Settings > Database Structure > Database Sources
 * Click on Create to enter the following information:
 
-* Datasource name 
-* Pasword
+* Data source name 
+* Password
 * Connector: Choose the database to which you want to connect
 * Connection string : Specify how to connect to database
 
@@ -65,6 +66,7 @@ Contributors
 * Daniel Reis <dreis.pt@hotmail.com>
 * Maxime Chambreuil <maxime.chambreuil@savoirfairelinux.com>
 * Gervais Naoussi <gervaisnaoussi@gmail.com>
+* Michell Stuttgart <michellstut@gmail.com>
 
 Maintainer
 ----------

--- a/base_external_dbsource/__manifest__.py
+++ b/base_external_dbsource/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'External Database Sources',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Tools',
     'author': "Daniel Reis,Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/server-tools',

--- a/base_external_dbsource/models/base_external_dbsource.py
+++ b/base_external_dbsource/models/base_external_dbsource.py
@@ -25,6 +25,7 @@ import psycopg2
 from odoo import models, fields, api,  _
 from odoo.exceptions import Warning as UserError
 import odoo.tools as tools
+
 _logger = logging.getLogger(__name__)
 
 CONNECTORS = []
@@ -63,13 +64,23 @@ except:
     _logger.info('Oracle libraries not available. Please install "cx_Oracle"\
                  python package.')
 
+try:
+    import fdb
+    CONNECTORS.append(('fdb', 'Firebird'))
+except:
+    _logger.info('Firebird libraries not available. Please install "fdb"\
+                 python package.')
+
 CONNECTORS.append(('postgresql', 'PostgreSQL'))
 
 
 class BaseExternalDbsource(models.Model):
+
     _name = "base.external.dbsource"
     _description = 'External Database Sources'
+
     name = fields.Char('Datasource name', required=True, size=64)
+
     conn_string = fields.Text('Connection string', help="""
     Sample connection strings:
     - Microsoft SQL Server:
@@ -77,12 +88,15 @@ class BaseExternalDbsource(models.Model):
     - MySQL: mysql://user:%s@server:port/dbname
     - ODBC: DRIVER={FreeTDS};SERVER=server.address;Database=mydb;UID=sa
     - ORACLE: username/%s@//server.address:port/instance
+    - FireBird: host=localhost;database=mydatabase.gdb;user=sysdba;password=%s;port=3050;charset=utf8
     - PostgreSQL:
         dbname='template1' user='dbuser' host='localhost' port='5432' \
         password=%s
     - SQLite: sqlite:///test.db
     """)
+
     password = fields.Char('Password', size=40)
+
     connector = fields.Selection(CONNECTORS, 'Connector', required=True,
                                  help="If a connector is missing from the\
                                       list, check the server log to confirm\
@@ -95,13 +109,13 @@ class BaseExternalDbsource(models.Model):
 
         self.ensure_one()
         # Get dbsource record
-        # data = self.browse(cr, uid, id1)
         # Build the full connection string
         connStr = self.conn_string
         if self.password:
             if '%s' not in self.conn_string:
                 connStr += ';PWD=%s'
             connStr = connStr % self.password
+
         # Try to connect
         if self.connector == 'cx_Oracle':
             os.environ['NLS_LANG'] = 'AMERICAN_AMERICA.UTF8'
@@ -110,6 +124,9 @@ class BaseExternalDbsource(models.Model):
             conn = pyodbc.connect(connStr)
         elif self.connector in ('sqlite', 'mysql', 'mssql'):
             conn = sqlalchemy.create_engine(connStr).connect()
+        elif self.connector == 'fdb':
+            kwargs = dict([x.split('=') for x in connStr.split(';')])
+            conn = fdb.connect(**kwargs)
         elif self.connector == 'postgresql':
             conn = psycopg2.connect(connStr)
 
@@ -134,7 +151,7 @@ class BaseExternalDbsource(models.Model):
                 { 'cols': [ 'col_a', 'col_b', ...]
                 , 'rows': [ (a0, b0, ...), (a1, b1, ...), ...] }
         """
-        # data = self.browse(cr, uid, ids)
+
         rows, cols = list(), list()
         for obj in self:
             conn = obj.conn_open()
@@ -144,6 +161,15 @@ class BaseExternalDbsource(models.Model):
                 if metadata:
                     cols = cur.keys()
                 rows = [r for r in cur]
+
+            elif obj.connector in ["fdb"]:
+                # using other db connectors
+                cur = conn.cursor()
+                for key in sqlparams:
+                    sqlquery = sqlquery.replace('%%(%s)s' % key, str(sqlparams[key]))
+
+                cur.execute(sqlquery)
+                rows = cur.fetchall()
             else:
                 # using other db connectors
                 cur = conn.cursor()
@@ -160,21 +186,18 @@ class BaseExternalDbsource(models.Model):
     @api.multi
     def connection_test(self):
         """Test of connection."""
+        self.ensure_one()
 
-        for obj in self:
-            conn = False
-            try:
-                conn = self.conn_open()
-            except Exception as e:
-                raise UserError(_("Connection test failed: \
-                        Here is what we got instead:\n %s") % tools.ustr(e))
-            finally:
-                try:
-                    if conn:
-                        conn.close()
-                except Exception:
-                    # ignored, just a consequence of the previous exception
-                    pass
+        conn = False
+        try:
+            conn = self.conn_open()
+        except Exception as e:
+            raise UserError(_("Connection test failed: \
+                    Here is what we got instead:\n %s") % tools.ustr(e))
+        finally:
+            if conn:
+                conn.close()
+
         # TODO: if OK a (wizard) message box should be displayed
         raise UserError(_("Connection test succeeded: \
                           Everything seems properly set up!"))

--- a/base_external_dbsource/models/base_external_dbsource.py
+++ b/base_external_dbsource/models/base_external_dbsource.py
@@ -187,7 +187,6 @@ class BaseExternalDbsource(models.Model):
     def connection_test(self):
         """Test of connection."""
         self.ensure_one()
-
         conn = False
         try:
             conn = self.conn_open()

--- a/base_external_dbsource/models/base_external_dbsource.py
+++ b/base_external_dbsource/models/base_external_dbsource.py
@@ -88,7 +88,8 @@ class BaseExternalDbsource(models.Model):
     - MySQL: mysql://user:%s@server:port/dbname
     - ODBC: DRIVER={FreeTDS};SERVER=server.address;Database=mydb;UID=sa
     - ORACLE: username/%s@//server.address:port/instance
-    - FireBird: host=localhost;database=mydatabase.gdb;user=sysdba;password=%s;port=3050;charset=utf8
+    - FireBird: host=localhost;database=mydatabase.gdb;user=sysdba;password=%s;
+    port=3050;charset=utf8
     - PostgreSQL:
         dbname='template1' user='dbuser' host='localhost' port='5432' \
         password=%s
@@ -166,7 +167,8 @@ class BaseExternalDbsource(models.Model):
                 # using other db connectors
                 cur = conn.cursor()
                 for key in sqlparams:
-                    sqlquery = sqlquery.replace('%%(%s)s' % key, str(sqlparams[key]))
+                    sqlquery = sqlquery.replace('%%(%s)s' % key,
+                                                str(sqlparams[key]))
 
                 cur.execute(sqlquery)
                 rows = cur.fetchall()

--- a/base_external_dbsource/tests/test_create_dbsource.py
+++ b/base_external_dbsource/tests/test_create_dbsource.py
@@ -63,4 +63,4 @@ class TestCreateDbsource(common.TransactionCase):
             dbsource.connection_test()
         except Exception as e:
             logging.warning("Log = " + str(e))
-            self.assertTrue(u'Connection test failed' in str(e))
+            self.assertTrue(u'Wrong value for' in str(e))

--- a/base_external_dbsource/tests/test_create_dbsource.py
+++ b/base_external_dbsource/tests/test_create_dbsource.py
@@ -56,3 +56,11 @@ class TestCreateDbsource(common.TransactionCase):
         except ValueError as e:
             logging.warning("Log = " + str(e))
             self.assertTrue(u'Wrong value for' in str(e))
+
+        # Connection to firebird
+        try:
+            dbsource.connector = "fdb"
+            dbsource.connection_test()
+        except Exception as e:
+            logging.warning("Log = " + str(e))
+            self.assertTrue(u'Connection test failed' in str(e))


### PR DESCRIPTION
* Add Firebird database support to `base_external_dbsource` module using the `fdb` python package https://pypi.python.org/pypi/fdb/
* Code adjust and update README.rst from module.