### PR TITLE
[FIX][10.0] Broken icon in auto_backup

### DIFF
--- a/auto_backup/view/db_backup_view.xml
+++ b/auto_backup/view/db_backup_view.xml
@@ -31,7 +31,7 @@
                             name="action_sftp_test_connection"
                             type="object"
                             string="Test SFTP Connection"
-                            icon="gtk-network"/>
+                            icon="fa-television"/>
                     </group>
                 </div>
                 <separator string="Help" colspan="2"/>


### PR DESCRIPTION
On button "Test SFTP Connection", the icon is actually not displayed.
The proposed icon is the same as the one used by standard Odoo (see button "Test Connection" in  `base` module).