### PR TITLE
[FIX][10.0] base_multi_image: Adhere to image delete bypass

### DIFF
--- a/base_multi_image/README.rst
+++ b/base_multi_image/README.rst
@@ -121,6 +121,7 @@ Contributors
 * Rafael Blasco <rafabn@antiun.com>
 * Jairo Llopis <yajo.sk8@gmail.com>
 * Sodexis <dev@sodexis.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/base_multi_image/models/owner.py
+++ b/base_multi_image/models/owner.py
@@ -90,9 +90,12 @@ class Owner(models.AbstractModel):
 
     @api.multi
     def unlink(self):
-        """Mimic `ondelete="cascade"` for multi images."""
+        """Mimic `ondelete="cascade"` for multi images.
+
+        Will be skipped if ``env.context['bypass_image_removal']`` == True
+        """
         images = self.mapped("image_ids")
         result = super(Owner, self).unlink()
-        if result:
+        if result and not self.env.context.get('bypass_image_removal'):
             images.unlink()
         return result


### PR DESCRIPTION
This is a forward port of #628 & should probably not be reviewed until it is merged in order to not duplicate effort.

* Add catch in owner unlink to allow for image delete bypass via context

- [x] #628