### PR TITLE
[FIX] mail_environment must not depend on server_environment_files

### DIFF
--- a/mail_environment/__manifest__.py
+++ b/mail_environment/__manifest__.py
@@ -12,7 +12,6 @@
     'website': 'http://odoo-community.org',
     'depends': ['fetchmail',
                 'server_environment',
-                'server_environment_files',
                 ],
     'data': ['views/fetchmail_server_views.xml',
              ],


### PR DESCRIPTION
Depending on server_environment is enough because server_environment_files is itself a dependency of server_environment.

Otherwise we'd need [this like in 9.0](https://github.com/OCA/server-tools/blob/14396ca2afbc7280caa552be5cb3925d420a0109/setup/mail_environment/setup.py#L5-L11).