### PR TITLE
FIX warning in mass editing module when read

### DIFF
--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -264,6 +264,8 @@ class MassEditingWizard(models.TransientModel):
             odoo.models:mass.editing.wizard.read()
                 with unknown field 'selection__myfield'
         """
-        # We remove fields which are not in _fields
-        real_fields = [x for x in fields if x in self._fields]
+        real_fields = fields
+        if fields:
+            # We remove fields which are not in _fields
+            real_fields = [x for x in fields if x in self._fields]
         return super(MassEditingWizard, self).read(real_fields, load=load)

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -256,3 +256,14 @@ class MassEditingWizard(models.TransientModel):
     @api.multi
     def action_apply(self):
         return {'type': 'ir.actions.act_window_close'}
+
+    def read(self, fields, load='_classic_read'):
+        """ Without this call, dynamic fields build by fields_view_get()
+            generate a log warning, i.e.:
+            odoo.models:mass.editing.wizard.read() with unknown field 'myfield'
+            odoo.models:mass.editing.wizard.read()
+                with unknown field 'selection__myfield'
+        """
+        # We remove fields which are not in _fields
+        real_fields = [x for x in fields if x in self._fields]
+        return super(MassEditingWizard, self).read(real_fields, load=load)


### PR DESCRIPTION
Just a small fix to remove Warning.

It also avoid Sentry users to send false positive alerts.

![sentry](https://cloud.githubusercontent.com/assets/1853434/23128237/74a430f8-f77e-11e6-9f9c-5f27a6bb4c84.png)
