### PR TITLE
[10.0] FIX auto_backup SFTP cleanup

### DIFF
--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Database Auto-Backup",
     "summary": "Backups database",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "author": (
         "Yenthe Van Ginneken, "
         "Agile Business Group, "

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -232,7 +232,7 @@ class DbBackup(models.Model):
                         for name in remote.listdir(rec.folder):
                             if (name.endswith(".dump.zip") and
                                     os.path.basename(name) < oldest):
-                                remote.unlink(name)
+                                remote.unlink('%s/%s' % (rec.folder, name))
 
     @api.multi
     @contextmanager


### PR DESCRIPTION
2017-03-09 13:07:36,067 25649 ERROR jdeal_2017-03-09 odoo.addons.auto_backup.models.db_backup: Cleanup of old database backups failed: %s
Traceback (most recent call last):
  File "server-tools/auto_backup/models/db_backup.py", line 242, in cleanup_log
    yield
  File "server-tools/auto_backup/models/db_backup.py", line 232, in cleanup
    remote.unlink(name)
  [..]
IOError: [Errno 2] No such file