### PR TITLE
[FIX] Request id no longer exists after concurrency rollback

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -2,6 +2,8 @@
 # © 2015 ABF OSIELL <http://osiell.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from psycopg2.extensions import AsIs
+
 from odoo import models, fields, api
 from odoo.http import request
 
@@ -51,7 +53,14 @@ class AuditlogHTTPRequest(models.Model):
         httprequest = request.httprequest
         if httprequest:
             if hasattr(httprequest, 'auditlog_http_request_id'):
-                return httprequest.auditlog_http_request_id
+                # Verify existence. Could have been rolled back after a
+                # concurrency error
+                self.env.cr.execute(
+                    "SELECT id FROM %s WHERE id = %s", (
+                        AsIs(self._table),
+                        httprequest.auditlog_http_request_id))
+                if self.env.cr.fetchone():
+                    return httprequest.auditlog_http_request_id
             vals = {
                 'name': httprequest.path,
                 'root_url': httprequest.url_root,


### PR DESCRIPTION
Forward port of https://github.com/OCA/server-tools/pull/701