### PR TITLE
[10.0][FIX] Move DB libs to travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
+  # Install libraries that require specific development headers
+  - pip install pymssql MySQL-python pyodbc
   - printf '[options]\n\nrunning_env = dev\n' > ${HOME}/.openerp_serverrc
   - ln -s ${TRAVIS_BUILD_DIR}/server_environment_files_sample ${TRAVIS_BUILD_DIR}/server_environment_files
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-  # Install libraries that require specific development headers
-  - pip install pymssql MySQL-python pyodbc
+  # Install libraries that require specific development headers, but not during lint test
+  - if ! [ "$LINT_CHECK" = "1" ]; then pip install pymssql MySQL-python pyodbc; fi
   - printf '[options]\n\nrunning_env = dev\n' > ${HOME}/.openerp_serverrc
   - ln -s ${TRAVIS_BUILD_DIR}/server_environment_files_sample ${TRAVIS_BUILD_DIR}/server_environment_files
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,3 @@ validate_email
 pysftp
 fdb
 sqlalchemy
-pymssql
-MySQL-python
-pyodbc


### PR DESCRIPTION
This is a stop gap to fix build while we determine how to accomplish OCA/maintainer-quality-tools#427

* Move libraries that require development headers to travis file to band-aid build
