### PR TITLE
[REF] mass_editing: migrate module to version 10.0

### DIFF
--- a/mass_editing/README.rst
+++ b/mass_editing/README.rst
@@ -76,7 +76,7 @@ help us smashing it by providing a detailed and welcomed `feedback
 <https://github.com/OCA/
 server-tools/issues/new?body=module:%20
 server-tools%0Aversion:%20
-9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+10.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Credits
 =======

--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Mass Editing',
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'author': 'Serpent Consulting Services Pvt. Ltd., '
               'Odoo Community Association (OCA)',
     'contributors': [
@@ -20,7 +20,7 @@
         'security/ir.model.access.csv',
         'views/mass_editing_view.xml',
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
     'auto_install': False,
 }

--- a/mass_editing/hooks.py
+++ b/mass_editing/hooks.py
@@ -8,5 +8,5 @@ def uninstall_hook(cr, registry):
                WHERE res_model = 'mass.editing.wizard'""")
     for res in cr.dictfetchall():
         value = 'ir.actions.act_window,%s' % res.get('id')
-        cr.execute("DELETE FROM ir_values WHERE value = '%s'" % value)
+        cr.execute("DELETE FROM ir_values WHERE value = %s", (value,))
     return True

--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -10,7 +10,7 @@ class MassObject(models.Model):
     _name = "mass.object"
     _description = "Mass Editing Object"
 
-    name = fields.Char('Name', required=True, select=1)
+    name = fields.Char(required=True, index=1)
     model_id = fields.Many2one('ir.model', 'Model', required=True,
                                help="Model is used for Selecting Fields. "
                                     "This is editable until Sidebar menu "
@@ -65,7 +65,6 @@ class MassObject(models.Model):
             'context': "{'mass_editing_object' : %d}" % (self.id),
             'view_mode': 'form, tree',
             'target': 'new',
-            'auto_refresh': 1,
         }).id
         vals['ref_ir_value_id'] = self.env['ir.values'].create({
             'name': button_name,
@@ -94,6 +93,7 @@ class MassObject(models.Model):
         self.unlink_action()
         return super(MassObject, self).unlink()
 
+    @api.multi
     @api.returns('self', lambda value: value.id)
     def copy(self, default=None):
         if default is None:

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -6,7 +6,7 @@ import ast
 
 from openerp.tests import common
 from openerp.modules import registry
-from openerp.addons.mass_editing.hooks import uninstall_hook
+from ..hooks import uninstall_hook
 
 
 class TestMassEditing(common.TransactionCase):

--- a/module_prototyper/tests/test_prototype.py
+++ b/module_prototyper/tests/test_prototype.py
@@ -47,7 +47,7 @@ class TestModulePrototyper(common.TransactionCase):
             'author': 't_author',
             'maintainer': 't_maintainer',
             'website': 't_website',
-            'dependencies': [(6, 0, [1, 2, 3, 4])],
+            'dependency_ids': [(6, 0, [1, 2, 3, 4])],
         })
         self.api_version = self.env['module_prototyper.api_version'].search([
             ('id', '=', self.ref('module_prototyper.api_version_80'))


### PR DESCRIPTION
I made the minimum changes in order to run this module in 10.0.
Update README and descriptions of the repository and the module it self
to refer this module as a 10.0 module y not a 9.0 unported module.