### PR TITLE
[FIX] auto_backup: SSHException on SFTP test button

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -126,7 +126,9 @@ class DbBackup(models.Model):
             # Just open and close the connection
             with self.sftp_connection():
                 raise exceptions.Warning(_("Connection Test Succeeded!"))
-        except (pysftp.CredentialException, pysftp.ConnectionException):
+        except (pysftp.CredentialException,
+                pysftp.ConnectionException,
+                pysftp.SSHException):
             _logger.info("Connection Test Failed!", exc_info=True)
             raise exceptions.Warning(_("Connection Test Failed!"))
 


### PR DESCRIPTION
When pressing the "Test SFTP Connection", sometimes the user does not get any warning.

This is our case, looking at the log:

```

2017-05-22 06:57:07,132 1016 ERROR database odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
  File "/opt/odoo/odoo-server/odoo/http.py", line 638, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/odoo-server/odoo/http.py", line 675, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/odoo-server/odoo/http.py", line 331, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/odoo-server/odoo/service/model.py", line 119, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/odoo-server/odoo/http.py", line 324, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/odoo-server/odoo/http.py", line 933, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/odoo-server/odoo/http.py", line 504, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/odoo-server/addons/web/controllers/main.py", line 886, in call_button
    action = self._call_kw(model, method, args, {})
  File "/opt/odoo/odoo-server/addons/web/controllers/main.py", line 874, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo-server/odoo/api.py", line 681, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo-server/odoo/api.py", line 672, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/oca/addons/auto_backup/models/db_backup.py", line 127, in action_sftp_test_connection
    with self.sftp_connection():
  File "/opt/odoo/oca/addons/auto_backup/models/db_backup.py", line 286, in sftp_connection
    return pysftp.Connection(**params)
  File "/usr/local/lib/python2.7/dist-packages/pysftp/__init__.py", line 132, in __init__
    self._tconnect['hostkey'] = self._cnopts.get_hostkey(host)
  File "/usr/local/lib/python2.7/dist-packages/pysftp/__init__.py", line 71, in get_hostkey
    raise SSHException("No hostkey for host %s found." % host)
SSHException: No hostkey for host xxx.xxx.xxx.xxx found.

```

With this PR I propose to handle also the SSHException while testing the SFTP Connection.
This way the user will be notified that a test failure occurred.
