### PR TITLE
[8.0] resilient letsencrypt extra

### DIFF
--- a/letsencrypt/models/letsencrypt.py
+++ b/letsencrypt/models/letsencrypt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Therp BV <http://therp.nl>
+# © 2016-2017 Therp BV <http://therp.nl>
 # © 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import os
@@ -136,7 +136,7 @@ class Letsencrypt(models.AbstractModel):
     def cron(self):
         domain = urlparse.urlparse(
             self.env['ir.config_parameter'].get_param(
-                'web.base.url', 'localhost')).netloc
+                'web.base.url', 'localhost')).hostname
         self.validate_domain(domain)
         account_key = self.generate_account_key()
         csr = self.generate_csr(domain)

--- a/letsencrypt/models/letsencrypt.py
+++ b/letsencrypt/models/letsencrypt.py
@@ -91,9 +91,11 @@ class Letsencrypt(models.AbstractModel):
             return ip.iptype() == 'PRIVATE'
 
         if domain in local_domains or _ip_is_private(domain):
-            raise UserError(
-                _("Let's encrypt doesn't work with private addresses "
-                  "or local domains!"))
+            raise UserError(_(
+                "Let's encrypt doesn't work with private addresses "
+                "or local domains!\n"
+                "Check the web.base.url system parameter."
+            ))
 
     @api.model
     def generate_csr(self, domain, ignore_altnames=False):

--- a/letsencrypt/models/letsencrypt.py
+++ b/letsencrypt/models/letsencrypt.py
@@ -97,10 +97,9 @@ class Letsencrypt(models.AbstractModel):
     def generate_csr(self, domain):
         domains = [domain]
         parameter_model = self.env['ir.config_parameter']
-        altnames = parameter_model.search(
-            [('key', 'like', 'letsencrypt.altname.')],
-            order='key'
-        )
+        altnames = parameter_model.search([
+            ('key', 'like', 'letsencrypt.altname.')
+        ])
         for altname in altnames:
             domains.append(altname.value)
         _logger.info('generating csr for %s', domain)

--- a/letsencrypt/models/letsencrypt.py
+++ b/letsencrypt/models/letsencrypt.py
@@ -97,9 +97,10 @@ class Letsencrypt(models.AbstractModel):
     def generate_csr(self, domain):
         domains = [domain]
         parameter_model = self.env['ir.config_parameter']
-        altnames = parameter_model.search([
-            ('key', 'like', 'letsencrypt.altname.')
-        ])
+        altnames = parameter_model.search(
+            [('key', 'like', 'letsencrypt.altname.')],
+            order='key'
+        )
         for altname in altnames:
             domains.append(altname.value)
         _logger.info('generating csr for %s', domain)


### PR DESCRIPTION
This includes the 8.0-resilient-letsencrypt PR: https://github.com/OCA/server-tools/pull/755

This PR has some improvements in error-handling and will make sure the main domain remains available, even if renewing of extra hostnames (altnames) fails.