### PR TITLE
[10.0] [FIX] auditlog: Duplicate logging

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -131,28 +131,28 @@ class AuditlogRule(models.Model):
             if getattr(rule, 'log_create') \
                     and not hasattr(model_model, check_attr):
                 model_model._patch_method('create', rule._make_create())
-                setattr(model_model, check_attr, True)
+                setattr(type(model_model), check_attr, True)
                 updated = True
             #   -> read
             check_attr = 'auditlog_ruled_read'
             if getattr(rule, 'log_read') \
                     and not hasattr(model_model, check_attr):
                 model_model._patch_method('read', rule._make_read())
-                setattr(model_model, check_attr, True)
+                setattr(type(model_model), check_attr, True)
                 updated = True
             #   -> write
             check_attr = 'auditlog_ruled_write'
             if getattr(rule, 'log_write') \
                     and not hasattr(model_model, check_attr):
                 model_model._patch_method('write', rule._make_write())
-                setattr(model_model, check_attr, True)
+                setattr(type(model_model), check_attr, True)
                 updated = True
             #   -> unlink
             check_attr = 'auditlog_ruled_unlink'
             if getattr(rule, 'log_unlink') \
                     and not hasattr(model_model, check_attr):
                 model_model._patch_method('unlink', rule._make_unlink())
-                setattr(model_model, check_attr, True)
+                setattr(type(model_model), check_attr, True)
                 updated = True
         return updated
 
@@ -166,6 +166,7 @@ class AuditlogRule(models.Model):
                 if getattr(rule, 'log_%s' % method) and hasattr(
                         getattr(model_model, method), 'origin'):
                     model_model._revert_method(method)
+                    delattr(type(model_model), 'auditlog_ruled_%s' % method)
                     updated = True
         if updated:
             modules.registry.RegistryManager.signal_registry_change(


### PR DESCRIPTION
* Update ``_patch_methods`` and ``_revert_methods`` in ``auditlog.rule`` model to properly track whether a method has already been patched for logging purposes. This prevents duplicate logs from being produced in various cases (e.g. when a logging rule is created as part of a module install).