### PR TITLE
[10.0][FIX] base_multi_image: Uninstall hook

### DIFF
--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -77,7 +77,7 @@ def uninstall_hook_for_submodules(cr, registry, model):
         model will be deleted
     """
     Image = registry["base_multi_image.image"]
-    images = Image.search([("owner_model", "=", model)])
+    images = Image.search(Image, [("owner_model", "=", model)])
     images.unlink()
 
 

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -20,7 +20,7 @@ def pre_init_hook_for_submodules(cr, model, field):
         Binary field that had the images in that :param:`model`, like
         ``image``.
     """
-    env = api.Environment(cr, SUPERUSER_ID, dict())
+    env = api.Environment(cr, SUPERUSER_ID, {})
     with cr.savepoint():
         table = env[model]._table
         column_exists = table_has_column(cr, table, field)
@@ -76,7 +76,7 @@ def uninstall_hook_for_submodules(cr, registry, model):
         Model technical name, like "res.partner". All multi-images for that
         model will be deleted
     """
-    env = api.Environment(cr, SUPERUSER_ID, dict())
+    env = api.Environment(cr, SUPERUSER_ID, {})
     with cr.savepoint():
         Image = env["base_multi_image.image"]
         images = Image.search([("owner_model", "=", model)])

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -76,9 +76,11 @@ def uninstall_hook_for_submodules(cr, registry, model):
         Model technical name, like "res.partner". All multi-images for that
         model will be deleted
     """
-    Image = registry["base_multi_image.image"]
-    images = Image.search(Image, [("owner_model", "=", model)])
-    images.unlink()
+    env = api.Environment(cr, SUPERUSER_ID, dict())
+    with cr.savepoint():
+        Image = env["base_multi_image.image"]
+        images = Image.search([("owner_model", "=", model)])
+        images.unlink()
 
 
 def table_has_column(cr, table, field):


### PR DESCRIPTION
Revisiting the `base_multi_image` uninstall hook. It turns out we do need to use the env, because the registry is actually returning a MetaModel here. This can be seen in:
* 3afbb19
* And there was a Travis build proving it, but it seems it was overwritten when I rebuilt. Sorry about that. Basically it was the same error we were getting, except saying that I was passing a `MetaModel` instead of a `list`. It still wanted the `BaseModel`.

I switched up to the env in the second commit here, then rebuilt the product-attribute PR to yield a [positive Travis](https://travis-ci.org/LasLabs/product-attribute/builds/193939658).

I'm curious if there's a way to test this directly in this module. The whole double PR to fix an issue that made it to a production branch isn't awesome, so I'd like to figure out how to nip this in the butt forever with a test. Best I can think of though is a `test_` module, which really isn't that much better than just requiring some other module that already exists IMO.