### PR TITLE
[10.0][FIX] Make letsencrypt resilient for alternate name removal.

### DIFF
--- a/letsencrypt/README.rst
+++ b/letsencrypt/README.rst
@@ -139,6 +139,7 @@ Contributors
 * Holger Brunn <hbrunn@therp.nl>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Dave Lasley <dave@laslabs.com>
+* Ronald Portier <ronald@therp.nl>
 
 ACME implementation
 -------------------

--- a/letsencrypt/models/letsencrypt.py
+++ b/letsencrypt/models/letsencrypt.py
@@ -38,13 +38,10 @@ class Letsencrypt(models.AbstractModel):
             _logger.log(loglevel, stderr)
         if stdout:
             _logger.log(loglevel, stdout)
-
         if process.returncode:
             raise exceptions.Warning(
-                _('Error calling %s: %d') % (cmdline[0], process.returncode),
-                ' '.join(cmdline),
+                _('Error calling %s: %d') % (cmdline[0], process.returncode)
             )
-
         return process.returncode
 
     @api.model

--- a/letsencrypt/models/letsencrypt.py
+++ b/letsencrypt/models/letsencrypt.py
@@ -94,9 +94,10 @@ class Letsencrypt(models.AbstractModel):
     def generate_csr(self, domain):
         domains = [domain]
         parameter_model = self.env['ir.config_parameter']
-        altnames = parameter_model.search([
-            ('key', 'like', 'letsencrypt.altname.')
-        ])
+        altnames = parameter_model.search(
+            [('key', 'like', 'letsencrypt.altname.')],
+            order='key'
+        )
         for altname in altnames:
             domains.append(altname.value)
         _logger.info('generating csr for %s', domain)


### PR DESCRIPTION
Sole #753 even before module is migrated.