### PR TITLE
[REF] sentry_logger: Use new environment variable for runbot builds based on travis2docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
 
 env:
   - VERSION="7.0" LINT_CHECK=1
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" LINT_CHECK=0
+  - VERSION="7.0" ODOO_REPO="odoo/odoo" LINT_CHECK=0 TESTS="1"
   - VERSION="7.0" ODOO_REPO="OCA/OCB" LINT_CHECK=0
   - VERSION="7.0" UNIT_TEST="1" LINT_CHECK=0 EXCLUDE=record_archiver
 

--- a/sentry_logger/__init__.py
+++ b/sentry_logger/__init__.py
@@ -56,7 +56,7 @@ try:
         root_logger.addHandler(handler)
     else:
         msg = u"Sentry DSN not defined in config file"
-        if os.environ.get('OCA_CI'):
+        if os.environ.get('OCA_RUNBOT'):
             # don't fail the build on runbot for this
             root_logger.info(msg)
         else:


### PR DESCRIPTION
- Fix https://github.com/OCA/server-tools/issues/627
- Add `TESTS="1"` in order to avoid skip build for runbot