### PR TITLE
Fix menu in base_exception

### DIFF
--- a/base_exception/views/base_exception_view.xml
+++ b/base_exception/views/base_exception_view.xml
@@ -46,6 +46,6 @@
                   <field name="context">{'active_test': False}</field>
               </record>
 
-        <menuitem action="action_exception_rule_tree" id="menu_action_exception" name="Exceptions" parent="base.menu_custom" sequence="90" />
+        <menuitem action="action_exception_rule_tree" id="menu_action_exception" parent="base.menu_custom" sequence="90" />
 
 </odoo>

--- a/base_exception/views/base_exception_view.xml
+++ b/base_exception/views/base_exception_view.xml
@@ -46,6 +46,6 @@
                   <field name="context">{'active_test': False}</field>
               </record>
 
-        <menuitem action="action_exception_rule_tree" id="menu_action_exception" parent="base_setup.menu_config" />
+        <menuitem action="action_exception_rule_tree" id="menu_action_exception" name="Exceptions" parent="base.menu_custom" sequence="90" />
 
 </odoo>


### PR DESCRIPTION
The placement of this menu item is causing this error. https://github.com/OCA/server-tools/pull/776#issuecomment-290450549

In adittion it disables all access to the general settings menu...

I suggest placing it unter technical settings, right at the bottom of it.