### PR TITLE
[10.0] add new module to manage technical user on company

### DIFF
--- a/base_technical_user/README.rst
+++ b/base_technical_user/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+Base Technical User
+===================
+
+This module extends the functionality of company management.
+It allows you to bind a technical user on the company in order to use it in
+batch processes.
+
+The technical user must
+- be inactive to avoid login
+- be in the required groups depending of what you need to do
+
+Usage
+=====
+
+If you install the module, you will find a tab on the company form allowing
+to define the technical user.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/base_technical_user/__init__.py
+++ b/base_technical_user/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/base_technical_user/__manifest__.py
+++ b/base_technical_user/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': "Base Technical User",
+    'summary': """
+        Add a technical user parameter on the company """,
+    'author': 'ACSONE SA/NV, Odoo Community Association (OCA)',
+    'website': "http://acsone.eu",
+    'category': 'Hidden/Dependency',
+    'version': '10.0.1.0.0',
+    'license': 'AGPL-3',
+    'depends': [
+        'base',
+    ],
+    'data': [
+        'views/res_company_view.xml'
+    ],
+    'installable': True
+}

--- a/base_technical_user/models/__init__.py
+++ b/base_technical_user/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import res_company

--- a/base_technical_user/models/res_company.py
+++ b/base_technical_user/models/res_company.py
@@ -11,4 +11,4 @@ class ResCompany(models.Model):
         comodel_name="res.users",
         string="Technical User",
         help="This user can be used by process for technical purpose",
-        domain="[('company_id', '=', id), ('active', '=', False)]")
+        domain="[('company_id', '=', id)]")

--- a/base_technical_user/models/res_company.py
+++ b/base_technical_user/models/res_company.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models, fields
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    user_tech_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Technical User",
+        help="This user can be used by process for technical purpose",
+        domain="[('company_id', '=', id), ('active', '=', False)]")

--- a/base_technical_user/views/res_company_view.xml
+++ b/base_technical_user/views/res_company_view.xml
@@ -7,9 +7,9 @@
         <field name="priority">20</field>
         <field name="arch" type="xml">
             <xpath expr="//notebook/page[1]" position="after">
-                <page string="Configuration">
+                <page name="configuration" string="Configuration">
                     <group>
-                        <group string="Technical Parameters" groups="base.group_erp_manager">
+                        <group name="tech_param" string="Technical Parameters" groups="base.group_erp_manager">
                             <field name="user_tech_id"/>
                         </group>
                     </group>

--- a/base_technical_user/views/res_company_view.xml
+++ b/base_technical_user/views/res_company_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_company_view_form_inherit_base_technical_user" model="ir.ui.view">
+        <field name="name">res.company.form (base_technical_user)</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[1]" position="after">
+                <page string="Configuration">
+                    <group>
+                        <group string="Technical Parameters" groups="base.group_erp_manager">
+                            <field name="user_tech_id"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/base_technical_user/odoo/__init__.py
+++ b/setup/base_technical_user/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/base_technical_user/odoo/addons/__init__.py
+++ b/setup/base_technical_user/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/base_technical_user/odoo/addons/base_technical_user
+++ b/setup/base_technical_user/odoo/addons/base_technical_user
@@ -1,0 +1,1 @@
+../../../../base_technical_user

--- a/setup/base_technical_user/setup.py
+++ b/setup/base_technical_user/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Sometimes, when you launch batch processes, you don't want to use the current user for several reasons
- the current user can switch company before the end of the batch process
- you can encounter concurrent access error if the user works in the meantime

This module add a technical user on the company. You can use for exemple in cron process or in queue job.