### PR TITLE
[MIG] Migrate module attachment_base_synchronize to v10

### DIFF
--- a/attachment_base_synchronize/README.rst
+++ b/attachment_base_synchronize/README.rst
@@ -1,4 +1,3 @@
-
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
@@ -22,7 +21,7 @@ An example of the use of this module, can be found in the external_file_location
 Usage
 =====
 
-Go the menu Settings > Attachments
+Go the menu Settings > Technical > Database Structure > Meta Data Attachments
 
 You can create / see standard attachments with additional fields
 
@@ -30,7 +29,7 @@ You can create / see standard attachments with additional fields
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/149/8.0
+   :target: https://runbot.odoo-community.org/runbot/149/10.0
 
 
 Known issues / Roadmap
@@ -43,13 +42,9 @@ Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues
-<https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
-<https://github.com/OCA/
-server-tools/issues/new?body=module:%20
-attachment_metadata%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======
@@ -64,9 +59,7 @@ Contributors
 ------------
 
 * Valentin CHEMIERE <valentin.chemiere@akretion.com>
-* Sebastien BEAU <sebastian.beau@akretion.com>
-* Joel Grand-Guillaume Camptocamp
-* initOS <http://initos.com>
+* Florian da Costa <florian.dacosta@akretion.com>
 * Angel Moya <http://angelmoya.es>
 
 Maintainer

--- a/attachment_base_synchronize/__manifest__.py
+++ b/attachment_base_synchronize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Attachment Base Synchronize',
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'www.akretion.com',
     'license': 'AGPL-3',
@@ -21,7 +21,7 @@
     'demo': [
         'demo/attachment_metadata_demo.xml'
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
     'images': [],
 }

--- a/attachment_base_synchronize/data/cron.xml
+++ b/attachment_base_synchronize/data/cron.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data noupdate="1">
+<odoo noupdate="1">
         
         <record model="ir.cron" id="cronjob_run_attachments_metadata">
             <field name='name'>Run Attachments Metadata</field>
@@ -14,5 +13,4 @@
             <field name="args">([])</field>
         </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/attachment_base_synchronize/demo/attachment_metadata_demo.xml
+++ b/attachment_base_synchronize/demo/attachment_metadata_demo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-<openerp>
-    <data noupdate="1">
+<odoo noupdate="1">
 
         <record id="attachment_metadata" model="ir.attachment.metadata">
             <field name="datas">bWlncmF0aW9uIHRlc3Q=</field>
@@ -8,5 +7,4 @@
             <field name="name">attachment_metadata.doc</field>
         </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/attachment_base_synchronize/security/ir.model.access.csv
+++ b/attachment_base_synchronize/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_attachment_metadata_user,ir.attachment.metadata.user,model_ir_attachment_metadata,base.group_user,1,0,0,0
+access_attachment_metadata_user,ir.attachment.metadata.user,model_ir_attachment_metadata,,1,0,0,0
+access_attachment_metadata_user,ir.attachment.metadata.user,model_ir_attachment_metadata,base.group_no_one,1,1,1,1

--- a/attachment_base_synchronize/tests/test_attachment_base_synchronize.py
+++ b/attachment_base_synchronize/tests/test_attachment_base_synchronize.py
@@ -2,9 +2,9 @@
 # Copyright 2016 Angel Moya (http://angelmoya.es)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp.tests.common import TransactionCase
-import openerp
-from openerp import api
+from odoo.tests.common import TransactionCase
+import odoo
+from odoo import api
 
 
 class TestAttachmentBaseSynchronize(TransactionCase):
@@ -31,7 +31,7 @@ class TestAttachmentBaseSynchronize(TransactionCase):
         )
         self.ir_attachment_metadata.run_attachment_metadata_scheduler()
         self.env.invalidate_all()
-        with openerp.registry(self.env.cr.dbname).cursor() as new_cr:
+        with odoo.registry(self.env.cr.dbname).cursor() as new_cr:
             new_env = api.Environment(
                 new_cr, self.env.uid, self.env.context)
             attach = self.attachment.with_env(new_env)
@@ -43,6 +43,10 @@ class TestAttachmentBaseSynchronize(TransactionCase):
     def test_set_done(self):
         """Test set_done manually
         """
+        self.assertEqual(
+            self.attachment.state,
+            'pending'
+        )
         self.attachment.set_done()
         self.assertEqual(
             self.attachment.state,

--- a/attachment_base_synchronize/views/attachment_view.xml
+++ b/attachment_base_synchronize/views/attachment_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-  <data>
+<odoo>
 
     <record id="view_attachment_improved_form" model="ir.ui.view">
         <field name="model">ir.attachment.metadata</field>
@@ -108,5 +107,4 @@
     sequence="20"
     action="action_attachment"/>
 
-  </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
The tests fail because of : https://github.com/OCA/server-tools/pull/762

If I play only the test of this module, it is all ok, but if I play base_kanban_stage tests together, it fails.
Indeed, because of base_kanban_stage's tests, the cursor is already in test_mode.
