### PR TITLE
[9.0][FIX] password_security: Validate admin pass

### DIFF
--- a/password_security/__openerp__.py
+++ b/password_security/__openerp__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '9.0.1.0.2',
+    'version': '9.0.1.0.3',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [
@@ -18,6 +18,9 @@
         'views/res_company_view.xml',
         'security/ir.model.access.csv',
         'security/res_users_pass_history.xml',
+    ],
+    "demo": [
+        'demo/res_users.xml',
     ],
     'installable': True,
 }

--- a/password_security/demo/res_users.xml
+++ b/password_security/demo/res_users.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2016 LasLabs Inc.
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+-->
+
+<odoo>
+
+    <record id="base.user_root" model="res.users">
+        <field name="password_write_date"
+               eval="datetime.now()"
+               />
+    </record>
+
+</odoo>


### PR DESCRIPTION
* Add current time as password_write_date for admin user in demo, disabling the reset prompt - fixes #652