### PR TITLE
[9.0][ADD] base_external_dbsource_elasticsearch

### DIFF
--- a/base_external_dbsource_elasticsearch/README.rst
+++ b/base_external_dbsource_elasticsearch/README.rst
@@ -1,0 +1,74 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+========================================
+External Database Source - Elasticsearch
+========================================
+
+This module extends ``base_external_dbsource``, allowing you to connect to
+foreign Elasticsearch databases.
+
+
+
+Installation
+============
+
+* Install ``elasticsearch`` python library
+
+Configuration
+=============
+
+Database sources can be configured in Settings > Configuration -> Data sources.
+
+
+Usage
+=====
+
+To use this module:
+
+* Go to Settings > Database Structure > Database Sources
+* Click on Create to enter the following information:
+
+* Datasource name 
+* Pasword
+* Connector: Choose the database to which you want to connect
+* Connection string : Specify how to connect to database
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/149/9.0 for server-tools
+
+Known issues / Roadmap
+======================
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/base_external_dbsource_elasticsearch/__init__.py
+++ b/base_external_dbsource_elasticsearch/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/base_external_dbsource_elasticsearch/__openerp__.py
+++ b/base_external_dbsource_elasticsearch/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+{
+    'name': 'External Database Source - Elasticsearch',
+    'version': '9.0.1.0.0',
+    'category': 'Tools',
+    'author': "LasLabs, "
+              "Odoo Community Association (OCA)",
+    'website': 'https://github.com/OCA/server-tools',
+    'license': 'LGPL-3',
+    'depends': [
+        'base_external_dbsource',
+    ],
+    'external_dependencies': {
+        'python': [
+            'elasticsearch',
+        ]
+    },
+    'installable': True,
+}

--- a/base_external_dbsource_elasticsearch/models/__init__.py
+++ b/base_external_dbsource_elasticsearch/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import base_external_dbsource

--- a/base_external_dbsource_elasticsearch/models/base_external_dbsource.py
+++ b/base_external_dbsource_elasticsearch/models/base_external_dbsource.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+import logging
+
+from uuid import uuid4
+
+from openerp import _, api, models
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from openerp.addons.base_external_dbsource.models import (
+        base_external_dbsource,
+    )
+    CONNECTORS = base_external_dbsource.BaseExternalDbsource.CONNECTORS
+    try:
+        from elasticsearch import Elasticsearch
+        CONNECTORS.append(('elasticsearch', 'Elasticsearch'))
+    except ImportError:
+        _logger.info('Elasticsearch library not available. Please install '
+                     '"elasticsearch" python package.')
+except ImportError:
+    _logger.info('base_external_dbsource Odoo module not found.')
+
+
+class BaseExternalDbsource(models.Model):
+    """ It provides logic for connection to an Elasticsearch data source. """
+
+    _inherit = "base.external.dbsource"
+
+    current_table = None
+
+    @api.multi
+    def connection_close_elasticsearch(self, connection):
+        return True
+
+    @api.multi
+    def connection_open_elasticsearch(self):
+        kwargs = {}
+        if self.ca_certs:
+            kwargs['ca_certs'] = self.ca_certs
+            if self.client_cert and self.client_key:
+                kwargs.update({
+                    'client_cert': self.client_cert,
+                    'client_key': self.client_key,
+                })
+        return Elasticsearch(
+            [self.conn_string_full],
+            **kwargs
+        )
+
+    def browse_elasticsearch(self, doc_id, doc_type='odoo'):
+        """ It returns the elasticsearch document. """
+        with self.connection_open() as elastic:
+            return elastic.get(
+                index=self.current_table,
+                doc_type=doc_type,
+                id=doc_id,
+            )
+
+    def create_elasticsearch(self, vals, doc_type='odoo'):
+        """ It creates and returns a new document on Elasticsearch """
+        return self.update_elasticsearch(vals, uuid4(), doc_type)
+
+    def delete_elasticsearch(self, doc_id, doc_type='odoo'):
+        """ It deletes a document from Elasticsearch """
+        with self.connection_open() as elastic:
+            return elastic.delete(
+                index=self.current_table,
+                doc_type=doc_type,
+                id=doc_id,
+            )
+
+    def search_elasticsearch(self, query):
+        """ It searches elasticsearch for query and returns results """
+        with self.connection_open() as elastic:
+            return elastic.search(
+                index=self.current_table,
+                body={'query': query},
+            )
+
+    def update_elasticsearch(self, body, doc_id, doc_type='odoo'):
+        """ It creates or updates a document of type on index.
+
+        Params:
+            body: (dict) Data to use as the body of the document.
+            doc_id: (int) ID of document in Elastic.
+            doc_type: (str) Document type.
+        Returns:
+            (dict) Document from Elasticsearch.
+        """
+        with self.connection_open() as elastic:
+            return elastic.index(
+                index=self.current_table,
+                doc_type=doc_type,
+                id=doc_id,
+                body=body,
+            )
+
+    # API/Compatibility
+
+    @api.multi
+    def execute_elasticsearch(self, query, params, metadata):
+        """ It searches Elasticsearch and returns the result.
+
+        This is a compatibility layer for the old API.
+        """
+
+        if not params.get('index'):
+            raise KeyError(_(
+                '"index" is a required key in "params" for Elasticsearch.',
+            ))
+
+        self.change_database_elasticsearch(params['index'])
+        res = self.search_elasticsearch(query)
+        cols = set(row.keys() for row in res) if metadata else []
+
+        return res, cols


### PR DESCRIPTION
This module provides Elasticsearch CRUD operations as an adapter to `base_external_dbsource` as discussed in #633.

Depends:
- [x] #642 

External Database Source - Elasticsearch
========================================

This module extends ``base_external_dbsource``, allowing you to connect to
foreign Elasticsearch databases.



Installation
============

* Install ``elasticsearch`` python library

Configuration
=============

Database sources can be configured in Settings > Configuration -> Data sources.


Usage
=====

To use this module:

* Go to Settings > Database Structure > Database Sources
* Click on Create to enter the following information:

* Datasource name 
* Pasword
* Connector: Choose the database to which you want to connect
* Connection string : Specify how to connect to database
