### PR TITLE
[10.0] mass_editing: allow to remove specific values of x2m fields

### DIFF
--- a/mass_editing/README.rst
+++ b/mass_editing/README.rst
@@ -92,6 +92,7 @@ Contributors
 * Oihane Crucelaegui <oihanecrucelaegi@gmail.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Jairo Llopis <jairo.llopis@tecnativa.com>
+* Leonardo Donelli @ MONK Software <leonardo.donelli@monksoftware.it>
 
 Maintainer
 ----------
@@ -107,4 +108,3 @@ mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
 To contribute to this module, please visit http://odoo-community.org.
-

--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -6,11 +6,13 @@
     'version': '10.0.1.1.0',
     'author': 'Serpent Consulting Services Pvt. Ltd., '
               'Tecnativa, '
+              'MONK Software, '
               'Odoo Community Association (OCA)',
     'contributors': [
         'Oihane Crucelaegui <oihanecrucelaegi@gmail.com>',
         'Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>',
-        'Jay Vora <jay.vora@serpentcs.com>'
+        'Jay Vora <jay.vora@serpentcs.com>',
+        'Leonardo Donelli <leonardo.donelli@monksoftware.it>',
     ],
     'category': 'Tools',
     'website': 'http://www.serpentcs.com',

--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Mass Editing',
-    'version': '10.0.1.1.1',
+    'version': '10.0.2.0.0',
     'author': 'Serpent Consulting Services Pvt. Ltd., '
               'Tecnativa, '
               'MONK Software, '

--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Mass Editing',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'author': 'Serpent Consulting Services Pvt. Ltd., '
               'Tecnativa, '
               'MONK Software, '

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Serpent Consulting Services Pvt. Ltd. (support@serpentcs.com)
+# © 2017 Leonardo Donelli @ MONK Software (<leonardo.donelli@monksoftware.it>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import ast
@@ -49,8 +50,10 @@ class TestMassEditing(common.TransactionCase):
         })
 
     def _create_mass_editing(self, model, fields):
-        """Create a Mass Editing with Partner as model and
-        email field of partner."""
+        """
+        Create a Mass Editing with Partner as model and
+        email field of partner.
+        """
         mass = self.mass_object_model.create({
             'name': 'Mass Editing for Partner',
             'model_id': model.id,
@@ -60,8 +63,10 @@ class TestMassEditing(common.TransactionCase):
         return mass
 
     def _apply_action(self, partner, vals):
-        """Create Wizard object to perform mass editing to
-        REMOVE field's value."""
+        """
+        Create Wizard object to perform mass editing to
+        REMOVE field's value.
+        """
         ctx = {
             'active_id': partner.id,
             'active_ids': partner.ids,
@@ -90,8 +95,10 @@ class TestMassEditing(common.TransactionCase):
                         'Onchange model list must contains model_id.')
 
     def test_mass_edit_email(self):
-        """Test Case for MASS EDITING which will remove and after add
-        Partner's email and will assert the same."""
+        """
+        Test Case for MASS EDITING which will remove and after add
+        Partner's email and will assert the same.
+        """
         # Remove email address
         vals = {
             'selection__email': 'remove',
@@ -110,8 +117,10 @@ class TestMassEditing(common.TransactionCase):
                             'Partner\'s Email should be set.')
 
     def test_mass_edit_m2m_categ(self):
-        """Test Case for MASS EDITING which will remove and add
-        Partner's category m2m."""
+        """
+        Test Case for MASS EDITING which will remove and add
+        Partner's category m2m.
+        """
         # Remove m2m categories
         vals = {
             'selection__category_id': 'remove_m2m',
@@ -134,7 +143,8 @@ class TestMassEditing(common.TransactionCase):
                         'IR Action must be window close.')
 
     def test_mass_edit_copy(self):
-        """Test if fields one2many field gets blank when mass editing record
+        """
+        Test if fields one2many field gets blank when mass editing record
         is copied.
         """
         self.assertEqual(self.copy_mass.field_ids.ids, [],
@@ -150,25 +160,27 @@ class TestMassEditing(common.TransactionCase):
         self.assertFalse(action, 'Sidebar action must be removed.')
 
     def test_unlink_mass(self):
-        """Test if related actions are removed when mass editing
-        record is unlinked."""
+        """
+        Test if related actions are removed when mass editing
+        record is unlinked.
+        """
         mass_action_id = "ir.actions.act_window," + str(self.mass.id)
         self.mass.unlink()
-        value_cnt = self.env['ir.values'].search([('value', '=',
-                                                   mass_action_id)],
-                                                 count=True)
         self.assertTrue(value_cnt == 0,
+        value_cnt = self.env['ir.values'].search(
+            [('value', '=', mass_action_id)], count=True)
                         "Sidebar action must be removed when mass"
                         " editing is unlinked.")
 
     def test_uninstall_hook(self):
-        """Test if related actions are removed when mass editing
-        record is uninstalled."""
+        """
+        Test if related actions are removed when mass editing
+        record is uninstalled.
+        """
         uninstall_hook(self.cr, registry)
         mass_action_id = "ir.actions.act_window," + str(self.mass.id)
-        value_cnt = self.env['ir.values'].search([('value', '=',
-                                                   mass_action_id)],
-                                                 count=True)
         self.assertTrue(value_cnt == 0,
                         "Sidebar action must be removed when mass"
                         " editing module is uninstalled.")
+        value_cnt = self.env['ir.values'].search(
+            [('value', '=', mass_action_id)], count=True)

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -139,7 +139,7 @@ class TestMassEditing(common.TransactionCase):
                         'Partner\'s category should be added.')
         # Check window close action
         res = wiz_action.action_apply()
-        self.assertTrue(res['type'] == 'ir.actions.act_window_close',
+        self.assertEqual(res['type'], 'ir.actions.act_window_close',
                         'IR Action must be window close.')
 
     def test_mass_edit_copy(self):
@@ -166,9 +166,9 @@ class TestMassEditing(common.TransactionCase):
         """
         mass_action_id = "ir.actions.act_window," + str(self.mass.id)
         self.mass.unlink()
-        self.assertTrue(value_cnt == 0,
         value_cnt = self.env['ir.values'].search(
             [('value', '=', mass_action_id)], count=True)
+        self.assertEqual(value_cnt, 0,
                         "Sidebar action must be removed when mass"
                         " editing is unlinked.")
 
@@ -179,8 +179,8 @@ class TestMassEditing(common.TransactionCase):
         """
         uninstall_hook(self.cr, registry)
         mass_action_id = "ir.actions.act_window," + str(self.mass.id)
-        self.assertTrue(value_cnt == 0,
-                        "Sidebar action must be removed when mass"
-                        " editing module is uninstalled.")
         value_cnt = self.env['ir.values'].search(
             [('value', '=', mass_action_id)], count=True)
+        self.assertEqual(value_cnt, 0,
+                         "Sidebar action must be removed when mass"
+                         " editing module is uninstalled.")

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -123,11 +123,11 @@ class TestMassEditing(common.TransactionCase):
         """
         # Remove m2m categories
         vals = {
-            'selection__category_id': 'remove_m2m',
+            'selection__category_id': 'clear',
         }
         self._apply_action(self.partner, vals)
-        self.assertNotEqual(self.partner.category_id, False,
-                            'Partner\'s category should be removed.')
+        self.assertEqual(len(self.partner.category_id), 0,
+                         'All partner\'s categories should be removed.')
         # Add m2m categories
         dist_categ_id = self.env.ref('base.res_partner_category_13').id
         vals = {
@@ -141,6 +141,18 @@ class TestMassEditing(common.TransactionCase):
         res = wiz_action.action_apply()
         self.assertEqual(res['type'], 'ir.actions.act_window_close',
                         'IR Action must be window close.')
+
+    def test_mass_edit_remove_single_m2m_value(self):
+        original_categories = self.partner.category_id
+        categories_to_remove = self.partner.category_id[:2]
+        vals = {
+            'selection__category_id': 'remove_value',
+            'category_id': [[6, 0, categories_to_remove.ids]]
+        }
+        self._apply_action(self.partner, vals)
+        self.assertEqual(
+            self.partner.category_id, original_categories-categories_to_remove,
+            'Only some specific partner categories should be removed')
 
     def test_mass_edit_copy(self):
         """

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -73,6 +73,8 @@ class MassEditingWizard(models.TransientModel):
                         'nolabel': '1',
                         'attrs': ("{'invisible': [('selection__" +
                                   field.name + "', '=', 'clear')]}"),
+                        'modifiers': ('{"invisible": [["selection__' +
+                                      field.name + '", "=", "clear"]]}'),
                     })
                 elif field.ttype == "one2many":
                     all_fields["selection__" + field.name] = {
@@ -99,6 +101,8 @@ class MassEditingWizard(models.TransientModel):
                         'nolabel': '1',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "', '=', 'remove')]}"),
+                        'modifiers': ('{"invisible":[["selection__' +
+                                      field.name + '", "=", "remove"]]}'),
                     })
                 elif field.ttype == "many2one":
                     all_fields["selection__" + field.name] = {
@@ -121,6 +125,8 @@ class MassEditingWizard(models.TransientModel):
                         'colspan': '4',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "', '=', 'remove')]}"),
+                        'modifiers': ('{"invisible":[("selection__' +
+                                      field.name + '", "=", "remove")]}'),
                     })
                 elif field.ttype == "char":
                     all_fields["selection__" + field.name] = {
@@ -142,6 +148,8 @@ class MassEditingWizard(models.TransientModel):
                         'nolabel': '1',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "','=','remove')]}"),
+                        'modifiers': ('{"invisible":[("selection__' +
+                                      field.name + '","=","remove")]}'),
                         'colspan': '4',
                     })
                 elif field.ttype == 'selection':
@@ -160,6 +168,8 @@ class MassEditingWizard(models.TransientModel):
                         'colspan': '4',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "', '=', 'remove')]}"),
+                        'modifiers': ('{"invisible":[("selection__' +
+                                      field.name + '", "=", "remove")]}'),
                     })
                     all_fields[field.name] = {
                         'type': field.ttype,
@@ -196,6 +206,8 @@ class MassEditingWizard(models.TransientModel):
                             'nolabel': '1',
                             'attrs': ("{'invisible':[('selection__" +
                                       field.name + "','=','remove')]}"),
+                            'modifiers': ('{"invisible":[("selection__' +
+                                          field.name + '","=","remove")]}'),
                         })
                     else:
                         all_fields["selection__" + field.name] = {
@@ -212,6 +224,8 @@ class MassEditingWizard(models.TransientModel):
                             'nolabel': '1',
                             'attrs': ("{'invisible':[('selection__" +
                                       field.name + "','=','remove')]}"),
+                            'modifiers': ('{"invisible":[("selection__' +
+                                          field.name + '","=","remove")]}'),
                             'colspan': '4',
                         })
             # Patch fields with required extra data

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -125,8 +125,8 @@ class MassEditingWizard(models.TransientModel):
                         'colspan': '4',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "', '=', 'remove')]}"),
-                        'modifiers': ('{"invisible":[("selection__' +
-                                      field.name + '", "=", "remove")]}'),
+                        'modifiers': ('{"invisible":[["selection__' +
+                                      field.name + '", "=", "remove"]]}'),
                     })
                 elif field.ttype == "char":
                     all_fields["selection__" + field.name] = {
@@ -148,8 +148,8 @@ class MassEditingWizard(models.TransientModel):
                         'nolabel': '1',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "','=','remove')]}"),
-                        'modifiers': ('{"invisible":[("selection__' +
-                                      field.name + '","=","remove")]}'),
+                        'modifiers': ('{"invisible":[["selection__' +
+                                      field.name + '","=","remove"]]}'),
                         'colspan': '4',
                     })
                 elif field.ttype == 'selection':
@@ -168,8 +168,8 @@ class MassEditingWizard(models.TransientModel):
                         'colspan': '4',
                         'attrs': ("{'invisible':[('selection__" +
                                   field.name + "', '=', 'remove')]}"),
-                        'modifiers': ('{"invisible":[("selection__' +
-                                      field.name + '", "=", "remove")]}'),
+                        'modifiers': ('{"invisible":[["selection__' +
+                                      field.name + '", "=", "remove"]]}'),
                     })
                     all_fields[field.name] = {
                         'type': field.ttype,
@@ -206,8 +206,8 @@ class MassEditingWizard(models.TransientModel):
                             'nolabel': '1',
                             'attrs': ("{'invisible':[('selection__" +
                                       field.name + "','=','remove')]}"),
-                            'modifiers': ('{"invisible":[("selection__' +
-                                          field.name + '","=","remove")]}'),
+                            'modifiers': ('{"invisible":[["selection__' +
+                                          field.name + '","=","remove"]]}'),
                         })
                     else:
                         all_fields["selection__" + field.name] = {
@@ -224,8 +224,8 @@ class MassEditingWizard(models.TransientModel):
                             'nolabel': '1',
                             'attrs': ("{'invisible':[('selection__" +
                                       field.name + "','=','remove')]}"),
-                            'modifiers': ('{"invisible":[("selection__' +
-                                          field.name + '","=","remove")]}'),
+                            'modifiers': ('{"invisible":[["selection__' +
+                                          field.name + '","=","remove"]]}'),
                             'colspan': '4',
                         })
             # Patch fields with required extra data

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Serpent Consulting Services Pvt. Ltd. (support@serpentcs.com)
+# © 2017 Leonardo Donelli @ MONK Software (<leonardo.donelli@monksoftware.it>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from lxml import etree

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -47,9 +47,12 @@ class MassEditingWizard(models.TransientModel):
                     all_fields["selection__" + field.name] = {
                         'type': 'selection',
                         'string': field_info[field.name]['string'],
-                        'selection': [('set', 'Set'),
-                                      ('remove_m2m', 'Remove'),
-                                      ('add', 'Add')]
+                        'selection': [
+                            ('set', 'Set'),
+                            ('clear', 'Clear (remove all values)'),
+                            ('remove_value', 'Remove specific values'),
+                            ('add', 'Add')
+                        ],
                     }
                     xml_group = etree.SubElement(xml_group, 'group', {
                         'colspan': '6',
@@ -69,13 +72,17 @@ class MassEditingWizard(models.TransientModel):
                         'colspan': '6',
                         'nolabel': '1',
                         'attrs': ("{'invisible': [('selection__" +
-                                  field.name + "', '=', 'remove_m2m')]}"),
+                                  field.name + "', '=', 'clear')]}"),
                     })
                 elif field.ttype == "one2many":
                     all_fields["selection__" + field.name] = {
                         'type': 'selection',
                         'string': field_info[field.name]['string'],
-                        'selection': [('set', 'Set'), ('remove', 'Remove')],
+                        'selection': [
+                            ('set', 'Set'),
+                            ('remove', 'Clear'),
+                            ('remove_value', 'Remove specific values'),
+                        ],
                     }
                     all_fields[field.name] = {
                         'type': field.ttype,
@@ -91,7 +98,7 @@ class MassEditingWizard(models.TransientModel):
                         'colspan': '6',
                         'nolabel': '1',
                         'attrs': ("{'invisible':[('selection__" +
-                                  field.name + "', '=', 'remove_o2m')]}"),
+                                  field.name + "', '=', 'remove')]}"),
                     })
                 elif field.ttype == "many2one":
                     all_fields["selection__" + field.name] = {
@@ -245,8 +252,13 @@ class MassEditingWizard(models.TransientModel):
                         values.update({split_key: vals.get(split_key, False)})
                     elif val == 'remove':
                         values.update({split_key: False})
-                    elif val == 'remove_m2m':
+                    elif val == 'clear':
                         values.update({split_key: [(5, 0, [])]})
+                    elif val == 'remove_value':
+                        x2m_list = []
+                        for x2m_id in vals.get(split_key, False)[0][2]:
+                            x2m_list.append((3, x2m_id, False))
+                        values.update({split_key: x2m_list})
                     elif val == 'add':
                         m2m_list = []
                         for m2m_id in vals.get(split_key, False)[0][2]:


### PR DESCRIPTION
Allow to remove only specific selectable values when mass editing one2many
and many2many fields.

For example, if mass editing the public categories of 3 products:
 - Product A: Snacks, Vegan, Gluten free
 - Product B: Cheese, Gluten Free, Gourmet
 - Product C: Wine, Drinks, Gluten Free

You can create a mass editing for the field, choose 'Remove specific values'
in the wizard, and select the 'Vegan' and 'Gluten Free' categories.
You will end up with:
 - Product A: Snacks
 - Product B: Cheese, Gourmet
 - Product C: Wine, Drinks

Additionally, when the selected operation type is `clear`/`remove`, correctly hide the values select field on the wizard, which helps to avoid confusion. (code to do that was already in place, but apparently the `attrs` attribute is not enough when building views in `fields_view_get`)