### PR TITLE
[FIX][9.0] base_multi_image: Adhere to image delete bypass

### DIFF
--- a/base_multi_image/README.rst
+++ b/base_multi_image/README.rst
@@ -121,6 +121,7 @@ Contributors
 * Rafael Blasco <rafabn@antiun.com>
 * Jairo Llopis <yajo.sk8@gmail.com>
 * Sodexis <dev@sodexis.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/base_multi_image/__openerp__.py
+++ b/base_multi_image/__openerp__.py
@@ -9,8 +9,9 @@
     "name": "Multiple images base",
     "summary": "Allow multiple images for database objects",
     "version": "9.0.1.1.0",
-    "author": "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+    "author": "Tecnativa, "
               "Antiun Ingeniería, S.L., Sodexis, "
+              "LasLabs, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "http://www.antiun.com",

--- a/base_multi_image/models/owner.py
+++ b/base_multi_image/models/owner.py
@@ -90,9 +90,12 @@ class Owner(models.AbstractModel):
 
     @api.multi
     def unlink(self):
-        """Mimic `ondelete="cascade"` for multi images."""
+        """Mimic `ondelete="cascade"` for multi images.
+
+        Will be skipped if ``env.context['bypass_image_removal']`` == True
+        """
         images = self.mapped("image_ids")
         result = super(Owner, self).unlink()
-        if result:
+        if result and not self.env.context.get('bypass_image_removal'):
             images.unlink()
         return result


### PR DESCRIPTION
At long last I have figured out the bug plaguing OCA/product-attribute#199, and it is actually in the base module. The images were being unlinked during the variant addition due to the call to super in the `unlink` method. 

It seems there was an intent for a context override, but it never made it into this module. It has now!

* Add catch in owner unlink to allow for image delete bypass via context