### PR TITLE
[FIX] Changed 'Contributors' of 'base_external_dbsource_firebird'

### DIFF
--- a/base_external_dbsource/README.rst
+++ b/base_external_dbsource/README.rst
@@ -70,7 +70,6 @@ Contributors
 * Daniel Reis <dreis.pt@hotmail.com>
 * Maxime Chambreuil <maxime.chambreuil@savoirfairelinux.com>
 * Gervais Naoussi <gervaisnaoussi@gmail.com>
-* Michell Stuttgart <michellstut@gmail.com>
 * Dave Lasley <dave@laslabs.com>
 
 Maintainer

--- a/base_external_dbsource_firebird/README.rst
+++ b/base_external_dbsource_firebird/README.rst
@@ -59,6 +59,7 @@ Contributors
 * Daniel Reis <dreis.pt@hotmail.com>
 * Maxime Chambreuil <maxime.chambreuil@savoirfairelinux.com>
 * Gervais Naoussi <gervaisnaoussi@gmail.com>
+* Michell Stuttgart <michellstut@gmail.com>
 * Dave Lasley <dave@laslabs.com>
 
 Maintainer


### PR DESCRIPTION
* I Removed my name from *base_external_dbsource* contributors.
* Add my name in *base_external_dbsource_firebird* contributors, because *firebird* database support was added for me. This is PR where *firebird* support was added. https://github.com/OCA/server-tools/pull/623