### PR TITLE
[FIX] base_multi_image: Use env in uninstall_hook

### DIFF
--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -78,7 +78,7 @@ def uninstall_hook_for_submodules(cr, registry, model):
     """
     env = api.Environment(cr, SUPERUSER_ID, dict())
     Image = env["base_multi_image.image"]
-    images = Image.search(env, [("owner_model", "=", model)])
+    images = Image.search([("owner_model", "=", model)])
     images.unlink()
 
 

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -78,8 +78,8 @@ def uninstall_hook_for_submodules(cr, registry, model):
     """
     env = api.Environment(cr, SUPERUSER_ID, dict())
     Image = env["base_multi_image.image"]
-    ids = Image.search(env, [("owner_model", "=", model)])
-    ids.unlink()
+    images = Image.search(env, [("owner_model", "=", model)])
+    images.unlink()
 
 
 def table_has_column(cr, table, field):

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -76,8 +76,7 @@ def uninstall_hook_for_submodules(cr, registry, model):
         Model technical name, like "res.partner". All multi-images for that
         model will be deleted
     """
-    env = api.Environment(cr, SUPERUSER_ID, dict())
-    Image = env["base_multi_image.image"]
+    Image = registry["base_multi_image.image"]
     images = Image.search([("owner_model", "=", model)])
     images.unlink()
 

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -76,9 +76,10 @@ def uninstall_hook_for_submodules(cr, registry, model):
         Model technical name, like "res.partner". All multi-images for that
         model will be deleted
     """
-    Image = registry["base_multi_image.image"]
-    ids = Image.search(cr, SUPERUSER_ID, [("owner_model", "=", model)])
-    Image.unlink(cr, SUPERUSER_ID, ids)
+    env = api.Environment(cr, SUPERUSER_ID, dict())
+    Image = env["base_multi_image.image"]
+    ids = Image.search(env, [("owner_model", "=", model)])
+    ids.unlink()
 
 
 def table_has_column(cr, table, field):


### PR DESCRIPTION
* Uninstall hook should use new API instead of old, which doesn’t exist anymore

This should fix the Travis fails in OCA/product-attribute#201