### PR TITLE
[8.0] FIX auto_backup SFTP cleanup

### DIFF
--- a/auto_backup/__openerp__.py
+++ b/auto_backup/__openerp__.py
@@ -7,7 +7,7 @@
 {
     "name": "Database Auto-Backup",
     "summary": "Backups database",
-    "version": "8.0.1.0.2",
+    "version": "8.0.1.0.3",
     "author": (
         "VanRoey.be - Yenthe Van Ginneken, Agile Business Group,"
         " Grupo ESOC Ingeniería de Servicios,"

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -229,7 +229,7 @@ class DbBackup(models.Model):
                         for name in remote.listdir(rec.folder):
                             if (name.endswith(".dump.zip") and
                                     os.path.basename(name) < oldest):
-                                remote.unlink(name)
+                                remote.unlink('%s/%s' % (rec.folder, name))
 
     @api.multi
     @contextmanager


### PR DESCRIPTION
2017-03-09 13:07:36,067 25649 ERROR jdeal_2017-03-09 odoo.addons.auto_backup.models.db_backup: Cleanup of old database backups failed: %s
Traceback (most recent call last):
  File "server-tools/auto_backup/models/db_backup.py", line 242, in cleanup_log
    yield
  File "server-tools/auto_backup/models/db_backup.py", line 232, in cleanup
    remote.unlink(name)
  [..]
IOError: [Errno 2] No such file