### PR TITLE
[10.0][FIX] Crash in base_user_role when role_id is not set on res.users.role.line

### DIFF
--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -44,8 +44,9 @@ class ResUsers(models.Model):
                 lambda rec: rec.is_enabled)
             for role_line in role_lines:
                 role = role_line.role_id
-                group_ids.append(role.group_id.id)
-                group_ids.extend(role.implied_ids.ids)
+                if role:
+                    group_ids.append(role.group_id.id)
+                    group_ids.extend(role.implied_ids.ids)
             group_ids = list(set(group_ids))    # Remove duplicates IDs
             vals = {
                 'groups_id': [(6, 0, group_ids)],

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -12,7 +12,7 @@
             <page string="Roles">
                 <field name="role_line_ids" nolabel="1">
                     <tree editable="bottom" colors="grey: not is_enabled;">
-                        <field name="role_id"/>
+                        <field name="role_id" required="1"/>
                         <field name="date_from"/>
                         <field name="date_to"/>
                         <field name="is_enabled"/>


### PR DESCRIPTION
To get the crash:
1) login as admin
2) Edit the "demo" user
3) In the Role tab, add a new line and leave the Role field empty
You get this crash:

```
2017-06-12 21:10:25,105 6068 INFO o0_test1 odoo.sql_db: bad query:  INSERT INTO res_groups_users_rel (uid, gid)
                        (SELECT a, b FROM unnest(ARRAY[5]) AS a, unnest(ARRAY[32, 1, false, 65, 71, 47, 26]) AS b)
                        EXCEPT (SELECT uid, gid FROM res_groups_users_rel WHERE uid IN (5))
                    
2017-06-12 21:10:25,106 6068 ERROR o0_test1 odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
  File "/home/alexis/new_boite/dev/odoo0/odoo/http.py", line 638, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/alexis/new_boite/dev/odoo0/odoo/http.py", line 675, in dispatch
    result = self._call_function(**self.params)
  File "/home/alexis/new_boite/dev/odoo0/odoo/http.py", line 331, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/alexis/new_boite/dev/odoo0/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/alexis/new_boite/dev/odoo0/odoo/http.py", line 324, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/alexis/new_boite/dev/odoo0/odoo/http.py", line 933, in __call__
    return self.method(*args, **kw)
  File "/home/alexis/new_boite/dev/odoo0/odoo/http.py", line 504, in response_wrap
    response = f(*args, **kw)
  File "/home/alexis/new_boite/dev/odoo0/addons/web/controllers/main.py", line 885, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/alexis/new_boite/dev/odoo0/addons/web/controllers/main.py", line 877, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/alexis/new_boite/dev/odoo0/odoo/api.py", line 681, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/home/alexis/new_boite/dev/odoo0/odoo/api.py", line 672, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/alexis/new_boite/dev/odoo0/addons/hr/models/res_users.py", line 17, in write
    result = super(User, self).write(vals)
  File "/home/alexis/new_boite/dev/odoo0/addons/mail/models/res_users.py", line 56, in write
    write_res = super(Users, self).write(vals)
  File "/home/alexis/new_boite/dev/server-tools0/base_user_role/models/user.py", line 31, in write
    self.sudo().set_groups_from_roles()
  File "/home/alexis/new_boite/dev/server-tools0/base_user_role/models/user.py", line 54, in set_groups_from_roles
    super(ResUsers, user).write(vals)
  File "/home/alexis/new_boite/dev/odoo0/odoo/addons/base/res/res_users.py", line 802, in write
    res = super(UsersView, self).write(values)
  File "/home/alexis/new_boite/dev/odoo0/odoo/addons/base/res/res_users.py", line 640, in write
    res = super(UsersImplied, self).write(values)
  File "/home/alexis/new_boite/dev/odoo0/odoo/addons/base/res/res_users.py", line 355, in write
    res = super(Users, self).write(values)
  File "/home/alexis/new_boite/dev/odoo0/odoo/models.py", line 3564, in write
    self._write(old_vals)
  File "/home/alexis/new_boite/dev/odoo0/odoo/models.py", line 3687, in _write
    field.write(self.with_context(rel_context), vals[name])
  File "/home/alexis/new_boite/dev/odoo0/odoo/fields.py", line 2402, in write
    link(act[2])
  File "/home/alexis/new_boite/dev/odoo0/odoo/fields.py", line 2367, in link
    cr.execute(query, (records.ids, list(sub_ids), tuple(records.ids)))
  File "/home/alexis/new_boite/dev/odoo0/odoo/sql_db.py", line 141, in wrapper
    return f(self, *args, **kwargs)
  File "/home/alexis/new_boite/dev/odoo0/odoo/sql_db.py", line 218, in execute
    res = self._obj.execute(query, params)
ProgrammingError: ARRAY types integer and boolean cannot be matched
LINE 2: ...b FROM unnest(ARRAY[5]) AS a, unnest(ARRAY[32, 1, false, 65,...
                                                             ^
```