### PR TITLE
[FIX] password_security: Fix password stored and token to reset password invalid

### DIFF
--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -20,7 +20,7 @@ class PasswordSecuritySession(Session):
             dict(map(operator.itemgetter('name', 'value'), fields))
         )
         user_id = request.env.user
-        user_id.check_password(new_password)
+        user_id._check_password(new_password)
         return super(PasswordSecuritySession, self).change_password(fields)
 
 
@@ -29,7 +29,7 @@ class PasswordSecurityHome(AuthSignupHome):
     def do_signup(self, qcontext):
         password = qcontext.get('password')
         user_id = request.env.user
-        user_id.check_password(password)
+        user_id._check_password(password)
         return super(PasswordSecurityHome, self).do_signup(qcontext)
 
     @http.route()

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -38,7 +38,7 @@ class ResUsers(models.Model):
     @api.multi
     def write(self, vals):
         if vals.get('password'):
-            self.check_password(vals['password'])
+            self._check_password(vals['password'])
             vals['password_write_date'] = fields.Datetime.now()
         return super(ResUsers, self).write(vals)
 
@@ -55,7 +55,7 @@ class ResUsers(models.Model):
             message.append('\n* ' + _('Numeric digit'))
         if company_id.password_special:
             message.append('\n* ' + _('Special character'))
-        if len(message):
+        if message:
             message = [_('Must contain the following:')] + message
         if company_id.password_length:
             message = [
@@ -65,7 +65,13 @@ class ResUsers(models.Model):
         return '\r'.join(message)
 
     @api.multi
-    def check_password(self, password):
+    def _check_password(self, password):
+        self._check_password_rules(password)
+        self._check_password_history(password)
+        return True
+
+    @api.multi
+    def _check_password_rules(self, password):
         self.ensure_one()
         if not password:
             return True
@@ -81,8 +87,6 @@ class ResUsers(models.Model):
             password_regex.append(r'(?=.*?\W)')
         password_regex.append('.{%d,}$' % company_id.password_length)
         if not re.search(''.join(password_regex), password):
-            self.env.cr.rollback()
-            self.invalidate_cache()
             raise PassError(self.password_match_message())
         return True
 
@@ -119,8 +123,6 @@ class ResUsers(models.Model):
             )
             delta = timedelta(hours=pass_min)
             if write_date + delta > datetime.now():
-                self.env.cr.rollback()
-                self.invalidate_cache()
                 raise PassError(
                     _('Passwords can only be reset every %d hour(s). '
                       'Please contact an administrator for assistance.') %
@@ -129,7 +131,7 @@ class ResUsers(models.Model):
         return True
 
     @api.multi
-    def _set_password(self, password):
+    def _check_password_history(self, password):
         """ It validates proposed password against existing history
         :raises: PassError on reused password
         """
@@ -144,13 +146,10 @@ class ResUsers(models.Model):
                 ]
             if recent_passes.filtered(
                     lambda r: crypt.verify(password, r.password_crypt)):
-                self.env.cr.rollback()
-                self.invalidate_cache()
                 raise PassError(
                     _('Cannot use the most recent %d passwords') %
                     rec_id.company_id.password_history
                 )
-        super(ResUsers, self)._set_password(password)
 
     @api.multi
     def _set_encrypted_password(self, encrypted):

--- a/password_security/tests/test_password_security_home.py
+++ b/password_security/tests/test_password_security_home.py
@@ -68,7 +68,7 @@ class TestPasswordSecurityHome(TransactionCase):
     def test_do_signup_check(self):
         """ It should check password on user """
         with self.mock_assets() as assets:
-            check_password = assets['request'].env.user.check_password
+            check_password = assets['request'].env.user._check_password
             check_password.side_effect = EndTestException
             with self.assertRaises(EndTestException):
                 self.password_security_home.do_signup(self.qcontext)

--- a/password_security/tests/test_password_security_session.py
+++ b/password_security/tests/test_password_security_session.py
@@ -40,7 +40,7 @@ class TestPasswordSecuritySession(TransactionCase):
     def test_change_password_check(self):
         """ It should check password on request user """
         with self.mock_assets() as assets:
-            check_password = assets['request'].env.user.check_password
+            check_password = assets['request'].env.user._check_password
             check_password.side_effect = EndTestException
             with self.assertRaises(EndTestException):
                 self.password_security_session.change_password(self.fields)

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -68,14 +68,14 @@ class TestResUsers(TransactionCase):
     def test_check_password_returns_true_for_valid_password(self):
         rec_id = self._new_record()
         self.assertTrue(
-            rec_id.check_password('asdQWE123$%^3'),
+            rec_id._check_password('asdQWE123$%^3'),
             'Password is valid but check failed.',
         )
 
     def test_check_password_raises_error_for_invalid_password(self):
         rec_id = self._new_record()
         with self.assertRaises(PassError):
-            rec_id.check_password('password')
+            rec_id._check_password('password')
 
     def test_save_password_crypt(self):
         rec_id = self._new_record()


### PR DESCRIPTION
Steps to reproduce issue:
1. Create a user with a valid password
2. Use the `Forget password` button
3. Use the same previous password

Saw:
Error of history password. Good!
Try to fix it your password and now the token to reset password is invalid. Wrong!
Check the fields user.password and is filled. Wrong!

Expected:
Error of history password and allow fix it and don't store user.password field.

Video:
[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/4PDz2djXuPU/0.jpg)](https://www.youtube.com/watch?v=4PDz2djXuPU)


If you don't want configure a email smtp apply the following patch:
```diff
diff --git a/addons/mail/models/mail_template.py b/addons/mail/models/mail_template.py
index 76d8ae741..316d96a3f 100644
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -560,6 +560,7 @@ class MailTemplate(models.Model):
                 updated with given values dict
            :returns: id of the mail.message that was created
         """
+        raise_exception=False
         self.ensure_one()
         Mail = self.env['mail.mail']
         Attachment = self.env['ir.attachment']  # TDE FIXME: should remove dfeault_type from context
```

The query executed from the video is:
`psql openerp_test -c "SELECT login FROM res_users WHERE password != ''"`
`psql openerp_test -c "UPDATE res_users SET password=Null"`

MERGER
=======
Please merge just one commit using merge & squash of github