### PR TITLE
[8.0][ADD] Add list manipulation operations to base_view_inheritance_extension.

### DIFF
--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -6,7 +6,8 @@
 Extended view inheritance
 =========================
 
-This module was written to make it simple to add custom operators for view inheritance.
+This module was written to make it simple to add custom operators for view
+inheritance.
 
 Usage
 =====
@@ -24,7 +25,8 @@ Change a python dictionary (context for example)
         $new_value
     </attribute>
 
-Note that views are subject to evaluation of xmlids anyways, so if you need to refer to some xmlid, say ``%(xmlid)s``.
+Note that views are subject to evaluation of xmlids anyways, so if you need
+to refer to some xmlid, say ``%(xmlid)s``.
 
 Move an element in the view
 ---------------------------
@@ -33,13 +35,30 @@ Move an element in the view
 
     <xpath expr="$xpath" position="move" target="$targetxpath" />
 
-This can also be used to wrap some element into another, create the target element first, then move the node youwant to wrap there.
+This can also be used to wrap some element into another, create the target
+element first, then move the node youwant to wrap there.
+
+Add to values in a list (states for example)
+--------------------------------------------
+
+.. code-block:: xml
+
+    <attribute name="$attribute" operation="list_add">
+        $new_value(s)
+    </attribute>
+
+Remove values from a list (states for example)
+----------------------------------------------
+
+.. code-block:: xml
+
+    <attribute name="$attribute" operation="list_remove">
+        $remove_value(s)
+    </attribute>
 
 Known issues / Roadmap
 ======================
 
-* add ``<attribute operation="python_list_add">$value</attribute>``
-* add ``<attribute operation="python_list_remove">$index</attribute>``
 * add ``<attribute operation="json_dict" key="$key">$value</attribute>``
 * support ``<xpath expr="$xpath" position="move" target="xpath" target_position="position" />``
 * support an ``eval`` attribute for our new node types
@@ -58,7 +77,8 @@ Credits
 Images
 ------
 
-* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+* Odoo Community Association:
+  `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------
@@ -66,7 +86,12 @@ Contributors
 * Holger Brunn <hbrunn@therp.nl>
 * Ronald Portier <rportier@therp.nl>
 
-Do not contact contributors directly about help with questions or problems concerning this addon, but use the `community mailing list <mailto:community@mail.odoo.com>`_ or the `appropriate specialized mailinglist <https://odoo-community.org/groups>`_ for help, and the bug tracker linked in `Bug Tracker`_ above for technical issues.
+Do not contact contributors directly about help with questions or problems
+concerning this addon, but use the
+`community mailing list <mailto:community@mail.odoo.com>`_ or the
+`appropriate specialized mailinglist <https://odoo-community.org/groups>`_
+for help, and the bug tracker linked in `Bug Tracker`_ above for
+technical issues.
 
 Maintainer
 ----------

--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -64,6 +64,7 @@ Contributors
 ------------
 
 * Holger Brunn <hbrunn@therp.nl>
+* Ronald Portier <rportier@therp.nl>
 
 Do not contact contributors directly about help with questions or problems concerning this addon, but use the `community mailing list <mailto:community@mail.odoo.com>`_ or the `appropriate specialized mailinglist <https://odoo-community.org/groups>`_ for help, and the bug tracker linked in `Bug Tracker`_ above for technical issues.
 

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -122,3 +122,21 @@ class IrUiView(models.Model):
         )
         target_node.append(node)
         return source
+
+    @api.model
+    def inheritance_handler_attributes_list_add(
+        self, source, specs, inherit_id
+    ):
+        """Implement
+        <$node position="attributes">
+            <attribute name="$attribute" operation="list_add">
+                $new_value
+            </attribute>
+        </$node>"""
+        node = self.locate_node(source, specs)
+        for attribute_node in specs:
+            attribute_name = attribute_node.get('name')
+            old_value = node.get(attribute_name) or ''
+            new_value = old_value + ',' + attribute_node.text
+            node.attrib[attribute_name] = new_value
+        return source

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -138,9 +138,7 @@ class IrUiView(models.Model):
             attribute_name = attribute_node.get('name')
             old_value = node.get(attribute_name) or ''
             new_value = old_value + ',' + attribute_node.text
-            node.attrib[attribute_name] = ','.join(filter(
-                None, old_value.split(',') + attribute_node.text.split(','))
-            )
+            node.attrib[attribute_name] = new_value
         return source
 
     @api.model

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -138,5 +138,26 @@ class IrUiView(models.Model):
             attribute_name = attribute_node.get('name')
             old_value = node.get(attribute_name) or ''
             new_value = old_value + ',' + attribute_node.text
-            node.attrib[attribute_name] = new_value
+            node.attrib[attribute_name] = ','.join(filter(
+                None, old_value.split(',') + attribute_node.text.split(','))
+            )
+        return source
+
+    @api.model
+    def inheritance_handler_attributes_list_remove(
+        self, source, specs, inherit_id
+    ):
+        """Implement
+        <$node position="attributes">
+            <attribute name="$attribute" operation="list_remove">
+                $value_to_remove
+            </attribute>
+        </$node>"""
+        node = self.locate_node(source, specs)
+        for attribute_node in specs:
+            attribute_name = attribute_node.get('name')
+            old_values = (node.get(attribute_name) or '').split(',')
+            remove_values = attribute_node.text.split(',')
+            new_values = [x for x in old_values if x not in remove_values]
+            node.attrib[attribute_name] = ','.join(filter(None, new_values))
         return source

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -6,6 +6,7 @@ from openerp.tests.common import TransactionCase
 
 
 class TestBaseViewInheritanceExtension(TransactionCase):
+
     def test_base_view_inheritance_extension(self):
         view_id = self.env.ref('base.view_partner_form').id
         fields_view_get = self.env['res.partner'].fields_view_get(
@@ -28,3 +29,26 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             view.xpath('//field[@name="child_ids"]')[0].getparent(),
             view.xpath('//page[@name="my_new_page"]')[0]
         )
+
+    def test_list_operations(self):
+        view_model = self.env['ir.ui.view']
+        inherit_id = self.env.ref('base.view_partner_form').id
+        source = etree.fromstring(
+            """<form><button name="test" states="draft,open"/></form>"""
+        )
+        specs = etree.fromstring(
+            """\
+            <button name="test" position="attributes">
+                <attribute
+                    name="states"
+                    operation="list_add"
+                    >valid</attribute>
+            </button>
+            """
+        )
+        modified_source = view_model.inheritance_handler_attributes_list_add(
+            source, specs, inherit_id
+        )
+        button_node = modified_source.xpath('//button[@name="test"]')[0]
+        # verify list was extended
+        self.assertEqual(button_node.attrib['states'], 'draft,open,valid')

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -36,6 +36,7 @@ class TestBaseViewInheritanceExtension(TransactionCase):
         source = etree.fromstring(
             """<form><button name="test" states="draft,open"/></form>"""
         )
+        # extend with single value
         specs = etree.fromstring(
             """\
             <button name="test" position="attributes">
@@ -50,5 +51,45 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             source, specs, inherit_id
         )
         button_node = modified_source.xpath('//button[@name="test"]')[0]
-        # verify list was extended
-        self.assertEqual(button_node.attrib['states'], 'draft,open,valid')
+        self.assertEqual(
+            button_node.attrib['states'],
+            'draft,open,valid'
+        )
+        # extend with list of values
+        specs = etree.fromstring(
+            """\
+            <button name="test" position="attributes">
+                <attribute
+                    name="states"
+                    operation="list_add"
+                    >payable,paid</attribute>
+            </button>
+            """
+        )
+        modified_source = view_model.inheritance_handler_attributes_list_add(
+            source, specs, inherit_id
+        )
+        button_node = modified_source.xpath('//button[@name="test"]')[0]
+        self.assertEqual(
+            button_node.attrib['states'],
+            'draft,open,valid,payable,paid'
+        )
+        # remove list of values
+        specs = etree.fromstring(
+            """\
+            <button name="test" position="attributes">
+                <attribute
+                    name="states"
+                    operation="list_remove"
+                    >open,payable</attribute>
+            </button>
+            """
+        )
+        modified_source = view_model.inheritance_handler_attributes_list_add(
+            source, specs, inherit_id
+        )
+        button_node = modified_source.xpath('//button[@name="test"]')[0]
+        self.assertEqual(
+            button_node.attrib['states'],
+            'draft,valid,paid'
+        )

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -30,11 +30,15 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             view.xpath('//page[@name="my_new_page"]')[0]
         )
 
-    def test_list_operations(self):
+    def test_list_add(self):
         view_model = self.env['ir.ui.view']
         inherit_id = self.env.ref('base.view_partner_form').id
         source = etree.fromstring(
-            """<form><button name="test" states="draft,open"/></form>"""
+            """\
+            <form>
+                <button name="test" states="draft,open"/>
+            </form>
+            """
         )
         # extend with single value
         specs = etree.fromstring(
@@ -47,9 +51,10 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             </button>
             """
         )
-        modified_source = view_model.inheritance_handler_attributes_list_add(
-            source, specs, inherit_id
-        )
+        modified_source = \
+            view_model.inheritance_handler_attributes_list_add(
+                source, specs, inherit_id
+            )
         button_node = modified_source.xpath('//button[@name="test"]')[0]
         self.assertEqual(
             button_node.attrib['states'],
@@ -66,13 +71,25 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             </button>
             """
         )
-        modified_source = view_model.inheritance_handler_attributes_list_add(
-            source, specs, inherit_id
-        )
+        modified_source = \
+            view_model.inheritance_handler_attributes_list_add(
+                source, specs, inherit_id
+            )
         button_node = modified_source.xpath('//button[@name="test"]')[0]
         self.assertEqual(
             button_node.attrib['states'],
             'draft,open,valid,payable,paid'
+        )
+
+    def test_list_remove(self):
+        view_model = self.env['ir.ui.view']
+        inherit_id = self.env.ref('base.view_partner_form').id
+        source = etree.fromstring(
+            """\
+            <form>
+                <button name="test" states="draft,open,valid,payable,paid"/>
+            </form>
+            """
         )
         # remove list of values
         specs = etree.fromstring(
@@ -85,9 +102,10 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             </button>
             """
         )
-        modified_source = view_model.inheritance_handler_attributes_list_add(
-            source, specs, inherit_id
-        )
+        modified_source = \
+            view_model.inheritance_handler_attributes_list_remove(
+                source, specs, inherit_id
+            )
         button_node = modified_source.xpath('//button[@name="test"]')[0]
         self.assertEqual(
             button_node.attrib['states'],


### PR DESCRIPTION
list_add might be used to change a value for an attribute for instance from states='draft,open' to 'draft,open,valid'. list_remove can be used to change for instance 'draft,proforma,open' to 'draft,open'.