### PR TITLE
[ADD] show the traceback, don't expect all exceptions to fill value

### DIFF
--- a/scheduler_error_mailer/ir_cron.py
+++ b/scheduler_error_mailer/ir_cron.py
@@ -21,11 +21,12 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
+import logging
+import sys
+import traceback
 from openerp import SUPERUSER_ID
 from openerp.osv import orm, fields
 from openerp.tools.translate import _
-import logging
 
 
 _logger = logging.getLogger(__name__)
@@ -57,6 +58,9 @@ class ir_cron(orm.Model):
             context = {
                 'job_exception': job_exception,
                 'dbname': cr.dbname,
+                'traceback': '\n'.join(
+                    traceback.format_exception(*sys.exc_info())
+                ),
             }
 
             _logger.debug("Sending scheduler error email with context=%s",

--- a/scheduler_error_mailer/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/ir_cron_email_tpl.xml
@@ -18,7 +18,7 @@
     <field name="body_html"><![CDATA[
 <div style="font-family: 'Lucida Grande', Ubuntu, Arial, Verdana, sans-serif; font-size: 12px; color: rgb(34, 34, 34); background-color: #FFF; ">
 
-<p>OpenERP tried to run the scheduler <em>${object.name or ''}</em> in the database <em>${ctx.get('dbname')}</em> but it failed. Here is the error message :</p>
+<p>Odoo tried to run the scheduler <em>${object.name or ''}</em> in the database <em>${ctx.get('dbname')}</em> but it failed. Here is the error message :</p>
 
 <strong>
 ${ctx.get('job_exception') and ctx.get('job_exception').value or ctx.get('job_exception') or 'Failed to get the error message from the context.'|e}

--- a/scheduler_error_mailer/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/ir_cron_email_tpl.xml
@@ -21,8 +21,12 @@
 <p>OpenERP tried to run the scheduler <em>${object.name or ''}</em> in the database <em>${ctx.get('dbname')}</em> but it failed. Here is the error message :</p>
 
 <strong>
-${ctx.get('job_exception') and ctx.get('job_exception').value or 'Failed to get the error message from the context.'}
+${ctx.get('job_exception') and ctx.get('job_exception').value or ctx.get('job_exception') or 'Failed to get the error message from the context.'|e}
 </strong>
+
+<pre>
+${ctx.get('traceback')|e}
+</pre>
 
 <p>You may check the logs of the Odoo server to get more information about this failure.</p>
 


### PR DESCRIPTION
the error messages are a lot more helpful for a programmer if they contain the traceback of the exception. I also added some HTML escaping and print the exception itself if its value property is Falsy