### PR TITLE
[9.0][FIX] database_cleanup: Isolate build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="database_cleanup"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="database_cleanup"
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="database_cleanup"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="database_cleanup"
 
 virtualenv:
   system_site_packages: true

--- a/database_cleanup/tests/test_database_cleanup.py
+++ b/database_cleanup/tests/test_database_cleanup.py
@@ -59,15 +59,11 @@ class TestDatabaseCleanup(TransactionCase):
         self.registry._pure_function_fields.pop(
             'x_database.cleanup.test.model')
         purge_models = self.env['cleanup.purge.wizard.model'].create({})
-        with self.assertRaisesRegexp(KeyError,
-                                     'x_database.cleanup.test.model'):
-            # TODO: Remove with-assert of KeyError after fix:
-            # https://github.com/odoo/odoo/pull/13978/files#r88654967
-            purge_models.purge_all()
-            # must be removed by the wizard
-            self.assertFalse(self.env['ir.model'].search([
-                ('model', '=', 'x_database.cleanup.test.model'),
-            ]))
+        purge_models.purge_all()
+        # must be removed by the wizard
+        self.assertFalse(self.env['ir.model'].search([
+            ('model', '=', 'x_database.cleanup.test.model'),
+        ]))
 
         # create a nonexistent module
         self.module = self.env['ir.module.module'].create({


### PR DESCRIPTION
* Isolate `database_cleanup` into its own build in Travis file to fix #689

Admittedly I didn't RTFM of MQT, but I'm guessing this is probably the way to do it. If build fails, I'll look into it!

Note that Runbot will only have the first Tests build as the usable, so Runbot is now not actually testing the `database_cleanup` module due to this change.