### PR TITLE
[10.0] Fix base_kanban_stage tests

### DIFF
--- a/base_kanban_stage/tests/test_base_kanban_abstract.py
+++ b/base_kanban_stage/tests/test_base_kanban_abstract.py
@@ -48,6 +48,11 @@ class TestBaseKanbanAbstract(SavepointCase):
         cls._init_test_model(BaseKanbanAbstractTester)
         cls.test_model = cls.env[BaseKanbanAbstractTester._name]
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.env.registry.leave_test_mode()
+        super(TestBaseKanbanAbstract, cls).tearDownClass()
+
     def setUp(self):
         super(TestBaseKanbanAbstract, self).setUp()
         test_stage_1 = self.env['base.kanban.stage'].create({


### PR DESCRIPTION
I think there is a problem with base_kanban_stage tests, as it never leaves the test mode : 
https://github.com/OCA/server-tools/blob/10.0/base_kanban_stage/tests/test_base_kanban_abstract.py#L47

Tests in other module may fail because of that. 