### PR TITLE
[9.0][FIX] base_kanban_stage: Add group_expand attr

### DIFF
--- a/base_kanban_stage/models/base_kanban_abstract.py
+++ b/base_kanban_stage/models/base_kanban_abstract.py
@@ -38,6 +38,7 @@ class BaseKanbanAbstract(models.AbstractModel):
         help='The Kanban stage that this record is currently in',
         default=lambda s: s._default_stage_id(),
         domain=lambda s: [('res_model.model', '=', s._name)],
+        group_expand='_read_group_stage_ids',
     )
     user_id = fields.Many2one(
         string='Assigned To',
@@ -102,13 +103,8 @@ class BaseKanbanAbstract(models.AbstractModel):
         return self.env['base.kanban.stage']
 
     @api.multi
-    def _read_group_stage_ids(
-        self, domain=None, read_group_order=None, access_rights_uid=None
-    ):
-        stage_model = self.env['base.kanban.stage']
-        if access_rights_uid:
-            stage_model = stage_model.sudo(access_rights_uid)
-        stages = stage_model.search([('res_model.model', '=', self._name)])
-        names = [(r.id, r.display_name) for r in stages]
-        fold = {r.id: r.fold for r in stages}
-        return names, fold
+    def _read_group_stage_ids(self, stages, domain, order):
+        search_domain = [('res_model_id.model', '=', self._name)]
+        if domain:
+            search_domain.extend(domain)
+        return stages.search(search_domain, order=order)

--- a/base_kanban_stage/tests/test_base_kanban_abstract.py
+++ b/base_kanban_stage/tests/test_base_kanban_abstract.py
@@ -37,32 +37,13 @@ class TestBaseKanbanAbstract(TransactionCase):
         self.id_1 = test_stage_1.id
         self.id_2 = test_stage_2.id
 
-    def test_read_group_stage_ids_base_case(self):
-        '''It should return a structure with the proper content'''
+    def test_read_group_stage_ids(self):
+        """It should return the correct recordset. """
         self.assertEqual(
-            self.test_model._read_group_stage_ids(),
-            (
-                [(self.id_1, 'Test Stage 1'), (self.id_2, 'Test Stage 2')],
-                {self.id_1: False, self.id_2: True},
-            )
-        )
-
-    def test_read_group_stage_ids_correct_associated_model(self):
-        '''It should only return info for stages with right associated model'''
-        stage_model = self.env['ir.model'].search([
-            ('model', '=', 'base.kanban.stage'),
-        ])
-        self.env['base.kanban.stage'].create({
-            'name': 'Test Stage 3',
-            'res_model': stage_model.id,
-        })
-
-        self.assertEqual(
-            self.test_model._read_group_stage_ids(),
-            (
-                [(self.id_1, 'Test Stage 1'), (self.id_2, 'Test Stage 2')],
-                {self.id_1: False, self.id_2: True},
-            )
+            self.test_model._read_group_stage_ids(
+                self.env['base.kanban.stage'], [], 'id',
+            ),
+            self.env['base.kanban.stage'].search([], order='id'),
         )
 
     def test_default_stage_id(self):


### PR DESCRIPTION
Simple fix for issue described in https://github.com/OCA/server-tools/pull/681#issuecomment-275572678:

* Add group_expand attr to abstract kanban model, allowing for empty columns
* Fix `_read_group_stage_ids` for new API

cc @dreispt @obulkin