### PR TITLE
9.0 mass editing fix missing views

### DIFF
--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -62,7 +62,7 @@ class MassObject(models.Model):
             'src_model': src_obj,
             'view_type': 'form',
             'context': "{'mass_editing_object' : %d}" % (self.id),
-            'view_mode': 'form, tree',
+            'view_mode': 'form,tree',
             'target': 'new',
             'auto_refresh': 1,
         }).id

--- a/mass_editing/tests/test_mass_editing.py
+++ b/mass_editing/tests/test_mass_editing.py
@@ -80,6 +80,10 @@ class TestMassEditing(common.TransactionCase):
         result = self.mass_wiz_obj.with_context(ctx).fields_view_get()
         self.assertTrue(result.get('arch'),
                         'Fields view get must return architecture.')
+        fields = result.get("fields")
+        self.assertTrue(fields)
+        for name, values in fields.items():
+            self.assertTrue(isinstance(values["views"], dict))
 
     def test_onchange_model(self):
         """Test whether onchange model_id returns model_id in list"""

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -207,6 +207,9 @@ class MassEditingWizard(models.TransientModel):
                                       field.name + "','=','remove')]}"),
                             'colspan': '4',
                         })
+            # Patch fields with required extra data
+            for field in all_fields.values():
+                field.setdefault("views", {})
             etree.SubElement(xml_form, 'separator', {
                 'string': '',
                 'colspan': '6',


### PR DESCRIPTION
A wrong view space resulted in frontend searching for ` tree` view, which of course does not exist.

Also before this patch, if you created a mass editing definition that included a *2many object and then opened the wizard, you got this exception:

    Uncaught TypeError: Cannot read property 'list' of undefined

    http://localhost/web/static/src/js/views/form_view.js:488
    Traceback:
    TypeError: Cannot read property 'list' of undefined
        at http://localhost/web/static/src/js/views/form_view.js:488:30
        at Function._.each._.forEach (http://localhost/web/static/lib/underscore/underscore.js:150:9)
        at http://localhost/web/static/src/js/views/form_view.js:486:19
        at Function._.each._.forEach (http://localhost/web/static/lib/underscore/underscore.js:150:9)
        at Class._build_onchange_specs (http://localhost/web/static/src/js/views/form_view.js:473:11)
        at Class.do_onchange (http://localhost/web/static/src/js/views/form_view.js:523:18)
        at Array.<anonymous> (http://localhost/web/static/src/js/views/form_view.js:377:26)
        at fire (http://localhost/web/static/lib/jquery/jquery.js:3119:58)
        at Object.fireWith [as resolveWith] (http://localhost/web/static/lib/jquery/jquery.js:3231:49)
        at Object.<anonymous> (http://localhost/web/static/lib/jquery/jquery.js:3360:58)

@Tecnativa