### PR TITLE
[10.0][MIG] oauth_provider

### DIFF
--- a/oauth_provider/README.rst
+++ b/oauth_provider/README.rst
@@ -1,0 +1,142 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+OAuth Provider
+==============
+
+This module allows you to turn Odoo into an OAuth 2 provider.
+
+It's meant to provide the basic authentication feature, and some data access routes.
+But you are encouraged to create custom routes, in other modules, to give structured data for any specific need.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Install the oauthlib python module
+#. Install the module like any other in Odoo
+#. For the token retrieval to work on a multi-database instance, you should add this module in the server_wide_modules list
+
+Configuration
+=============
+
+This module requires you to configure two things :
+
+#. The scopes are used to define restricted data access
+#. The clients are used to declare applications that will be allowed to request tokens and data
+
+To configure scopes, you need to:
+
+#. Go to Settings > Users > OAuth Provider Scopes
+#. Create some scopes:
+
+ - The scope name and description will be displayed to the user on the authorization page.
+ - The code is the value provided by the OAuth clients to request access to the scope.
+ - The model defines which model the scope is linked to (access to user data, partners, sales orders, etc.).
+ - The filter allows you to determine which records will be accessible through this scope. No filter means all records of the model are accessible.
+ - The field names allows you to define which fields will be provided to the clients. An empty list only returns the id of accessible records.
+
+To configure clients, you need to:
+
+#. Go to Settings > Users > OAuth Provider Clients
+#. Create at least one client:
+
+ - The name will be displayed to the user on the authorization page.
+ - The client identifier is the value provided by the OAuth clients to request authorizations/tokens.
+ - The application type adapts the process to four pre-defined profiles:
+
+   - Web Application : Authorization Code Grant
+   - Mobile Application : Implicit Grant
+   - Legacy Application : Resource Owner Password Credentials Grant
+   - Backend Application : User Credentials Grant (not implemented yet)
+
+ - The skip authorization checkbox allows the client to skip the authorization page, and directly deliver a token without prompting the user (useful when the application is trusted).
+ - The allowed scopes list defines which data will be accessible by this client applicaton.
+ - The allowed redirect URIs must match the URI sent by the client, to avoid redirecting users to an unauthorized service. The first value in the list is the default redirect URI.
+
+For example, to configure an Odoo's *auth_oauth* module compatible client, you will enter these values :
+
+- Name : Anything you want
+- Client identifier : The identifier you want to give to this client
+- Application Type : Mobile Application (Odoo uses the implicit grant mode, which corresponds to the mobile application profile)
+- Allowed Scopes : Nothing required, but allowing access to current user's email and name is used by Odoo to fill user's information on signup
+- Allowed Redirect URIs : http://odoo.example.com/auth_oauth/signin
+
+Usage
+=====
+
+This module will allow OAuth clients to use your Odoo instance as an OAuth provider.
+
+Once configured, you must give these information to your client application :
+
+#. Client identifier : Identifies the application (to be able to check allowed scopes and redirect URIs)
+#. Allowed scopes : The codes of scopes allowed for this client
+#. URLs for the requests :
+
+  - Authorization request : http://odoo.example.com/oauth2/authorize
+  - Token request : http://odoo.example.com/oauth2/token
+  - Token information request : http://odoo.example.com/oauth2/tokeninfo
+     Parameters : access_token
+  - User information request : http://odoo.example.com/oauth2/userinfo
+     Parameters : access_token
+  - Any other model information request (depending on the scopes) : http://odoo.example.com/oauth2/otherinfo
+     Parameters : access_token and model
+
+For example, to configure the *auth_oauth* Odoo module as a client, you will enter these values :
+
+- Provider name : Anything you want
+- Client ID : The identifier of the client configured in your Odoo Provider instance
+- Body : Text displayed on Odoo's login page link
+- Authentication URL : http://odoo.example.com/oauth2/authorize
+- Scope : A space separated list of scope codes allowed to the client in your Odoo Provider instance
+- Validation URL : http://odoo.example.com/oauth2/tokeninfo
+- Data URL : http://odoo.example.com/oauth2/userinfo
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/149/9.0
+
+Known issues / Roadmap
+======================
+
+* Implement the backend application profile (client credentials grant type)
+* Add checkboxes on the authorization page to allow the user to disable some scopes for a token ? (I don't know if this is allowed in the OAuth protocol)
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Sylvain Garancher <sylvain.garancher@syleam.fr>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/oauth_provider/__init__.py
+++ b/oauth_provider/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import controllers
+from . import models
+
+import uuid
+
+
+def pre_init_hook(cr):
+    """ Initialize oauth_identifier on res.users
+
+    The standard initialization puts the same value for every existing record,
+    which is invalid for this field.
+    This is done in the pre_init_hook to be able to add the unique constrait
+    on the first run, when installing the module.
+    """
+    cr.execute('ALTER TABLE res_users ADD COLUMN oauth_identifier varchar')
+    cr.execute('SELECT id FROM res_users')
+    for user_id in cr.fetchall():
+        cr.execute(
+            'UPDATE res_users SET oauth_identifier = %s WHERE id = %s',
+            (str(uuid.uuid4()), user_id))

--- a/oauth_provider/__init__.py
+++ b/oauth_provider/__init__.py
@@ -1,24 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import controllers
 from . import models
 
-import uuid
-
-
-def pre_init_hook(cr):
-    """ Initialize oauth_identifier on res.users
-
-    The standard initialization puts the same value for every existing record,
-    which is invalid for this field.
-    This is done in the pre_init_hook to be able to add the unique constrait
-    on the first run, when installing the module.
-    """
-    cr.execute('ALTER TABLE res_users ADD COLUMN oauth_identifier varchar')
-    cr.execute('SELECT id FROM res_users')
-    for user_id in cr.fetchall():
-        cr.execute(
-            'UPDATE res_users SET oauth_identifier = %s WHERE id = %s',
-            (str(uuid.uuid4()), user_id))
+from .hooks import pre_init_hook, post_load

--- a/oauth_provider/__manifest__.py
+++ b/oauth_provider/__manifest__.py
@@ -1,21 +1,21 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 {
     'name': 'OAuth Provider',
     'summary': 'Allows to use Odoo as an OAuth2 provider',
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'category': 'Authentication',
     'website': 'http://www.syleam.fr/',
-    'author': 'SYLEAM, Odoo Community Association (OCA)',
-    'license': 'AGPL-3',
+    'author': 'SYLEAM, LasLabs, Odoo Community Association (OCA)',
+    'license': 'LGPL-3',
     'installable': True,
     'external_dependancies': {
         'python': ['oauthlib'],
     },
     'depends': [
-        'base',
+        'web',
     ],
     'data': [
         'security/oauth_provider_security.xml',
@@ -25,4 +25,5 @@
         'templates/authorization.xml',
     ],
     'pre_init_hook': 'pre_init_hook',
+    'post_load': 'post_load',
 }

--- a/oauth_provider/__openerp__.py
+++ b/oauth_provider/__openerp__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'OAuth Provider',
+    'summary': 'Allows to use Odoo as an OAuth2 provider',
+    'version': '9.0.1.0.0',
+    'category': 'Authentication',
+    'website': 'http://www.syleam.fr/',
+    'author': 'SYLEAM, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'installable': True,
+    'external_dependancies': {
+        'python': ['oauthlib'],
+    },
+    'depends': [
+        'base',
+    ],
+    'data': [
+        'security/oauth_provider_security.xml',
+        'security/ir.model.access.csv',
+        'views/oauth_provider_client.xml',
+        'views/oauth_provider_scope.xml',
+        'templates/authorization.xml',
+    ],
+    'pre_init_hook': 'pre_init_hook',
+}

--- a/oauth_provider/controllers/__init__.py
+++ b/oauth_provider/controllers/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import main

--- a/oauth_provider/controllers/__init__.py
+++ b/oauth_provider/controllers/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from . import main
+from . import oauth_mixin
+
+from . import rest_api_controller
+from . import oauth_provider_controller

--- a/oauth_provider/controllers/main.py
+++ b/oauth_provider/controllers/main.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import json
+import logging
+import werkzeug.utils
+import werkzeug.wrappers
+from datetime import datetime
+from openerp import http, fields
+from openerp.addons.web.controllers.main import ensure_db
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import oauthlib
+    from oauthlib import oauth2
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class OAuth2ProviderController(http.Controller):
+    def __init__(self):
+        super(OAuth2ProviderController, self).__init__()
+
+    def _get_request_information(self):
+        """ Retrieve needed arguments for oauthlib methods """
+        uri = http.request.httprequest.base_url
+        http_method = http.request.httprequest.method
+        body = oauthlib.common.urlencode(
+            http.request.httprequest.values.items())
+        headers = http.request.httprequest.headers
+
+        return uri, http_method, body, headers
+
+    def _check_access_token(self, access_token):
+        """ Check if the provided access token is valid """
+        token = http.request.env['oauth.provider.token'].search([
+            ('token', '=', access_token),
+        ])
+        if not token:
+            return False
+
+        oauth2_server = token.client_id.get_oauth2_server()
+        # Retrieve needed arguments for oauthlib methods
+        uri, http_method, body, headers = self._get_request_information()
+
+        # Validate request information
+        valid, oauthlib_request = oauth2_server.verify_request(
+            uri, http_method=http_method, body=body, headers=headers)
+
+        if valid:
+            return token
+
+        return False
+
+    def _json_response(self, data=None, status=200, headers=None):
+        """ Returns a json response to the client """
+        if headers is None:
+            headers = {'Content-Type': 'application/json'}
+
+        return werkzeug.wrappers.BaseResponse(
+            json.dumps(data), status=status, headers=headers)
+
+    @http.route('/oauth2/authorize', type='http', auth='user', methods=['GET'])
+    def authorize(self, client_id=None, response_type=None, redirect_uri=None,
+                  scope=None, state=None, *args, **kwargs):
+        """ Check client's request, and display an authorization page to the user,
+
+        The authorization page lists allowed scopes
+        If the client is configured to skip the authorization page, directly
+        redirects to the requested URI
+        """
+        client = http.request.env['oauth.provider.client'].search([
+            ('identifier', '=', client_id),
+        ])
+        if not client:
+            return http.request.render(
+                'oauth_provider.authorization_error', {
+                    'title': 'Unknown Client Identifier!',
+                    'message': 'This client identifier is invalid.',
+                })
+        oauth2_server = client.get_oauth2_server()
+
+        # Retrieve needed arguments for oauthlib methods
+        uri, http_method, body, headers = self._get_request_information()
+        try:
+            scopes, credentials = oauth2_server.validate_authorization_request(
+                uri, http_method=http_method, body=body, headers=headers)
+            # Store only some values, because the pickling of the full request
+            # object is not possible
+            http.request.httpsession['oauth_scopes'] = scopes
+            http.request.httpsession['oauth_credentials'] = {
+                'client_id': credentials['client_id'],
+                'redirect_uri': credentials['redirect_uri'],
+                'response_type': credentials['response_type'],
+                'state': credentials['state'],
+            }
+            if client.skip_authorization:
+                # Skip the authorization page
+                # Useful when the application is trusted
+                return self.authorize_post()
+        except oauth2.FatalClientError as e:
+            return http.request.render(
+                'oauth_provider.authorization_error', {
+                    'title': 'Error: {error}'.format(error=e.error),
+                    'message': e.description,
+                })
+        except oauth2.OAuth2Error as e:
+            return http.request.render(
+                'oauth_provider.authorization_error', {
+                    'title': 'Error: {error}'.format(error=e.error),
+                    'message': 'An unknown error occured! Please contact your '
+                    'administrator',
+                })
+
+        oauth_scopes = client.scope_ids.filtered(
+            lambda record: record.code in scopes)
+        return http.request.render(
+            'oauth_provider.authorization', {
+                'oauth_client': client.name,
+                'oauth_scopes': oauth_scopes,
+            })
+
+    @http.route(
+        '/oauth2/authorize', type='http', auth='user', methods=['POST'])
+    def authorize_post(self, *args, **kwargs):
+        """ Redirect to the requested URI during the authorization """
+        client = http.request.env['oauth.provider.client'].search([
+            ('identifier', '=', http.request.httpsession.get(
+                'oauth_credentials', {}).get('client_id'))])
+        if not client:
+            return http.request.render(
+                'oauth_provider.authorization_error', {
+                    'title': 'Unknown Client Identifier!',
+                    'message': 'This client identifier is invalid.',
+                })
+        oauth2_server = client.get_oauth2_server()
+
+        # Retrieve needed arguments for oauthlib methods
+        uri, http_method, body, headers = self._get_request_information()
+        scopes = http.request.httpsession['oauth_scopes']
+        credentials = http.request.httpsession['oauth_credentials']
+        headers, body, status = oauth2_server.create_authorization_response(
+            uri, http_method=http_method, body=body, headers=headers,
+            scopes=scopes, credentials=credentials)
+
+        return werkzeug.utils.redirect(headers['Location'], code=status)
+
+    @http.route('/oauth2/token', type='http', auth='none', methods=['POST'],
+                csrf=False)
+    def token(self, client_id=None, client_secret=None, redirect_uri=None,
+              scope=None, code=None, grant_type=None, username=None,
+              password=None, refresh_token=None, *args, **kwargs):
+        """ Return a token corresponding to the supplied information
+
+        Not all parameters are required, depending on the application type
+        """
+        ensure_db()
+
+        # If no client_id is specified, get it from session
+        if client_id is None:
+            client_id = http.request.httpsession.get(
+                'oauth_credentials', {}).get('client_id')
+
+        client = http.request.env['oauth.provider.client'].sudo().search([
+            ('identifier', '=', client_id),
+        ])
+
+        if not client:
+            return self._json_response(
+                data={'error': 'invalid_client_id'}, status=401)
+        oauth2_server = client.get_oauth2_server()
+
+        # Retrieve needed arguments for oauthlib methods
+        uri, http_method, body, headers = self._get_request_information()
+        credentials = {'scope': scope}
+
+        # Retrieve the authorization code, if any, to get Odoo's user id
+        existing_code = http.request.env[
+            'oauth.provider.authorization.code'].search([
+                ('client_id.identifier', '=', client_id),
+                ('code', '=', code),
+            ])
+        if existing_code:
+            credentials['odoo_user_id'] = existing_code.user_id.id
+        # Retrieve the existing token, if any, to get Odoo's user id
+        existing_token = http.request.env['oauth.provider.token'].search([
+            ('client_id.identifier', '=', client_id),
+            ('refresh_token', '=', refresh_token),
+        ])
+        if existing_token:
+            credentials['odoo_user_id'] = existing_token.user_id.id
+
+        headers, body, status = oauth2_server.create_token_response(
+            uri, http_method=http_method, body=body, headers=headers,
+            credentials=credentials)
+
+        return werkzeug.wrappers.BaseResponse(
+            body, status=status, headers=headers)
+
+    @http.route('/oauth2/tokeninfo', type='http', auth='none', methods=['GET'])
+    def tokeninfo(self, access_token=None, *args, **kwargs):
+        """ Return some information about the supplied token
+
+        Similar to Google's "tokeninfo" request
+        """
+        ensure_db()
+        token = self._check_access_token(access_token)
+        if not token:
+            return self._json_response(
+                data={'error': 'invalid_or_expired_token'}, status=401)
+
+        token_lifetime = (fields.Datetime.from_string(token.expires_at) -
+                          datetime.now()).seconds
+        # Base data to return
+        data = {
+            'audience': token.client_id.identifier,
+            'scopes': ' '.join(token.scope_ids.mapped('code')),
+            'expires_in': token_lifetime,
+        }
+
+        # Add the oauth user identifier, if user's information access is
+        # allowed by the token's scopes
+        user_data = token.get_data_for_model(
+            'res.users', res_id=token.user_id.id)
+        if 'id' in user_data:
+            data.update(user_id=token.generate_user_id())
+        return self._json_response(data=data)
+
+    @http.route('/oauth2/userinfo', type='http', auth='none', methods=['GET'])
+    def userinfo(self, access_token=None, *args, **kwargs):
+        """ Return some information about the user linked to the supplied token
+
+        Similar to Google's "userinfo" request
+        """
+        ensure_db()
+        token = self._check_access_token(access_token)
+        if not token:
+            return self._json_response(
+                data={'error': 'invalid_or_expired_token'}, status=401)
+
+        data = token.get_data_for_model('res.users', res_id=token.user_id.id)
+        return self._json_response(data=data)
+
+    @http.route('/oauth2/otherinfo', type='http', auth='none', methods=['GET'])
+    def otherinfo(self, access_token=None, model=None, *args, **kwargs):
+        """ Return allowed information about the requested model """
+        ensure_db()
+        token = self._check_access_token(access_token)
+        if not token:
+            return self._json_response(
+                data={'error': 'invalid_or_expired_token'}, status=401)
+
+        model_obj = http.request.env['ir.model'].search([
+            ('model', '=', model),
+        ])
+        if not model_obj:
+            return self._json_response(
+                data={'error': 'invalid_model'}, status=400)
+
+        data = token.get_data_for_model(model)
+        return self._json_response(data=data)
+
+    @http.route(
+        '/oauth2/revoke_token', type='http', auth='none', methods=['POST'])
+    def revoke_token(self, token=None, *args, **kwargs):
+        """ Revoke the supplied token """
+        ensure_db()
+        body = oauthlib.common.urlencode(
+            http.request.httprequest.values.items())
+        db_token = http.request.env['oauth.provider.token'].search([
+            ('token', '=', token),
+        ])
+        if not db_token:
+            db_token = http.request.env['oauth.provider.token'].search([
+                ('refresh_token', '=', token),
+            ])
+        if not db_token:
+            return self._json_response(
+                data={'error': 'invalid_or_expired_token'}, status=401)
+        oauth2_server = db_token.client_id.get_oauth2_server()
+
+        # Retrieve needed arguments for oauthlib methods
+        uri, http_method, body, headers = self._get_request_information()
+
+        headers, body, status = oauth2_server.create_revocation_response(
+            uri, http_method=http_method, body=body, headers=headers)
+        return werkzeug.wrappers.BaseResponse(
+            body, status=status, headers=headers)

--- a/oauth_provider/controllers/oauth_mixin.py
+++ b/oauth_provider/controllers/oauth_mixin.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import logging
+
+from odoo import http
+from odoo.addons.web.controllers.main import ensure_db
+
+from ..exceptions import OauthApiException, OauthInvalidTokenException
+from ..http import _json_response
+
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import oauthlib
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class OauthMixin(http.Controller):
+
+    def _validate_model(self, model_name, token=None):
+        """ Validate the access token & return a usable model.
+
+        Args:
+            model_name (str): Name of model to find.
+            token (OauthProviderToken, optional): Will return the model in
+                the scope of the token user, if defined.
+
+        Returns:
+            IrModel: Usable model object that matched model_name.
+
+        Raises:
+            OauthApiException: If the model is not found.
+        """
+        ensure_db()
+        model_obj = http.request.env['ir.model'].search([
+            ('model', '=', model_name),
+        ])
+        if not model_obj:
+            raise OauthApiException('Model Not Found')
+        if token is not None:
+            model_obj = model_obj.sudo(user=token.user_id)
+        return model_obj
+
+    def _validate_token(self, access_token):
+        """ Find the access token & return it if valid.
+
+        Args:
+            access_token (str): Access token that should be validated.
+
+        Returns:
+            OAuthProviderToken: Token record, if valid.
+
+        Raises:
+            OauthInvalidTokenException: When the token is invalid or expired.
+        """
+        ensure_db()
+        token = self._get_access_token(access_token)
+        if not token:
+            raise OauthInvalidTokenException()
+        return token
+
+    @classmethod
+    def _get_access_token(cls, access_token):
+        """ Verify access token and return record if valid.
+
+        Args:
+             access_token (str): OAuth2 access token to be validated.
+
+        Returns:
+            OauthProviderToken: Valid token record for use.
+            NoneType: None if no matching token was found in the database.
+            bool: False if the token was invalid.
+        """
+        token = http.request.env['oauth.provider.token'].search([
+            ('token', '=', access_token),
+        ])
+        if not token:
+            return None
+
+        oauth2_server = token.client_id.get_oauth2_server()
+        # Retrieve needed arguments for oauthlib methods
+        uri, http_method, body, headers = cls._get_request_information()
+
+        # Validate request information
+        valid, oauthlib_request = oauth2_server.verify_request(
+            uri, http_method=http_method, body=body, headers=headers,
+        )
+
+        if valid:
+            return token
+
+        return False
+
+    @staticmethod
+    def _get_request_information():
+        """ Retrieve needed arguments for oauthlib methods.
+
+        Returns:
+            tuple: uri, http_method, body, headers
+        """
+        uri = http.request.httprequest.base_url
+        http_method = http.request.httprequest.method
+        body = oauthlib.common.urlencode(
+            http.request.httprequest.values.items(),
+        )
+        headers = http.request.httprequest.headers
+
+        return uri, http_method, body, headers
+
+    @staticmethod
+    def _json_response(data=None, error=None, headers=None, status=None):
+        """ Returns a json response to the client.
+
+        Args:
+            result (mixed, optional): User's requested data.
+            error (dict, optional): Serialized error data (from
+                `_handle_exception`).
+            headers (dict, optional): Mapping of headers to apply to the
+                request. If the `Content-Type` header is not defined,
+                 `application/json` will automatically be added.
+
+        Returns:
+            Response: Werkzeug response object based on the input.
+        """
+        try:
+            return http.request._json_response(data, error)
+        except AttributeError:
+            return _json_response(data, error, headers, status)

--- a/oauth_provider/controllers/oauth_provider_controller.py
+++ b/oauth_provider/controllers/oauth_provider_controller.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-import json
 import logging
 import werkzeug.utils
 import werkzeug.wrappers
 from datetime import datetime
-from openerp import http, fields
-from openerp.addons.web.controllers.main import ensure_db
+from odoo import http, fields
+from odoo.addons.web.controllers.main import ensure_db
+
+from .oauth_mixin import OauthMixin
 
 _logger = logging.getLogger(__name__)
 
@@ -19,50 +20,13 @@ except ImportError:
     _logger.debug('Cannot `import oauthlib`.')
 
 
-class OAuth2ProviderController(http.Controller):
-    def __init__(self):
-        super(OAuth2ProviderController, self).__init__()
+class OAuth2ProviderController(OauthMixin):
 
-    def _get_request_information(self):
-        """ Retrieve needed arguments for oauthlib methods """
-        uri = http.request.httprequest.base_url
-        http_method = http.request.httprequest.method
-        body = oauthlib.common.urlencode(
-            http.request.httprequest.values.items())
-        headers = http.request.httprequest.headers
-
-        return uri, http_method, body, headers
-
-    def _check_access_token(self, access_token):
-        """ Check if the provided access token is valid """
-        token = http.request.env['oauth.provider.token'].search([
-            ('token', '=', access_token),
-        ])
-        if not token:
-            return False
-
-        oauth2_server = token.client_id.get_oauth2_server()
-        # Retrieve needed arguments for oauthlib methods
-        uri, http_method, body, headers = self._get_request_information()
-
-        # Validate request information
-        valid, oauthlib_request = oauth2_server.verify_request(
-            uri, http_method=http_method, body=body, headers=headers)
-
-        if valid:
-            return token
-
-        return False
-
-    def _json_response(self, data=None, status=200, headers=None):
-        """ Returns a json response to the client """
-        if headers is None:
-            headers = {'Content-Type': 'application/json'}
-
-        return werkzeug.wrappers.BaseResponse(
-            json.dumps(data), status=status, headers=headers)
-
-    @http.route('/oauth2/authorize', type='http', auth='user', methods=['GET'])
+    @http.route('/oauth2/authorize',
+                type='http',
+                auth='user',
+                methods=['GET'],
+                )
     def authorize(self, client_id=None, response_type=None, redirect_uri=None,
                   scope=None, state=None, *args, **kwargs):
         """ Check client's request, and display an authorization page to the user,
@@ -89,8 +53,8 @@ class OAuth2ProviderController(http.Controller):
                 uri, http_method=http_method, body=body, headers=headers)
             # Store only some values, because the pickling of the full request
             # object is not possible
-            http.request.httpsession['oauth_scopes'] = scopes
-            http.request.httpsession['oauth_credentials'] = {
+            http.request.session['oauth_scopes'] = scopes
+            http.request.session['oauth_credentials'] = {
                 'client_id': credentials['client_id'],
                 'redirect_uri': credentials['redirect_uri'],
                 'response_type': credentials['response_type'],
@@ -122,12 +86,15 @@ class OAuth2ProviderController(http.Controller):
                 'oauth_scopes': oauth_scopes,
             })
 
-    @http.route(
-        '/oauth2/authorize', type='http', auth='user', methods=['POST'])
+    @http.route('/oauth2/authorize',
+                type='http',
+                auth='user',
+                methods=['POST'],
+                )
     def authorize_post(self, *args, **kwargs):
         """ Redirect to the requested URI during the authorization """
         client = http.request.env['oauth.provider.client'].search([
-            ('identifier', '=', http.request.httpsession.get(
+            ('identifier', '=', http.request.session.get(
                 'oauth_credentials', {}).get('client_id'))])
         if not client:
             return http.request.render(
@@ -139,16 +106,20 @@ class OAuth2ProviderController(http.Controller):
 
         # Retrieve needed arguments for oauthlib methods
         uri, http_method, body, headers = self._get_request_information()
-        scopes = http.request.httpsession['oauth_scopes']
-        credentials = http.request.httpsession['oauth_credentials']
+        scopes = http.request.session['oauth_scopes']
+        credentials = http.request.session['oauth_credentials']
         headers, body, status = oauth2_server.create_authorization_response(
             uri, http_method=http_method, body=body, headers=headers,
             scopes=scopes, credentials=credentials)
 
         return werkzeug.utils.redirect(headers['Location'], code=status)
 
-    @http.route('/oauth2/token', type='http', auth='none', methods=['POST'],
-                csrf=False)
+    @http.route('/oauth2/token',
+                type='http',
+                auth='none',
+                methods=['POST'],
+                csrf=False,
+                )
     def token(self, client_id=None, client_secret=None, redirect_uri=None,
               scope=None, code=None, grant_type=None, username=None,
               password=None, refresh_token=None, *args, **kwargs):
@@ -160,7 +131,7 @@ class OAuth2ProviderController(http.Controller):
 
         # If no client_id is specified, get it from session
         if client_id is None:
-            client_id = http.request.httpsession.get(
+            client_id = http.request.session.get(
                 'oauth_credentials', {}).get('client_id')
 
         client = http.request.env['oauth.provider.client'].sudo().search([
@@ -168,6 +139,7 @@ class OAuth2ProviderController(http.Controller):
         ])
 
         if not client:
+
             return self._json_response(
                 data={'error': 'invalid_client_id'}, status=401)
         oauth2_server = client.get_oauth2_server()
@@ -199,14 +171,18 @@ class OAuth2ProviderController(http.Controller):
         return werkzeug.wrappers.BaseResponse(
             body, status=status, headers=headers)
 
-    @http.route('/oauth2/tokeninfo', type='http', auth='none', methods=['GET'])
+    @http.route('/oauth2/tokeninfo',
+                type='http',
+                auth='none',
+                methods=['GET'],
+                )
     def tokeninfo(self, access_token=None, *args, **kwargs):
         """ Return some information about the supplied token
 
         Similar to Google's "tokeninfo" request
         """
         ensure_db()
-        token = self._check_access_token(access_token)
+        token = self._get_access_token(access_token)
         if not token:
             return self._json_response(
                 data={'error': 'invalid_or_expired_token'}, status=401)
@@ -222,32 +198,43 @@ class OAuth2ProviderController(http.Controller):
 
         # Add the oauth user identifier, if user's information access is
         # allowed by the token's scopes
-        user_data = token.get_data_for_model(
-            'res.users', res_id=token.user_id.id)
+        user_data = token.get_data(
+            'res.users', record_ids=token.user_id.ids)
         if 'id' in user_data:
             data.update(user_id=token.generate_user_id())
         return self._json_response(data=data)
 
-    @http.route('/oauth2/userinfo', type='http', auth='none', methods=['GET'])
+    @http.route('/oauth2/userinfo',
+                type='http',
+                auth='none',
+                methods=['GET'],
+                )
     def userinfo(self, access_token=None, *args, **kwargs):
         """ Return some information about the user linked to the supplied token
 
         Similar to Google's "userinfo" request
         """
         ensure_db()
-        token = self._check_access_token(access_token)
+        token = self._get_access_token(access_token)
         if not token:
             return self._json_response(
                 data={'error': 'invalid_or_expired_token'}, status=401)
 
-        data = token.get_data_for_model('res.users', res_id=token.user_id.id)
+        data = token.get_data('res.users', record_ids=token.user_id.ids)
         return self._json_response(data=data)
 
-    @http.route('/oauth2/otherinfo', type='http', auth='none', methods=['GET'])
+    @http.route('/oauth2/otherinfo',
+                type='http',
+                auth='none',
+                methods=['GET'],
+                )
     def otherinfo(self, access_token=None, model=None, *args, **kwargs):
         """ Return allowed information about the requested model """
+        _logger.warn(
+            '`/oauth2/otherinfo` endpoint is deprecated. Use the REST API.',
+        )
         ensure_db()
-        token = self._check_access_token(access_token)
+        token = self._get_access_token(access_token)
         if not token:
             return self._json_response(
                 data={'error': 'invalid_or_expired_token'}, status=401)
@@ -259,11 +246,14 @@ class OAuth2ProviderController(http.Controller):
             return self._json_response(
                 data={'error': 'invalid_model'}, status=400)
 
-        data = token.get_data_for_model(model)
+        data = token.get_data(model)
         return self._json_response(data=data)
 
-    @http.route(
-        '/oauth2/revoke_token', type='http', auth='none', methods=['POST'])
+    @http.route('/oauth2/revoke_token',
+                type='http',
+                auth='none',
+                methods=['POST'],
+                )
     def revoke_token(self, token=None, *args, **kwargs):
         """ Revoke the supplied token """
         ensure_db()

--- a/oauth_provider/controllers/rest_api_controller.py
+++ b/oauth_provider/controllers/rest_api_controller.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import logging
+
+from odoo import http, _
+
+from ..exceptions import OauthApiException
+from .oauth_mixin import OauthMixin
+
+_logger = logging.getLogger(__name__)
+
+
+class RestApiController(OauthMixin):
+
+    API_VERSION = '1.0'
+
+    @http.route(
+        '/api/rest/%s/<string:model>' % API_VERSION,
+        type='json',
+        auth='none',
+        methods=['GET'],
+    )
+    def rest_list(self, access_token, model, domain=None, *a, **kw):
+        """ Return allowed information from all records.
+
+        Args:
+            access_token (str): OAuth2 access token to utilize for the
+                operation.
+            model (str): Name of model to operate on.
+            domain (list, optional): Domain to apply to the search, in the
+                standard Odoo format. This will be appended to the scope's
+                pre-existing filter.
+
+        Returns:
+            list of dicts: List of data mappings matching query.
+        """
+        token = self._validate_token(access_token)
+        self._validate_model(model)
+        data = token.get_data(model, domain=domain)
+        return data
+
+    @http.route(
+        '/api/rest/%s/<string:model>/<int:record_id>' % API_VERSION,
+        type='json',
+        auth='none',
+        methods=['GET'],
+    )
+    def rest_read(self, access_token, model, record_id, *a, **kw):
+        """ Return allowed information from specific records.
+
+        Args:
+            access_token (str): OAuth2 access token to utilize for the
+                operation.
+            model (str): Name of model to operate on.
+            record_id (int): ID of record to get.
+        """
+        token = self._validate_token(access_token)
+        self._validate_model(model)
+        data = token.get_data(model, [record_id])
+        return data
+
+    @http.route(
+        '/api/rest/%s/<string:model>' % API_VERSION,
+        type='json',
+        auth='none',
+        methods=['POST'],
+    )
+    def rest_create(self, access_token, model, *args, **kwargs):
+        """ Create and return new record.
+
+        Args:
+            access_token (str): OAuth2 access token to utilize for the
+                operation.
+            model (str): Name of model to operate on.
+            kwargs (mixed): All other named arguments are used as the data
+                for record mutation.
+
+        Returns:
+            dict: Newly created record data.
+        """
+        token = self._validate_token(access_token)
+        self._validate_model(model)
+        record = token.create_record(model, kwargs)
+        return token.get_data(model, record.ids)
+
+    @http.route(
+        ['/api/rest/%s/<string:model>/<int:record_id>' % API_VERSION,
+         '/api/rest/%s/<string:model>/' % API_VERSION,
+         ],
+        type='json',
+        auth='none',
+        methods=['PUT'],
+    )
+    def rest_write(self, access_token, model, record_id=None,
+                   record_ids=None, *args, **kwargs):
+        """ Modify the defined records and return the newly modified data.
+
+        Args:
+            access_token (str): OAuth2 access token to utilize for the
+                operation.
+            model (str): Name of model to operate on.
+            record_id (int): ID of record to mutate (provided as route
+                argument).
+            record_ids (list of ints): IDs of record to mutate (provided as
+                PUT argument).
+            kwargs (mixed): All other named arguments are used as the data
+                for record mutation.
+
+        Returns:
+            list of dicts: Newly modified record data.
+        """
+
+        record_ids = self._get_record_ids(record_id, record_ids)
+        token = self._validate_token(access_token)
+        self._validate_model(model)
+        record = token.write_record(model, record_ids, kwargs)
+        return token.get_data(model, record.ids)
+
+    @http.route(
+        ['/api/rest/%s/<string:model>/<int:record_id>' % API_VERSION,
+         '/api/rest/%s/<string:model>/' % API_VERSION,
+         ],
+        type='json',
+        auth='none',
+        methods=['DELETE'],
+    )
+    def data_delete(self, access_token, model, record_id=None,
+                    record_ids=None, *args, **kwargs):
+        """ Delete the defined records.
+
+        Args:
+            access_token (str): OAuth2 access token to utilize for the
+                operation.
+            model (str): Name of model to operate on.
+            record_id (int): ID of record to mutate (provided as route
+                argument).
+            record_ids (list of ints): IDs of record to mutate (provided as PUT
+                argument).
+
+        Returns:
+            bool
+        """
+
+        record_ids = self._get_record_ids(record_id, record_ids)
+        token = self._validate_token(access_token)
+        self._validate_model(model)
+        token.delete_record(model, record_ids)
+
+        return True
+
+    def _get_record_ids(self, record_id, record_ids):
+        if record_ids is None:
+            record_ids = []
+        if record_id is not None:
+            record_ids.append(record_id)
+
+        if not record_ids:
+            raise OauthApiException(_(
+                'No record ID was defined. You can define a record ID by '
+                'appending it to the end of the route, or including a '
+                '`record_ids` argument in the `PUT` data, which is a list '
+                'of record IDs to mutate.',
+            ))
+
+        return record_ids

--- a/oauth_provider/exceptions.py
+++ b/oauth_provider/exceptions.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from werkzeug import exceptions
+
+from odoo import _
+
+
+class OauthApiException(exceptions.BadRequest):
+    pass
+
+
+class OauthInvalidTokenException(exceptions.Unauthorized):
+
+    def __init__(self):
+        super(OauthInvalidTokenException, self).__init__(
+            _('Invalid or expired token'),
+        )
+        self.traceback = ('', '', '')
+
+
+class OauthScopeValidationException(exceptions.Forbidden):
+
+    def __init__(self, code='unknown'):
+        msg = _(
+            'There was an error validating the attempted action against '
+            'your session\'s authorized scope. The error code is: %s',
+        )
+        super(OauthScopeValidationException, self).__init__(msg % code)
+        self.traceback = ('', '', '')

--- a/oauth_provider/hooks.py
+++ b/oauth_provider/hooks.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import uuid
+
+from odoo import http
+
+from .http import _handle_exception, __init__
+
+
+def pre_init_hook(cr):
+    """ Initialize oauth_identifier on res.users
+
+    The standard initialization puts the same value for every existing record,
+    which is invalid for this field.
+    This is done in the pre_init_hook to be able to add the unique constrait
+    on the first run, when installing the module.
+    """
+    cr.execute('ALTER TABLE res_users ADD COLUMN oauth_identifier varchar')
+    cr.execute('SELECT id FROM res_users')
+    for user_id in cr.fetchall():
+        cr.execute(
+            'UPDATE res_users SET oauth_identifier = %s WHERE id = %s',
+            (str(uuid.uuid4()), user_id))
+
+
+def post_load():
+    """Monkey patch HTTP methods."""
+    # http.JsonRequest._json_response = _json_response
+    http.JsonRequest._handle_exception = _handle_exception
+    http.JsonRequest.__init__ = __init__

--- a/oauth_provider/http.py
+++ b/oauth_provider/http.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import json
+
+from werkzeug.exceptions import BadRequest
+
+from odoo import http
+
+
+old_handle_exception = http.JsonRequest._handle_exception
+old_json_response = http.JsonRequest._json_response
+old_init = http.JsonRequest.__init__
+
+
+def __init__(self, *args):
+    try:
+        old_init(self, *args)
+    except BadRequest as e:
+        try:
+            args = self.httprequest.args
+            self.jsonrequest = args
+            self.params = json.loads(self.jsonrequest.get('params', "{}"))
+            self.context = self.params.pop('context',
+                                           dict(self.session.context))
+        except ValueError:
+            raise e
+
+
+def _handle_exception(self, exception):
+    """ Override the original method to handle Werkzeug exceptions.
+
+    Args:
+        exception (Exception): Exception object that is being thrown.
+
+    Returns:
+        BaseResponse: JSON Response.
+    """
+
+    # For some reason a try/except here still raised...
+    code = getattr(exception, 'code', None)
+    if code is None:
+        return old_handle_exception(
+            self, exception,
+        )
+
+    error = {
+        'data': http.serialize_exception(exception),
+        'code': code,
+    }
+
+    try:
+        error['message'] = exception.description
+    except AttributeError:
+        try:
+            error['message'] = exception.message
+        except AttributeError:
+            error['message'] = 'Internal Server Error'
+
+    return self._json_response(error=error)
+
+
+def _json_response(result=None, error=None, headers=None, status=None):
+    """ Returns a JSON response to the OAuth client.
+
+    This is mainly provided as a compatibility layer for old methods.
+
+    The true solution to all of this is to design a new Request type and
+    somehow use that instead of JSON-RPC. That's a lot of work though, so
+    this instead.
+
+    Args:
+        result (mixed, optional): User's requested data.
+        error (dict, optional): Serialized error data (from
+            `_handle_exception`).
+        jsonrpc (bool, optional): Set to False in order to respond without
+            JSON-RPC, and instead send a simple JSON response.
+        headers (dict, optional): Mapping of headers to apply to the
+            request. If the `Content-Type` header is not defined,
+             `application/json` will automatically be added.
+
+    Returns:
+        Response: Werkzeug response object based on the input.
+    """
+
+    if headers is None:
+        headers = {}
+
+    if 'Content-Type' not in headers:
+        headers['Content-Type'] = 'application/json'
+
+    body = json.dumps(result or error)
+    headers['Content-Length'] = len(body)
+
+    return http.Response(
+        body,
+        status=status or (error and error.get('code', 200)) or 200,
+        headers=headers,
+    )

--- a/oauth_provider/i18n/am.po
+++ b/oauth_provider/i18n/am.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Amharic (https://www.transifex.com/oca/teams/23907/am/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: am\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/am.po
+++ b/oauth_provider/i18n/am.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/ar.po
+++ b/oauth_provider/i18n/ar.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# SaFi J. <safi2266@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: SaFi J. <safi2266@gmail.com>, 2017\n"
+"Language-Team: Arabic (https://www.transifex.com/oca/teams/23907/ar/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ar\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "نشِط"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "أنشئ بواسطة"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "أنشئ في"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "الوصف"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "اسم العرض"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "المعرف"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "آخر تعديل في"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "آخر تحديث بواسطة"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "آخر تحديث في"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "النموذج"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "الاسم"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "مسلسل"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "المستخدم"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "المستخدمون"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/ar.po
+++ b/oauth_provider/i18n/ar.po
@@ -7,7 +7,7 @@
 # SaFi J. <safi2266@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/bg.po
+++ b/oauth_provider/i18n/bg.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/bg.po
+++ b/oauth_provider/i18n/bg.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Bulgarian (https://www.transifex.com/oca/teams/23907/bg/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: bg\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Активен"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Код"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Създадено от"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Създадено на"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Описание"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Име за Показване"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Последно обновено на"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Последно обновено от"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Последно обновено на"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Име"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Последователност"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/bs.po
+++ b/oauth_provider/i18n/bs.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/bs.po
+++ b/oauth_provider/i18n/bs.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Bosnian (https://www.transifex.com/oca/teams/23907/bs/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: bs\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktivno"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Kreirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Kreirano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Prikaži naziv"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Zadnje mijenjano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Zadnji ažurirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Zadnje ažurirano"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Ime"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sekvenca"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Korisnik"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/ca.po
+++ b/oauth_provider/i18n/ca.po
@@ -8,7 +8,7 @@
 # Carles Antoli <carlesantoli@hotmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/ca.po
+++ b/oauth_provider/i18n/ca.po
@@ -1,0 +1,575 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Marc Tormo i Bochaca <mtbochaca@gmail.com>, 2017
+# Carles Antoli <carlesantoli@hotmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Carles Antoli <carlesantoli@hotmail.com>, 2017\n"
+"Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Actiu"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Codi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creat per"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creat el"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripció"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Mostrar el nom"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Camps "
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Darrera modificació el"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Darrera Actualització per"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Darrera Actualització el"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Model"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nom"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Cap"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Contrasenya "
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Seqüència"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuari"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Usuaris"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/cs.po
+++ b/oauth_provider/i18n/cs.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Jaroslav Helemik Nemec <nemec@helemik.cz>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Jaroslav Helemik Nemec <nemec@helemik.cz>, 2017\n"
+"Language-Team: Czech (https://www.transifex.com/oca/teams/23907/cs/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: cs\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktivní"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Vytvořil(a)"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Vytvořeno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Popis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Zobrazovaný název"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Naposled upraveno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Naposled upraveno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Naposled upraveno"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Název"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Číselná řada"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Uživatel"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/cs.po
+++ b/oauth_provider/i18n/cs.po
@@ -7,7 +7,7 @@
 # Jaroslav Helemik Nemec <nemec@helemik.cz>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/da.po
+++ b/oauth_provider/i18n/da.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Danish (https://www.transifex.com/oca/teams/23907/da/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: da\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiv"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Oprettet af"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Oprettet den"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Beskrivelse"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Vist navn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "Id"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Sidst ændret den"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Sidst opdateret af"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Sidst opdateret den"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Navn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Rækkefølge"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Brugere"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/da.po
+++ b/oauth_provider/i18n/da.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/de.po
+++ b/oauth_provider/i18n/de.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Rudolf Schnapka <rs@techno-flex.de>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Rudolf Schnapka <rs@techno-flex.de>, 2017\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiv"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Schlüssel"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Angelegt durch"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Angelegt am"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Beschreibung"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Felder"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr "Filter"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Zuletzt geändert am"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Zuletzt akualisiert durch"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Zuletzt akualisiert am"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modell"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr "Modellbezeichnung"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Name"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Keine"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Passwort"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Reihenfolge"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Benutzer"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Benutzer"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/de.po
+++ b/oauth_provider/i18n/de.po
@@ -7,7 +7,7 @@
 # Rudolf Schnapka <rs@techno-flex.de>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/el_GR.po
+++ b/oauth_provider/i18n/el_GR.po
@@ -7,7 +7,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/el_GR.po
+++ b/oauth_provider/i18n/el_GR.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# Kostas Goutoudis <goutoudis@gmail.com>, 2017
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/el_GR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: el_GR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Δημιουργήθηκε από "
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Δημιουργήθηκε στις"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Περιγραφή"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "Κωδικός"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Τελευταία ενημέρωση από"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Τελευταία ενημέρωση στις"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Ονομασία"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Ιεράρχηση"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Χρήστες"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/en_GB.po
+++ b/oauth_provider/i18n/en_GB.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: English (United Kingdom) (https://www.transifex.com/oca/teams/23907/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: en_GB\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Active"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Created by"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Created on"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Description"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Display Name"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Last Modified on"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Name"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sequence"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "User"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/en_GB.po
+++ b/oauth_provider/i18n/en_GB.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es.po
+++ b/oauth_provider/i18n/es.po
@@ -1,0 +1,575 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2017
+# Eduardo Rodríguez Crespo <erocre@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Eduardo Rodríguez Crespo <erocre@gmail.com>, 2017\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activa"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Código"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Campos"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr "Filtro"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modelo"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr "Nombre del modelo"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Ninguno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Contraseña"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Usuarios"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es.po
+++ b/oauth_provider/i18n/es.po
@@ -8,7 +8,7 @@
 # Eduardo Rodríguez Crespo <erocre@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_AR.po
+++ b/oauth_provider/i18n/es_AR.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_AR.po
+++ b/oauth_provider/i18n/es_AR.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Argentina) (https://www.transifex.com/oca/teams/23907/es_AR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_AR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Mostrar Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización realizada por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_CL.po
+++ b/oauth_provider/i18n/es_CL.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Chile) (https://www.transifex.com/oca/teams/23907/es_CL/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_CL\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización de"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_CL.po
+++ b/oauth_provider/i18n/es_CL.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_CO.po
+++ b/oauth_provider/i18n/es_CO.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_CO.po
+++ b/oauth_provider/i18n/es_CO.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Colombia) (https://www.transifex.com/oca/teams/23907/es_CO/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_CO\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre Público"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última Modificación el"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Actualizado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Actualizado"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_CR.po
+++ b/oauth_provider/i18n/es_CR.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_CR.po
+++ b/oauth_provider/i18n/es_CR.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Costa Rica) (https://www.transifex.com/oca/teams/23907/es_CR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_CR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualización por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_DO.po
+++ b/oauth_provider/i18n/es_DO.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_DO.po
+++ b/oauth_provider/i18n/es_DO.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Dominican Republic) (https://www.transifex.com/oca/teams/23907/es_DO/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_DO\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización de"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_EC.po
+++ b/oauth_provider/i18n/es_EC.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_EC.po
+++ b/oauth_provider/i18n/es_EC.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Ecuador) (https://www.transifex.com/oca/teams/23907/es_EC/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_EC\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID (identificación)"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización de"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_ES.po
+++ b/oauth_provider/i18n/es_ES.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_ES.po
+++ b/oauth_provider/i18n/es_ES.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Spain) (https://www.transifex.com/oca/teams/23907/es_ES/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Ninguno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Usuarios"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_MX.po
+++ b/oauth_provider/i18n/es_MX.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_MX.po
+++ b/oauth_provider/i18n/es_MX.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Mexico) (https://www.transifex.com/oca/teams/23907/es_MX/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_MX\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre desplegado"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Ultima modificacion realizada"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizacion por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultima actualización realizada"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modelo"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_PE.po
+++ b/oauth_provider/i18n/es_PE.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Peru) (https://www.transifex.com/oca/teams/23907/es_PE/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_PE\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nombre a Mostrar"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Ultima Modificación en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Actualizado última vez por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultima Actualización"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_PE.po
+++ b/oauth_provider/i18n/es_PE.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_PY.po
+++ b/oauth_provider/i18n/es_PY.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_PY.po
+++ b/oauth_provider/i18n/es_PY.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Paraguay) (https://www.transifex.com/oca/teams/23907/es_PY/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_PY\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualización por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultima actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/es_VE.po
+++ b/oauth_provider/i18n/es_VE.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/es_VE.po
+++ b/oauth_provider/i18n/es_VE.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Venezuela) (https://www.transifex.com/oca/teams/23907/es_VE/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_VE\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Mostrar nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Modificada por última vez"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última actualización realizada por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizacion en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/et.po
+++ b/oauth_provider/i18n/et.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/et.po
+++ b/oauth_provider/i18n/et.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Estonian (https://www.transifex.com/oca/teams/23907/et/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: et\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiivne"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Loonud"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Loodud"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Kirjeldus"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Näidatav nimi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Viimati muudetud"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Viimati uuendatud"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Viimati uuendatud"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nimi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Järjekord"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Kasutaja"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/eu.po
+++ b/oauth_provider/i18n/eu.po
@@ -7,7 +7,7 @@
 # Esther Martín Menéndez <esthermartin001@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/eu.po
+++ b/oauth_provider/i18n/eu.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Esther Martín Menéndez <esthermartin001@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Esther Martín Menéndez <esthermartin001@gmail.com>, 2017\n"
+"Language-Team: Basque (https://www.transifex.com/oca/teams/23907/eu/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: eu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Kodea"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Nork sortua"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Created on"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Deskribapena"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Izena erakutsi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Last Updated on"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Model"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Izena"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sekuentzia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/fa.po
+++ b/oauth_provider/i18n/fa.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/fa.po
+++ b/oauth_provider/i18n/fa.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Persian (https://www.transifex.com/oca/teams/23907/fa/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fa\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "ایجاد شده توسط"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "ایجاد شده در"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "توصیف"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "نام نمایشی"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "شناسه"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "تاریخ آخرین به‌روزرسانی"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "آخرین به روز رسانی توسط"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "آخرین به روز رسانی در"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "نام"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "دنباله"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/fi.po
+++ b/oauth_provider/i18n/fi.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2017\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiivinen"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Koodi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Luonut"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Luotu"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Kuvaus"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nimi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Kentät"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Viimeksi muokattu"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Viimeksi päivittänyt"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Viimeksi päivitetty"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Mall"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nimi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sekvenssi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Käyttäjä"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Käyttäjät"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/fi.po
+++ b/oauth_provider/i18n/fi.po
@@ -7,7 +7,7 @@
 # Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/fr.po
+++ b/oauth_provider/i18n/fr.po
@@ -7,7 +7,7 @@
 # Sébastien Alix <seb@usr-src.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/fr.po
+++ b/oauth_provider/i18n/fr.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Sébastien Alix <seb@usr-src.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Sébastien Alix <seb@usr-src.org>, 2017\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Active"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Code"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Description"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Afficher le nom"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Champs"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr "Filtre"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Dernière modification par"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modèle"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr "Nom du modèle"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nom"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Aucune"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Mot de passe"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Séquence"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Utilisateur"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Utilisateurs"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/fr_CA.po
+++ b/oauth_provider/i18n/fr_CA.po
@@ -7,7 +7,7 @@
 # Adriana Ierfino <adriana.ierfino@savoirfairelinux.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/fr_CA.po
+++ b/oauth_provider/i18n/fr_CA.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Adriana Ierfino <adriana.ierfino@savoirfairelinux.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Adriana Ierfino <adriana.ierfino@savoirfairelinux.com>, 2017\n"
+"Language-Team: French (Canada) (https://www.transifex.com/oca/teams/23907/fr_CA/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr_CA\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Code"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Description"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Afficher le nom"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Champs"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "Identifiant"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Dernière mise à jour par"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modèle"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nom"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/fr_CH.po
+++ b/oauth_provider/i18n/fr_CH.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: French (Switzerland) (https://www.transifex.com/oca/teams/23907/fr_CH/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr_CH\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Actif"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Modifié par"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Modifié le"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Utilisateurs"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/fr_CH.po
+++ b/oauth_provider/i18n/fr_CH.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/gl.po
+++ b/oauth_provider/i18n/gl.po
@@ -1,0 +1,575 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# Alejandro Santana <alejandrosantana@anubia.es>, 2017
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# César Castro Cruz <ulmroan@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: César Castro Cruz <ulmroan@gmail.com>, 2017\n"
+"Language-Team: Galician (https://www.transifex.com/oca/teams/23907/gl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: gl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Código"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descrición"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última modificación"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "ültima actualización por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nome"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Ningún"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/gl.po
+++ b/oauth_provider/i18n/gl.po
@@ -8,7 +8,7 @@
 # César Castro Cruz <ulmroan@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/gl_ES.po
+++ b/oauth_provider/i18n/gl_ES.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/gl_ES.po
+++ b/oauth_provider/i18n/gl_ES.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Galician (Spain) (https://www.transifex.com/oca/teams/23907/gl_ES/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: gl_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/he.po
+++ b/oauth_provider/i18n/he.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/he.po
+++ b/oauth_provider/i18n/he.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Hebrew (https://www.transifex.com/oca/teams/23907/he/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: he\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "נוצר על ידי"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "נוצר ב-"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "תיאור"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "השם המוצג"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "מזהה"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "תאריך שינוי אחרון"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "עודכן לאחרונה על ידי"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "עודכן לאחרונה על"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "שם"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "רצף"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/hr.po
+++ b/oauth_provider/i18n/hr.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/hr.po
+++ b/oauth_provider/i18n/hr.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktivno"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Šifra"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Kreirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Kreirano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Naziv "
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Polja"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Zadnje modificirano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Zadnji ažurirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Zadnje ažuriranje"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Model"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Naziv"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Redoslijed"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Korisnik"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Korisnici"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/hr_HR.po
+++ b/oauth_provider/i18n/hr_HR.po
@@ -7,7 +7,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/hr_HR.po
+++ b/oauth_provider/i18n/hr_HR.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# Bole <bole@dajmi5.com>, 2017
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr_HR\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktivan"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Šifra"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Kreirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Kreirano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Naziv"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr "Filter"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Zadnje modificirano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Zadnji ažurirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Zadnje ažurirano"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Naziv"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Korisnici"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/hu.po
+++ b/oauth_provider/i18n/hu.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/hu.po
+++ b/oauth_provider/i18n/hu.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktív"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Készítette"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Létrehozás dátuma"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Leírás"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Név megjelenítése"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Utolsó frissítés dátuma"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Utoljára frissítve, által"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Utoljára frissítve "
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modell, minta"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Név"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sorszám"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Felhasználó"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/id.po
+++ b/oauth_provider/i18n/id.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/id.po
+++ b/oauth_provider/i18n/id.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Indonesian (https://www.transifex.com/oca/teams/23907/id/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: id\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktif"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Dibuat oleh"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Dibuat pada"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Keterangan"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nama Tampilan"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Terakhir Dimodifikasi pada"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Diperbaharui oleh"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Diperbaharui pada"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nama"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Berurutan"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/it.po
+++ b/oauth_provider/i18n/it.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Paolo Valier <paolo.valier@hotmail.it>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Paolo Valier <paolo.valier@hotmail.it>, 2017\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Attivo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Codice"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creato da"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creato il"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descrizione"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nome da visualizzare"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Campi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Ultima modifica il"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Ultimo aggiornamento di"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultimo aggiornamento il"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modello"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nome"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Nessuno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Password"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sequenza"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Utente"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Utenti"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/it.po
+++ b/oauth_provider/i18n/it.po
@@ -7,7 +7,7 @@
 # Paolo Valier <paolo.valier@hotmail.it>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/ja.po
+++ b/oauth_provider/i18n/ja.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/ja.po
+++ b/oauth_provider/i18n/ja.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/ja/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "有効"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "作成者"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "作成日"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "説明"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "表示名"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "最終更新日"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "最終更新者"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "最終更新日"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "名称"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "順序"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "ユーザ"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/ko.po
+++ b/oauth_provider/i18n/ko.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/ko.po
+++ b/oauth_provider/i18n/ko.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Korean (https://www.transifex.com/oca/teams/23907/ko/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ko\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "작성자"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "작성일"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "설명"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "표시 이름"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "최근 수정"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "최근 갱신한 사람"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "최근 갱신 날짜"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "이름"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "순서"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/lt.po
+++ b/oauth_provider/i18n/lt.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/lt.po
+++ b/oauth_provider/i18n/lt.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Lithuanian (https://www.transifex.com/oca/teams/23907/lt/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: lt\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktyvus"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Sukūrė"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Sukurta"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Aprašymas"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Vaizduojamas pavadinimas"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Paskutinį kartą keista"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Paskutinį kartą atnaujino"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Paskutinį kartą atnaujinta"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Pavadinimas"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Seka"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Naudotojas"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/lt_LT.po
+++ b/oauth_provider/i18n/lt_LT.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/lt_LT.po
+++ b/oauth_provider/i18n/lt_LT.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Lithuanian (Lithuania) (https://www.transifex.com/oca/teams/23907/lt_LT/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: lt_LT\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Sukūrė"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Sukurta"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Paskutinį kartą atnaujino"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Paskutinį kartą atnaujinta"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/lv.po
+++ b/oauth_provider/i18n/lv.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/lv.po
+++ b/oauth_provider/i18n/lv.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Latvian (https://www.transifex.com/oca/teams/23907/lv/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: lv\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktīvs"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Izveidoja"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Izveidots"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Apraksts"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Pēdējo reizi atjaunoja"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Pēdējās izmaiņas"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nosaukums"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secība"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Lietotājs"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/mk.po
+++ b/oauth_provider/i18n/mk.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/mk.po
+++ b/oauth_provider/i18n/mk.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Macedonian (https://www.transifex.com/oca/teams/23907/mk/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: mk\n"
+"Plural-Forms: nplurals=2; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : 1;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Активно"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Креирано од"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Креирано на"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Опис"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Прикажи име"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Последна промена на"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Последно ажурирање од"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Последно ажурирање на"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Име"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Секвенца"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Корисник"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/mn.po
+++ b/oauth_provider/i18n/mn.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Mongolian (https://www.transifex.com/oca/teams/23907/mn/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: mn\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Идэвхитэй"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Үүсгэгч"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Үүсгэсэн"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Тодорхойлолт"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Дэлгэцийн Нэр"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Сүүлийн засвар хийсэн огноо"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Сүүлийн засвар хийсэн"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Сүүлийн засвар хийсэн огноо"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Нэр"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Дараалал"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Хэрэглэгч"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/mn.po
+++ b/oauth_provider/i18n/mn.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/nb.po
+++ b/oauth_provider/i18n/nb.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/nb.po
+++ b/oauth_provider/i18n/nb.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Norwegian Bokmål (https://www.transifex.com/oca/teams/23907/nb/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nb\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiv"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Opprettet av"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Opprettet den"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Beskrivelse"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Visnings navn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Sist oppdatert "
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Sist oppdatert av"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Sist oppdatert"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Navn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sekvens"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Bruker"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/nb_NO.po
+++ b/oauth_provider/i18n/nb_NO.po
@@ -7,7 +7,7 @@
 # Imre Kristoffer Eilertsen <imreeil42@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/nb_NO.po
+++ b/oauth_provider/i18n/nb_NO.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Imre Kristoffer Eilertsen <imreeil42@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Imre Kristoffer Eilertsen <imreeil42@gmail.com>, 2017\n"
+"Language-Team: Norwegian Bokmål (Norway) (https://www.transifex.com/oca/teams/23907/nb_NO/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nb_NO\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiv"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Kode"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Laget av"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Laget den"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Vis navn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Sist endret den"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Sist oppdatert av"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Sist oppdatert den"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/nl.po
+++ b/oauth_provider/i18n/nl.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Actief"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Code"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Aangemaakt door"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Aangemaakt op"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Omschrijving"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Te tonen naam"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr "Filter"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Laatst bijgewerkt op"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Laatst bijgewerkt door"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Laatst bijgewerkt op"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Model"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Naam"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Wachtwoord"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Reeks"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Gebruiker"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Gebruikers"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/nl.po
+++ b/oauth_provider/i18n/nl.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/nl_BE.po
+++ b/oauth_provider/i18n/nl_BE.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/nl_BE.po
+++ b/oauth_provider/i18n/nl_BE.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Dutch (Belgium) (https://www.transifex.com/oca/teams/23907/nl_BE/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl_BE\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Actief"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Gemaakt door"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Gemaakt op"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Omschrijving"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Schermnaam"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Laatst Aangepast op"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Laatst bijgewerkt door"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Laatst bijgewerkt op"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Naam:"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Volgorde"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Gebruiker"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/nl_NL.po
+++ b/oauth_provider/i18n/nl_NL.po
@@ -6,7 +6,7 @@
 # Peter Hageman <hageman.p@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-06-24 08:50+0000\n"
 "PO-Revision-Date: 2017-06-24 08:50+0000\n"

--- a/oauth_provider/i18n/nl_NL.po
+++ b/oauth_provider/i18n/nl_NL.po
@@ -1,0 +1,578 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# Peter Hageman <hageman.p@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 08:50+0000\n"
+"PO-Revision-Date: 2017-06-24 08:50+0000\n"
+"Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/teams/23907/nl_NL/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl_NL\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Weergavenaam"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "JSON Web Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Laatst gewijzigd op"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/pl.po
+++ b/oauth_provider/i18n/pl.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Polish (https://www.transifex.com/oca/teams/23907/pl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pl\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>=14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktywny"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Kod"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Utworzone przez"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Utworzono"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Wyświetlana nazwa "
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Ostatnio modyfikowano"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Ostatnio modyfikowane przez"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ostatnia zmiana"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nazwa"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Numeracja"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Użytkownik"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/pl.po
+++ b/oauth_provider/i18n/pl.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/pt.po
+++ b/oauth_provider/i18n/pt.po
@@ -7,7 +7,7 @@
 # Pedro Castro Silva <pedrocs@sossia.pt>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/pt.po
+++ b/oauth_provider/i18n/pt.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Pedro Castro Silva <pedrocs@sossia.pt>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Pedro Castro Silva <pedrocs@sossia.pt>, 2017\n"
+"Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Ativo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Código"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descrição"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nome"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Campos"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Modificado a última vez por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Atualizado pela última vez por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Atualizado pela última vez em"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modelo"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nome"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sequência"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Utilizador"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/pt_BR.po
+++ b/oauth_provider/i18n/pt_BR.po
@@ -7,7 +7,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/pt_BR.po
+++ b/oauth_provider/i18n/pt_BR.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# Letícia do Nascimento Souza <leticia.souza@kmee.com.br>, 2017
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Ativo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Código"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descrição"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nome para Mostrar"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Campos"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última atualização em"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Última atualização por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Última atualização em"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modelo"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nome"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Nenhum"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Senha"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sequência"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Usuário"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Usuários"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/pt_PT.po
+++ b/oauth_provider/i18n/pt_PT.po
@@ -7,7 +7,7 @@
 # Pedro Castro Silva <pedrocs@sossia.pt>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/pt_PT.po
+++ b/oauth_provider/i18n/pt_PT.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Pedro Castro Silva <pedrocs@sossia.pt>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Pedro Castro Silva <pedrocs@sossia.pt>, 2017\n"
+"Language-Team: Portuguese (Portugal) (https://www.transifex.com/oca/teams/23907/pt_PT/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_PT\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Ativo"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Código"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Descrição"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nome a Apresentar"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Campos"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Última Modificação Em"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Atualizado pela última vez por"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Atualizado pela última vez em"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Modelo"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nome"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Utilizador"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/ro.po
+++ b/oauth_provider/i18n/ro.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/ro.po
+++ b/oauth_provider/i18n/ro.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Romanian (https://www.transifex.com/oca/teams/23907/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Activ"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Creat la"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Nume Afişat"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Ultima actualizare în"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare făcută de"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare la"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Nume"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Secventa"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Utilizator"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/ru.po
+++ b/oauth_provider/i18n/ru.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Russian (https://www.transifex.com/oca/teams/23907/ru/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ru\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Активное"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Код"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Создано"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Создан"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Описание"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Последний раз обновлено"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Последний раз обновлено"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Модель"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Название"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Последовательность"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Пользователь"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/ru.po
+++ b/oauth_provider/i18n/ru.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/sk.po
+++ b/oauth_provider/i18n/sk.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# gebri <gebri@inmail.sk>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: gebri <gebri@inmail.sk>, 2017\n"
+"Language-Team: Slovak (https://www.transifex.com/oca/teams/23907/sk/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sk\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktívne"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Vytvoril"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Vytvorené"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Popis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Zobraziť meno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Posledná modifikácia"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Naposledy upravoval"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Naposledy upravované"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Meno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Postupnosť"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/sk.po
+++ b/oauth_provider/i18n/sk.po
@@ -7,7 +7,7 @@
 # gebri <gebri@inmail.sk>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/sl.po
+++ b/oauth_provider/i18n/sl.po
@@ -7,7 +7,7 @@
 # Matjaž Mozetič <m.mozetic@matmoz.si>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/sl.po
+++ b/oauth_provider/i18n/sl.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>, 2017\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktivno"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Koda"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Ustvaril"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Ustvarjeno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Prikazni naziv"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Polja"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr "Filter"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Zadnjič spremenjeno"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Zadnji posodobil"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Zadnjič posodobljeno"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Model"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr "Naziv modela"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Naziv"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr "Brez"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Geslo"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Zaporedje"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Uporabnik"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Uporabniki"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/sr.po
+++ b/oauth_provider/i18n/sr.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/sr.po
+++ b/oauth_provider/i18n/sr.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Serbian (https://www.transifex.com/oca/teams/23907/sr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sr\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Kreiran"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Ime"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Niz"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/sr@latin.po
+++ b/oauth_provider/i18n/sr@latin.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/sr@latin.po
+++ b/oauth_provider/i18n/sr@latin.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Serbian (Latin) (https://www.transifex.com/oca/teams/23907/sr@latin/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sr@latin\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktivno"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Kreirao"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Kreiran"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Opis"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Ime za prikaz"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Zadnja izmjena"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Zadnja izmjena"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Zadnja izmjena"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Ime:"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sekvenca"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Korisnik"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/sv.po
+++ b/oauth_provider/i18n/sv.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/sv.po
+++ b/oauth_provider/i18n/sv.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Swedish (https://www.transifex.com/oca/teams/23907/sv/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sv\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Aktiv"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Skapad av"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Skapad den"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Beskrivnig"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Visa namn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Senast redigerad"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Senast uppdaterad av"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Senast uppdaterad"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Namn"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sequence"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Användare"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/th.po
+++ b/oauth_provider/i18n/th.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/th.po
+++ b/oauth_provider/i18n/th.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Thai (https://www.transifex.com/oca/teams/23907/th/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: th\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "เปิดใช้งาน"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "สร้างโดย"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "สร้างเมื่อ"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "รายละเอียด"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "ชื่อที่ใช้แสดง"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "รหัส"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "แก้ไขครั้งสุดท้ายเมื่อ"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "อัพเดทครั้งสุดท้ายโดย"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "อัพเดทครั้งสุดท้ายเมื่อ"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "ชื่อ"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "กำหนดเลขที่เอกสาร"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "ผู้ใช้"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/tr.po
+++ b/oauth_provider/i18n/tr.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Ahmet Altinisik <aaltinisik@altinkaya.com.tr>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Ahmet Altinisik <aaltinisik@altinkaya.com.tr>, 2017\n"
+"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Etkin"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Kod"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Oluşturan"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Oluşturuldu"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Açıklama"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Görünen İsim"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr "Alanlar"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Son değişiklik"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Son güncelleyen"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Son güncelleme"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Model"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Adı"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr "Parola"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sıralama"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Kullanıcı"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Kullanıcılar"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/tr.po
+++ b/oauth_provider/i18n/tr.po
@@ -7,7 +7,7 @@
 # Ahmet Altinisik <aaltinisik@altinkaya.com.tr>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/tr_TR.po
+++ b/oauth_provider/i18n/tr_TR.po
@@ -7,7 +7,7 @@
 # Ozge Altinisik <ozge@altinkaya.com.tr>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/tr_TR.po
+++ b/oauth_provider/i18n/tr_TR.po
@@ -1,0 +1,574 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# Ozge Altinisik <ozge@altinkaya.com.tr>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Ozge Altinisik <ozge@altinkaya.com.tr>, 2017\n"
+"Language-Team: Turkish (Turkey) (https://www.transifex.com/oca/teams/23907/tr_TR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr_TR\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Etkin"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Oluşturan"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Oluşturulma tarihi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Açıklama"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Görünen ad"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "Kimlik"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "En son güncelleme tarihi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "En son güncelleyen "
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "En son güncelleme tarihi"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "Tip"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr "Tip adı"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Ad"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Sıra"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Kullanıcı"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "Kullanıcılar"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/uk.po
+++ b/oauth_provider/i18n/uk.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/uk.po
+++ b/oauth_provider/i18n/uk.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Ukrainian (https://www.transifex.com/oca/teams/23907/uk/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: uk\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Створив"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Дата створення"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Опис"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Назва для відображення"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Остання модифікація"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Востаннє оновив"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Останнє оновлення"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Name"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Послідовність"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/vi.po
+++ b/oauth_provider/i18n/vi.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/vi.po
+++ b/oauth_provider/i18n/vi.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Vietnamese (https://www.transifex.com/oca/teams/23907/vi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: vi\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Hoạt động"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Được tạo bởi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Được tạo vào"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Miêu tả"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "Tên hiển thị"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "Sửa lần cuối vào"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Last Updated by"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Cập nhật lần cuối vào"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Tên"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "Trình tự"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "Người sử dụng"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/vi_VN.po
+++ b/oauth_provider/i18n/vi_VN.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Vietnamese (Viet Nam) (https://www.transifex.com/oca/teams/23907/vi_VN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: vi_VN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "Có hiệu lực"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "Mã"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "Tạo bởi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "Tạo vào"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "Mô tả"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "Cập nhật lần cuối bởi"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "Cập nhật lần cuối vào"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "Tên"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/vi_VN.po
+++ b/oauth_provider/i18n/vi_VN.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/zh_CN.po
+++ b/oauth_provider/i18n/zh_CN.po
@@ -8,7 +8,7 @@
 # Jeffery CHEN <jeffery9@gmail.com>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/i18n/zh_CN.po
+++ b/oauth_provider/i18n/zh_CN.po
@@ -1,0 +1,575 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+# ITGeeker <alanljj@qq.com>, 2017
+# Jeffery CHEN <jeffery9@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: Jeffery CHEN <jeffery9@gmail.com>, 2017\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "有效"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr "代码"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "创建者"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "创建时间"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "说明"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "显示名称"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "ID"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "最后修改时间"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "最后更新者"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "上次更新日期"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr "模型"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "名称"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "序列"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "用户"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr "用户"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/zh_TW.po
+++ b/oauth_provider/i18n/zh_TW.po
@@ -1,0 +1,573 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * oauth_provider
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-19 18:00+0000\n"
+"PO-Revision-Date: 2017-04-19 18:00+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Chinese (Taiwan) (https://www.transifex.com/oca/teams/23907/zh_TW/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_active
+msgid "A token is active only if it has not yet expired."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_active
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_active
+msgid "Active"
+msgstr "活躍"
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Allowed Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "Allowed Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "Allowed redirect URIs for the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_application_type
+msgid "Application type to be used with this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+#: selection:oauth.provider.client,response_type:0
+msgid "Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "Authorize"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Backend Application (not implemented)"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.token,token_type:0
+msgid "Bearer"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid ""
+"Check this box if the user shouldn't be prompted to authorize or not the "
+"requested scopes."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Client Credentials"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_identifier
+msgid "Client Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_client_id
+msgid "Client allowed to redirect using this URI."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_client_id
+msgid "Client associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_client_id
+msgid "Client associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_code
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_code
+msgid "Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_code
+msgid "Code of the scope, used in OAuth requests."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_uid
+msgid "Created by"
+msgstr "建立者"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_create_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_create_date
+msgid "Created on"
+msgstr "建立於"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_description
+msgid "Description"
+msgstr "說明"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_description
+msgid "Description of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_display_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_display_name
+msgid "Display Name"
+msgstr "顯示名稱"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expiration time of the token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_expires_at
+msgid "Expires at"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_field_ids
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Fields"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_field_ids
+msgid "Fields allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_filter_id
+msgid "Filter applied to retrieve records allowed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+msgid "Filter settings"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_grant_type
+msgid "Grant type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_id
+msgid "ID"
+msgstr "編號"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Implicit"
+msgstr ""
+
+#. module: oauth_provider
+#: code:addons/oauth_provider/models/oauth_provider_token.py:75
+#, python-format
+msgid "Invalid operator {operator} for  field active!"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope___last_update
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token___last_update
+msgid "Last Modified on"
+msgstr "最後修改:"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_uid
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_uid
+msgid "Last Updated by"
+msgstr "最後更新："
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_write_date
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_write_date
+msgid "Last Updated on"
+msgstr "最後更新於"
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Legacy Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_scope_ids
+msgid "List of scopes the client is allowed to access."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Mobile Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_model
+msgid "Model Name"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model_id
+msgid "Model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_name
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_scope_name
+msgid "Name"
+msgstr "名稱"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_code
+msgid "Name of the authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_model
+msgid "Name of the model allowed to be accessed by this scope."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_scope_name
+msgid "Name of the scope, displayed to the user."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_name
+msgid "Name of this client."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,response_type:0
+msgid "None"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_grant_type
+msgid "OAuth Grant Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_res_users_oauth_identifier
+msgid "OAuth Identifier"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_authorization_code
+msgid "OAuth Provider Authorization Code"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_client
+msgid "OAuth Provider Client"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_client_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_client
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_tree
+msgid "OAuth Provider Clients"
+msgstr ""
+
+#. module: oauth_provider
+#: model:res.groups,name:oauth_provider.group_oauth_provider_manager
+msgid "OAuth Provider Manager"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_redirect_uri
+msgid "OAuth Provider Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_scope
+msgid "OAuth Provider Scope"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.actions.act_window,name:oauth_provider.act_open_oauth_provider_scope_view
+#: model:ir.ui.menu,name:oauth_provider.menu_oauth_provider_scope
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_form
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_search
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_scope_tree
+msgid "OAuth Provider Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_oauth_provider_token
+msgid "OAuth Provider Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_redirect_uri_ids
+msgid "OAuth Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_response_type
+msgid "OAuth Response Type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_secret
+msgid "Optional secret used to authenticate the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Order of the redirect URIs."
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,grant_type:0
+msgid "Password"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,token_type:0
+msgid "Randomly generated"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_redirect_uri_id
+msgid "Redirect URI associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.view_oauth_provider_client_form
+msgid "Redirect URIs"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "Refresh token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_response_type
+msgid "Response type used by the client for OAuth."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_scope_ids
+msgid "Scopes allowed by this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_scope_ids
+msgid "Scopes allowed by this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_secret
+msgid "Secret"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_redirect_uri_sequence
+msgid "Sequence"
+msgstr "序列"
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_skip_authorization
+msgid "Skip authorization"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_res_users_oauth_identifier
+msgid "String used to identify this user during an OAuth session."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:res.users:0
+msgid "The OAuth identifier of the user must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.authorization.code:0
+msgid "The authorization code must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.scope:0
+msgid "The code of the scopes must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.client:0
+msgid "The identifier of the client must be unique !"
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The refresh token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_refresh_token
+msgid "The refresh token, if applicable."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token
+msgid "The token itself."
+msgstr ""
+
+#. module: oauth_provider
+#: sql_constraint:oauth.provider.token:0
+msgid "The token must be unique per client !"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.ui.view,arch_db:oauth_provider.authorization
+msgid "This application would like to access these resources :"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token
+#: selection:oauth.provider.client,response_type:0
+msgid "Token"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_client_token_type
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_token_type
+msgid "Token type"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_token_type
+msgid ""
+"Type of token stored. Currently, only the bearer token type is available."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_token_type
+msgid ""
+"Type of token to return. The base module only provides randomly generated "
+"tokens."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_redirect_uri_name
+msgid "URI of the redirect."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_client_identifier
+msgid "Unique identifier of the client."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_authorization_code_user_id
+#: model:ir.model.fields,field_description:oauth_provider.field_oauth_provider_token_user_id
+msgid "User"
+msgstr "使用者"
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_user_id
+msgid "User associated to this authorization code."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_token_user_id
+msgid "User associated to this token."
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model,name:oauth_provider.model_res_users
+msgid "Users"
+msgstr ""
+
+#. module: oauth_provider
+#: selection:oauth.provider.client,application_type:0
+msgid "Web Application"
+msgstr ""
+
+#. module: oauth_provider
+#: model:ir.model.fields,help:oauth_provider.field_oauth_provider_authorization_code_active
+msgid "When unchecked, the code is invalidated."
+msgstr ""

--- a/oauth_provider/i18n/zh_TW.po
+++ b/oauth_provider/i18n/zh_TW.po
@@ -6,7 +6,7 @@
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 10.0c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-19 18:00+0000\n"
 "PO-Revision-Date: 2017-04-19 18:00+0000\n"

--- a/oauth_provider/models/__init__.py
+++ b/oauth_provider/models/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import oauth_provider_authorization_code
+from . import oauth_provider_redirect_uri
+from . import oauth_provider_scope
+from . import oauth_provider_token
+from . import oauth_provider_client
+from . import res_users

--- a/oauth_provider/models/__init__.py
+++ b/oauth_provider/models/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import oauth_provider_authorization_code
 from . import oauth_provider_redirect_uri

--- a/oauth_provider/models/oauth_provider_authorization_code.py
+++ b/oauth_provider/models/oauth_provider_authorization_code.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class OAuthProviderAuthorizationCode(models.Model):
+    _name = 'oauth.provider.authorization.code'
+    _description = 'OAuth Provider Authorization Code'
+    _rec_name = 'code'
+
+    code = fields.Char(required=True, help='Name of the authorization code.')
+    client_id = fields.Many2one(
+        comodel_name='oauth.provider.client', string='Client', required=True,
+        help='Client associated to this authorization code.')
+    user_id = fields.Many2one(
+        comodel_name='res.users', string='User', required=True,
+        help='User associated to this authorization code.')
+    redirect_uri_id = fields.Many2one(
+        comodel_name='oauth.provider.redirect.uri', string='Redirect URI',
+        required=True,
+        help='Redirect URI associated to this authorization code.')
+    scope_ids = fields.Many2many(
+        comodel_name='oauth.provider.scope', string='Scopes',
+        help='Scopes allowed by this authorization code.')
+    active = fields.Boolean(
+        default=True, help='When unchecked, the code is invalidated.')
+
+    _sql_constraints = [
+        ('code_client_id_unique', 'UNIQUE (code, client_id)',
+         'The authorization code must be unique per client !'),
+    ]

--- a/oauth_provider/models/oauth_provider_authorization_code.py
+++ b/oauth_provider/models/oauth_provider_authorization_code.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from openerp import models, fields
+from odoo import models, fields
 
 
-class OAuthProviderAuthorizationCode(models.Model):
+class OauthProviderAuthorizationCode(models.Model):
     _name = 'oauth.provider.authorization.code'
     _description = 'OAuth Provider Authorization Code'
     _rec_name = 'code'

--- a/oauth_provider/models/oauth_provider_client.py
+++ b/oauth_provider/models/oauth_provider_client.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import hashlib
+import uuid
+import logging
+from openerp import models, api, fields
+from ..oauth2.validator import OdooValidator
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from oauthlib import oauth2
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class OAuthProviderClient(models.Model):
+    _name = 'oauth.provider.client'
+    _description = 'OAuth Provider Client'
+
+    name = fields.Char(required=True, help='Name of this client.')
+    identifier = fields.Char(
+        string='Client Identifier', required=True, readonly=True,
+        default=lambda self: str(uuid.uuid4()), copy=False,
+        help='Unique identifier of the client.')
+    secret = fields.Char(
+        help='Optional secret used to authenticate the client.')
+    skip_authorization = fields.Boolean(
+        help='Check this box if the user shouldn\'t be prompted to authorize '
+        'or not the requested scopes.')
+    application_type = fields.Selection(
+        selection=[
+            ('web application', 'Web Application'),
+            ('mobile application', 'Mobile Application'),
+            ('legacy application', 'Legacy Application'),
+            ('backend application', 'Backend Application (not implemented)'),
+        ], required=True, default='web application',
+        help='Application type to be used with this client.')
+    grant_type = fields.Selection(
+        selection=[
+            ('authorization_code', 'Authorization Code'),
+            ('implicit', 'Implicit'),
+            ('password', 'Password'),
+            ('client_credentials', 'Client Credentials'),
+        ], string='OAuth Grant Type',
+        compute='_compute_grant_response_type', store=True,
+        help='Grant type used by the client for OAuth.')
+    response_type = fields.Selection(
+        selection=[
+            ('code', 'Authorization Code'),
+            ('token', 'Token'),
+            ('none', 'None'),
+        ], string='OAuth Response Type',
+        compute='_compute_grant_response_type', store=True,
+        help='Response type used by the client for OAuth.')
+    token_type = fields.Selection(
+        selection=[('random', 'Randomly generated')],
+        required=True, default='random',
+        help='Type of token to return. The base module only provides randomly '
+        'generated tokens.')
+    scope_ids = fields.Many2many(
+        comodel_name='oauth.provider.scope', string='Allowed Scopes',
+        help='List of scopes the client is allowed to access.')
+    redirect_uri_ids = fields.One2many(
+        comodel_name='oauth.provider.redirect.uri', inverse_name='client_id',
+        string='OAuth Redirect URIs',
+        help='Allowed redirect URIs for the client.')
+
+    _sql_constraints = [
+        ('identifier_unique', 'UNIQUE (identifier)',
+         'The identifier of the client must be unique !'),
+    ]
+
+    @api.model
+    def application_type_mapping(self):
+        return {
+            'web application': ('authorization_code', 'code'),
+            'mobile application': ('implicit', 'token'),
+            'legacy application': ('password', 'none'),
+            'backend application': ('client_credentials', 'none'),
+        }
+
+    @api.multi
+    @api.depends('application_type')
+    def _compute_grant_response_type(self):
+        applications = self.application_type_mapping()
+        for client in self:
+            client.grant_type, client.response_type = applications[
+                client.application_type]
+
+    @api.multi
+    def get_oauth2_server(self, validator=None, **kwargs):
+        """ Returns an OAuth2 server instance, depending on the client application type
+
+        Generates an OdooValidator instance if no custom validator is defined
+        All other arguments are directly passed to the server constructor (for
+        example, a token generator function)
+        """
+        self.ensure_one()
+
+        if validator is None:
+            validator = OdooValidator()
+
+        if self.application_type == 'web application':
+            return oauth2.WebApplicationServer(validator, **kwargs)
+        elif self.application_type == 'mobile application':
+            return oauth2.MobileApplicationServer(validator, **kwargs)
+        elif self.application_type == 'legacy application':
+            return oauth2.LegacyApplicationServer(validator, **kwargs)
+        elif self.application_type == 'backend application':
+            return oauth2.BackendApplicationServer(validator, **kwargs)
+
+    @api.multi
+    def generate_user_id(self, user):
+        """ Generates a unique user identifier for this client
+
+        Include the client and user identifiers in the final identifier to
+        generate a different identifier for the same user, depending on the
+        client accessing this user. By doing this, clients cannot find a list
+        of common users by comparing their identifiers list from tokeninfo.
+        """
+        self.ensure_one()
+
+        user_identifier = self.identifier \
+            + user.sudo().oauth_identifier
+
+        # Use a sha256 to avoid a too long final string
+        return hashlib.sha256(user_identifier).hexdigest()

--- a/oauth_provider/models/oauth_provider_client.py
+++ b/oauth_provider/models/oauth_provider_client.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import hashlib
 import uuid
 import logging
-from openerp import models, api, fields
+from odoo import models, api, fields
 from ..oauth2.validator import OdooValidator
 
 _logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ except ImportError:
     _logger.debug('Cannot `import oauthlib`.')
 
 
-class OAuthProviderClient(models.Model):
+class OauthProviderClient(models.Model):
     _name = 'oauth.provider.client'
     _description = 'OAuth Provider Client'
 

--- a/oauth_provider/models/oauth_provider_redirect_uri.py
+++ b/oauth_provider/models/oauth_provider_redirect_uri.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class OAuthProviderRedirectURI(models.Model):
+    _name = 'oauth.provider.redirect.uri'
+    _description = 'OAuth Provider Redirect URI'
+
+    name = fields.Char(required=True, help='URI of the redirect.')
+    sequence = fields.Integer(
+        required=True, default=10, help='Order of the redirect URIs.')
+    client_id = fields.Many2one(
+        comodel_name='oauth.provider.client', string='Client', required=True,
+        help='Client allowed to redirect using this URI.')

--- a/oauth_provider/models/oauth_provider_redirect_uri.py
+++ b/oauth_provider/models/oauth_provider_redirect_uri.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from openerp import models, fields
+from odoo import models, fields
 
 
-class OAuthProviderRedirectURI(models.Model):
+class OauthProviderRedirectURI(models.Model):
     _name = 'oauth.provider.redirect.uri'
     _description = 'OAuth Provider Redirect URI'
 

--- a/oauth_provider/models/oauth_provider_scope.py
+++ b/oauth_provider/models/oauth_provider_scope.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import datetime
+import dateutil
+import time
+from collections import defaultdict
+from openerp import models, api, fields
+from openerp.tools.safe_eval import safe_eval
+
+
+class OAuthProviderScope(models.Model):
+    _name = 'oauth.provider.scope'
+    _description = 'OAuth Provider Scope'
+
+    name = fields.Char(
+        required=True, translate=True,
+        help='Name of the scope, displayed to the user.')
+    code = fields.Char(
+        required=True, help='Code of the scope, used in OAuth requests.')
+    description = fields.Text(
+        required=True, translate=True,
+        help='Description of the scope, displayed to the user.')
+    model_id = fields.Many2one(
+        comodel_name='ir.model', string='Model', required=True,
+        help='Model allowed to be accessed by this scope.')
+    model = fields.Char(
+        related='model_id.model', string='Model Name', readonly=True,
+        help='Name of the model allowed to be accessed by this scope.')
+    filter_id = fields.Many2one(
+        comodel_name='ir.filters', string='Filter',
+        domain="[('model_id', '=', model)]",
+        help='Filter applied to retrieve records allowed by this scope.')
+    field_ids = fields.Many2many(
+        comodel_name='ir.model.fields', string='Fields',
+        domain="[('model_id', '=', model_id)]",
+        help='Fields allowed by this scope.')
+
+    _sql_constraints = [
+        ('code_unique', 'UNIQUE (code)',
+         'The code of the scopes must be unique !'),
+    ]
+
+    @api.model
+    def _get_ir_filter_eval_context(self):
+        """ Returns the base eval context for ir.filter domains evaluation """
+        return {
+            'datetime': datetime,
+            'dateutil': dateutil,
+            'time': time,
+            'uid': self.env.uid,
+            'user': self.env.user,
+        }
+
+    @api.multi
+    def get_data_for_model(self, model, res_id=None, all_scopes_match=False):
+        """ Return the data matching the scopes from the requested model """
+        data = defaultdict(dict)
+        eval_context = self._get_ir_filter_eval_context()
+        all_scopes_records = self.env[model]
+        for scope in self.filtered(lambda record: record.model == model):
+            # Retrieve the scope's domain
+            filter_domain = [(1, '=', 1)]
+            if scope.filter_id:
+                filter_domain = safe_eval(
+                    scope.filter_id.sudo().domain, eval_context)
+            if res_id is not None:
+                filter_domain.append(('id', '=', res_id))
+
+            # Retrieve data of the matching records, depending on the scope's
+            # fields
+            records = self.env[model].search(filter_domain)
+            for record_data in records.read(scope.field_ids.mapped('name')):
+                for field, value in record_data.items():
+                    if isinstance(value, tuple):
+                        # Return only the name for a many2one
+                        data[record_data['id']][field] = value[1]
+                    else:
+                        data[record_data['id']][field] = value
+
+            # Keep a list of records that match all scopes
+            if not all_scopes_records:
+                all_scopes_records = records
+            else:
+                all_scopes_records &= records
+
+        # If all scopes are required to match, filter the results to keep only
+        # those mathing all scopes
+        if all_scopes_match:
+            data = dict(filter(
+                lambda record_data: record_data[0] in all_scopes_records.ids,
+                data.items()))
+
+        # If a single record was requested, return only data coming from this
+        # record
+        # Return an empty dictionnary if this record didn't recieve data to
+        # return
+        if res_id is not None:
+            data = data.get(res_id, {})
+
+        return data

--- a/oauth_provider/models/oauth_provider_scope.py
+++ b/oauth_provider/models/oauth_provider_scope.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import datetime
 import dateutil
 import time
 from collections import defaultdict
-from openerp import models, api, fields
-from openerp.tools.safe_eval import safe_eval
+
+from odoo import api, fields, models
+from odoo.tools.safe_eval import safe_eval
+
+from ..exceptions import OauthScopeValidationException
 
 
-class OAuthProviderScope(models.Model):
+class OauthProviderScope(models.Model):
     _name = 'oauth.provider.scope'
     _description = 'OAuth Provider Scope'
 
@@ -42,8 +45,9 @@ class OAuthProviderScope(models.Model):
          'The code of the scopes must be unique !'),
     ]
 
+    @property
     @api.model
-    def _get_ir_filter_eval_context(self):
+    def ir_filter_eval_context(self):
         """ Returns the base eval context for ir.filter domains evaluation """
         return {
             'datetime': datetime,
@@ -54,23 +58,53 @@ class OAuthProviderScope(models.Model):
         }
 
     @api.multi
-    def get_data_for_model(self, model, res_id=None, all_scopes_match=False):
-        """ Return the data matching the scopes from the requested model """
-        data = defaultdict(dict)
-        eval_context = self._get_ir_filter_eval_context()
-        all_scopes_records = self.env[model]
-        for scope in self.filtered(lambda record: record.model == model):
-            # Retrieve the scope's domain
-            filter_domain = [(1, '=', 1)]
-            if scope.filter_id:
-                filter_domain = safe_eval(
-                    scope.filter_id.sudo().domain, eval_context)
-            if res_id is not None:
-                filter_domain.append(('id', '=', res_id))
+    def filter_by_model(self, model):
+        """ Return the current scopes that are associated to the model.
 
-            # Retrieve data of the matching records, depending on the scope's
-            # fields
-            records = self.env[model].search(filter_domain)
+        Args:
+            model (str or BaseModel): Name or object of the model to operate
+                on.
+
+        Returns:
+            OauthProviderScope: Recordsets associated to the model.
+        """
+        if isinstance(model, models.BaseModel):
+            model = model._name
+        return self.filtered(lambda record: record.model == model)
+
+    @api.multi
+    def get_data(self, model_name, record_ids=None, all_scopes_match=False,
+                 domain=None):
+        """ Return the data matching the scopes from the requested model.
+
+        Args:
+            model_name (str): Name of the model to operate on.
+            record_ids (list[int]): ID of record(s) to find. Will only return
+                this record, if defined.
+            all_scopes_match (bool): True to filter out records that do not
+                match all of the scopes in the current recordset.
+            domain (list of tuples, optional): Domain to append to the
+                `filter_domain` that is defined in the scope.
+
+        Returns:
+            dict:
+                This will be a dictionary of scoped record data, keyed by
+                record ID.
+                If `record_ids` is defined, and only one ID, the inner data
+                dictionary will be returned without nesting.
+        """
+
+        data = defaultdict(dict)
+        eval_context = self.ir_filter_eval_context
+        all_scopes_records = self.env[model_name]
+        record_ids = record_ids or []
+
+        for scope in self.filter_by_model(model_name):
+
+            records = scope._get_scoped_records(
+                model_name, eval_context, domain, record_ids,
+            )
+
             for record_data in records.read(scope.field_ids.mapped('name')):
                 for field, value in record_data.items():
                     if isinstance(value, tuple):
@@ -86,17 +120,219 @@ class OAuthProviderScope(models.Model):
                 all_scopes_records &= records
 
         # If all scopes are required to match, filter the results to keep only
-        # those mathing all scopes
+        # those matching all scopes
         if all_scopes_match:
-            data = dict(filter(
-                lambda record_data: record_data[0] in all_scopes_records.ids,
-                data.items()))
+            data = dict(
+                filter(
+                    lambda _data: _data[0] in all_scopes_records.ids,
+                    data.items(),
+                ),
+            )
 
-        # If a single record was requested, return only data coming from this
-        # record
-        # Return an empty dictionnary if this record didn't recieve data to
-        # return
-        if res_id is not None:
-            data = data.get(res_id, {})
+        matched_records = {
+            rec_id: data.get(rec_id, {}) for rec_id in record_ids
+        }
+        if matched_records:
+            if len(matched_records) == 1:
+                return matched_records.values()[0]
+            return matched_records
 
         return data
+
+    @api.multi
+    def create_record(self, model_name, vals):
+        """ Create a record, validate the scope, and return (if valid).
+
+        Args:
+            model_name (str): Name of the model to operate on.
+            vals (dict): Values to create record with, keyed by field name.
+
+        Returns:
+            OauthProviderScope: Newly created record
+
+        Raises:
+            OauthScopeValidationException: If fields are included in vals,
+                but are not within the current scope.
+        """
+
+        if not self._validate_scope_field(model_name, vals):
+            raise OauthScopeValidationException('field')
+
+        record = self.env[model_name].create(vals)
+
+        if not self._validate_scope_record(record):
+            raise OauthScopeValidationException('record')
+
+        return record
+
+    def get_record(self, model_name, domain=None):
+        """ Get the currently scoped records, adhering to optional domain.
+
+        Args:
+            model_name (str): Model to search.
+            domain (list of tuples, optional): Additional domain to add to the
+                currently scoped filter.
+
+        Returns:
+            BaseModel: Recordsets.
+        """
+        records = self.env[model_name]
+        eval_context = self.ir_filter_eval_context
+        for scope in self.filter_by_model(model_name):
+            records += scope._get_scoped_records(
+                model_name, eval_context, domain,
+            )
+        return records
+
+    @api.multi
+    def write_record(self, records, vals):
+        """ Write to a recordset, adhering to the current scope.
+
+        Args:
+            records (BaseModel): Recordset to write to.
+            vals (dict): Values to modify records with, keyed by field name.
+
+        Returns:
+            OauthProviderScope: The same recordset that was provided as input.
+
+        Raises:
+            OauthScopeValidationException: Raised in the following cases:
+                * If records are attempted to be edited, but are not within
+                    the current scope.
+                * If fields are included in vals, but are not within the
+                    current scope.
+                * If the record no longer falls within scope after being
+        """
+
+        if not self._validate_scope_field(records._name, vals):
+            raise OauthScopeValidationException('field')
+
+        if not self._validate_scope_record(records):
+            raise OauthScopeValidationException('record')
+
+        records.write(vals)
+
+        if not self._validate_scope_record(records):
+            raise OauthScopeValidationException('record')
+
+        return records
+
+    @api.multi
+    def delete_record(self, records):
+        """ Delete a recordset that is within the current scope.
+
+        Args:
+            records (BaseModel): Recordset to delete.
+
+        Raises:
+            OauthScopeValidationException: If records are not within the
+                current scope.
+        """
+
+        if not self._validate_scope_record(records):
+            raise OauthScopeValidationException('record')
+
+        records.unlink()
+
+    @api.multi
+    def _get_filter_domain(self, eval_context, record_ids=None):
+        """ Return the scope's domain.
+
+        Args:
+            eval_context (dict): Base eval context, such as provided by
+                `ir_filter_eval_context`
+            record_ids (list[ints], optional): ID of record(s) to explicitly
+                query.
+
+        Returns:
+            list of tuples: Domain of the scope, in standard Odoo format.
+        """
+
+        self.ensure_one()
+
+        if record_ids is None:
+            record_ids = []
+
+        filter_domain = [(1, '=', 1)]
+
+        if self.filter_id:
+            filter_domain = safe_eval(
+                self.filter_id.sudo().domain,
+                eval_context,
+            )
+
+        if record_ids:
+            filter_domain.append(
+                ('id', 'in', record_ids),
+            )
+
+        return filter_domain
+
+    @api.multi
+    def _get_scoped_records(self, model_name, eval_context=None,
+                            add_domain=None, record_ids=None):
+        """ Return records that are within the scopes in the recordset.
+
+        Args:
+            model_name (str): Name of model to operate on.
+            eval_context (dict, optional): Base eval context, such as provided
+                by `ir_filter_eval_context`.
+            add_domain (list of tuples, optional): Domain to append to the
+                `filter_domain` that is defined in the scope.
+            record_ids (list[int], optional): ID of record to find. Will
+                only return this record, if defined.
+
+        Returns:
+            BaseModel: Recordset matching the scope.
+        """
+
+        self.ensure_one()
+        if eval_context is None:
+            eval_context = self.ir_filter_eval_context
+        if add_domain is None:
+            add_domain = []
+        filter_domain = self._get_filter_domain(eval_context, record_ids)
+        return self.env[model_name].search(filter_domain + add_domain)
+
+    @api.multi
+    def _validate_scope_record(self, records):
+        """ Validate that the recordset is within the current scope.
+
+        Args:
+            records (BaseModel): Recordset to validate.
+
+        Returns:
+            bool: Indicating whether the records are within scope.
+        """
+
+        scoped_records = self.env[records._name]
+        for scope in self:
+            scoped_records |= scope._get_scoped_records(
+                records._name,
+            )
+        return all([
+            r in scoped_records for r in records
+        ])
+
+    @api.multi
+    def _validate_scope_field(self, model, vals):
+        """ Validate that the input vals do not violate the current scope.
+
+        If there are no fields defined in the scope, all fields are assumed to
+        be permitted.
+
+        Args:
+            model (BaseModel): Name of the model to operate on.
+            vals (dict): Values that should be checked against the current
+                scope, keyed by field name.
+
+        Returns:
+            bool: Whether the values are within the scope.
+        """
+        scopes = self.filter_by_model(model)
+        field_names = scopes.mapped('field_ids.name')
+        if not field_names:
+            return True
+        return all([
+            f in field_names for f in vals.keys()
+        ])

--- a/oauth_provider/models/oauth_provider_token.py
+++ b/oauth_provider/models/oauth_provider_token.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, api, fields, exceptions, _
+
+
+class OAuthProviderToken(models.Model):
+    _name = 'oauth.provider.token'
+    _description = 'OAuth Provider Token'
+    _rec_name = 'token'
+
+    token = fields.Char(required=True, help='The token itself.')
+    token_type = fields.Selection(
+        selection=[('Bearer', 'Bearer')], required=True, default='Bearer',
+        help='Type of token stored. Currently, only the bearer token type is '
+        'available.')
+    refresh_token = fields.Char(
+        help='The refresh token, if applicable.')
+    client_id = fields.Many2one(
+        comodel_name='oauth.provider.client', string='Client', required=True,
+        help='Client associated to this token.')
+    user_id = fields.Many2one(
+        comodel_name='res.users', string='User', required=True,
+        help='User associated to this token.')
+    scope_ids = fields.Many2many(
+        comodel_name='oauth.provider.scope', string='Scopes',
+        help='Scopes allowed by this token.')
+    expires_at = fields.Datetime(
+        required=True, help='Expiration time of the token.')
+    active = fields.Boolean(
+        compute='_compute_active', search='_search_active',
+        help='A token is active only if it has not yet expired.')
+
+    _sql_constraints = [
+        ('token_unique', 'UNIQUE (token, client_id)',
+         'The token must be unique per client !'),
+        ('refresh_token_unique', 'UNIQUE (refresh_token, client_id)',
+         'The refresh token must be unique per client !'),
+    ]
+
+    @api.multi
+    def _compute_active(self):
+        for token in self:
+            token.active = fields.Datetime.now() < token.expires_at
+
+    @api.model
+    def _search_active(self, operator, operand):
+        domain = []
+        if operator == 'in':
+            if True in operand:
+                domain += self._search_active('=', True)
+            if False in operand:
+                domain += self._search_active('=', False)
+            if len(domain) > 1:
+                domain = [(1, '=', 1)]
+        elif operator == 'not in':
+            if True in operand:
+                domain += self._search_active('!=', True)
+            if False in operand:
+                domain += self._search_active('!=', False)
+            if len(domain) > 1:
+                domain = [(0, '=', 1)]
+        elif operator in ('=', '!='):
+            operators = {
+                ('=', True): '>',
+                ('=', False): '<=',
+                ('!=', False): '>',
+                ('!=', True): '<=',
+            }
+            domain = [('expires_at', operators[operator, operand],
+                       fields.Datetime.now())]
+        else:
+            raise exceptions.UserError(
+                _('Invalid operator {operator} for  field active!').format(
+                    operator=operator))
+
+        return domain
+
+    @api.multi
+    def generate_user_id(self):
+        """ Generates a unique user identifier for this token """
+        self.ensure_one()
+
+        return self.client_id.generate_user_id(self.user_id)
+
+    @api.multi
+    def get_data_for_model(self, model, res_id=None, all_scopes_match=False):
+        """ Returns the data of the accessible records of the requested model,
+
+        Data are returned depending on the allowed scopes for the token
+        If the all_scopes_match argument is set to True, return only records
+        allowed by all token's scopes
+        """
+        self.ensure_one()
+
+        # Retrieve records allowed from all scopes
+        return self.sudo(user=self.user_id).scope_ids.get_data_for_model(
+            model, res_id=res_id, all_scopes_match=all_scopes_match)

--- a/oauth_provider/models/res_users.py
+++ b/oauth_provider/models/res_users.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import uuid
+from openerp import models, fields
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    oauth_identifier = fields.Char(
+        string='OAuth Identifier', required=True, readonly=True,
+        default=lambda self: str(uuid.uuid4()), copy=False,
+        help='String used to identify this user during an OAuth session.')
+
+    _sql_constraints = [
+        ('oauth_identifier_unique', 'UNIQUE (oauth_identifier)',
+         'The OAuth identifier of the user must be unique !'),
+    ]

--- a/oauth_provider/models/res_users.py
+++ b/oauth_provider/models/res_users.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import uuid
-from openerp import models, fields
+from odoo import models, fields
 
 
 class ResUsers(models.Model):

--- a/oauth_provider/oauth2/validator.py
+++ b/oauth_provider/oauth2/validator.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import base64
+import logging
+from datetime import datetime, timedelta
+from openerp import http
+from openerp import fields
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from oauthlib.oauth2 import RequestValidator
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class OdooValidator(RequestValidator):
+    """ OAuth2 validator to be used in Odoo
+
+    This is an implementation of oauthlib's RequestValidator interface
+    https://github.com/idan/oauthlib/oauthlib/oauth2/rfc6749/request_validator.py
+    """
+    def _load_client(self, request, client_id=None):
+        """ Returns a client instance for the request """
+        client = request.client
+        if not client:
+            request.client = http.request.env['oauth.provider.client'].search([
+                ('identifier', '=', client_id or request.client_id),
+            ])
+            request.odoo_user = http.request.env.user
+            request.client.client_id = request.client.identifier
+
+    def _extract_auth(self, request):
+        """ Extract auth string from request headers """
+        auth = request.headers.get('Authorization', ' ')
+        auth_type, auth_string = auth.split(' ', 1)
+        if auth_type != 'Basic':
+            return ''
+
+        return auth_string
+
+    def authenticate_client(self, request, *args, **kwargs):
+        """ Authenticate the client """
+        auth_string = self._extract_auth(request)
+        auth_string_decoded = base64.b64decode(auth_string)
+
+        # If we don't have a proper auth string, get values in the request body
+        if ':' not in auth_string_decoded:
+            client_id = request.client_id
+            client_secret = request.client_secret
+        else:
+            client_id, client_secret = auth_string_decoded.split(':', 1)
+
+        self._load_client(request)
+        return (request.client.identifier == client_id) and \
+            (request.client.secret or '') == (client_secret or '')
+
+    def authenticate_client_id(self, client_id, request, *args, **kwargs):
+        """ Ensure client_id belong to a non-confidential client """
+        self._load_client(request, client_id=client_id)
+        return bool(request.client) and not request.client.secret
+
+    def client_authentication_required(self, request, *args, **kwargs):
+        """ Determine if the client authentication is required for the request
+        """
+        # If an auth string was specified, unconditionnally authenticate
+        if self._extract_auth(request):
+            return True
+
+        self._load_client(request)
+        return request.client.grant_type in (
+            'password',
+            'authorization_code',
+            'refresh_token',
+        ) or request.client_secret or \
+            not request.odoo_user.active
+
+    def confirm_redirect_uri(
+            self, client_id, code, redirect_uri, client, *args, **kwargs):
+        """ Ensure that the authorization process' redirect URI
+
+        The authorization process corresponding to the code must begin by using
+        this redirect_uri
+        """
+        code = http.request.env['oauth.provider.authorization.code'].search([
+            ('client_id.identifier', '=', client_id),
+            ('code', '=', code),
+        ])
+        return redirect_uri == code.redirect_uri_id.name
+
+    def get_default_redirect_uri(self, client_id, request, *args, **kwargs):
+        """ Returns the default redirect URI for the client """
+        client = http.request.env['oauth.provider.client'].search([
+            ('identifier', '=', client_id),
+        ])
+        return client.redirect_uri_ids and client.redirect_uri_ids[0].name \
+            or ''
+
+    def get_default_scopes(self, client_id, request, *args, **kwargs):
+        """ Returns a list of default scoprs for the client """
+        client = http.request.env['oauth.provider.client'].search([
+            ('identifier', '=', client_id),
+        ])
+        return ' '.join(client.scope_ids.mapped('code'))
+
+    def get_original_scopes(self, refresh_token, request, *args, **kwargs):
+        """ Returns the list of scopes associated to the refresh token """
+        token = http.request.env['oauth.provider.token'].search([
+            ('client_id', '=', request.client.id),
+            ('refresh_token', '=', refresh_token),
+        ])
+        return token.scope_ids.mapped('code')
+
+    def invalidate_authorization_code(
+            self, client_id, code, request, *args, **kwargs):
+        """ Invalidates an authorization code """
+        code = http.request.env['oauth.provider.authorization.code'].search([
+            ('client_id.identifier', '=', client_id),
+            ('code', '=', code),
+        ])
+        code.sudo().write({'active': False})
+
+    def is_within_original_scope(
+            self, request_scopes, refresh_token, request, *args, **kwargs):
+        """ Check if the requested scopes are within a scope of the token """
+        token = http.request.env['oauth.provider.token'].search([
+            ('client_id', '=', request.client.id),
+            ('refresh_token', '=', refresh_token),
+        ])
+        return set(request_scopes).issubset(
+            set(token.scope_ids.mapped('code')))
+
+    def revoke_token(self, token, token_type_hint, request, *args, **kwargs):
+        """ Revoke an access of refresh token """
+        db_token = http.request.env['oauth.provider.token'].search([
+            ('token', '=', token),
+        ])
+        # If we revoke a full token, simply unlink it
+        if db_token:
+            db_token.sudo().unlink()
+        # If we revoke a refresh token, empty it in the corresponding token
+        else:
+            db_token = http.request.env['oauth.provider.token'].search([
+                ('refresh_token', '=', token),
+            ])
+            db_token.sudo().refresh_token = False
+
+    def rotate_refresh_token(self, request):
+        """ Determine if the refresh token has to be renewed
+
+        Called after refreshing an access token
+        Always refresh the token by default, but child classes could override
+        this method to change this behaviour.
+        """
+        return True
+
+    def save_authorization_code(
+            self, client_id, code, request, *args, **kwargs):
+        """ Store the authorization code into the database """
+        redirect_uri = http.request.env['oauth.provider.redirect.uri'].search([
+            ('name', '=', request.redirect_uri),
+        ])
+        http.request.env['oauth.provider.authorization.code'].sudo().create({
+            'code': code['code'],
+            'client_id': request.client.id,
+            'user_id': request.odoo_user.id,
+            'redirect_uri_id': redirect_uri.id,
+            'scope_ids': [(6, 0, request.client.scope_ids.filtered(
+                lambda record: record.code in request.scopes).ids)],
+        })
+
+    def save_bearer_token(self, token, request, *args, **kwargs):
+        """ Store the bearer token into the database """
+        scopes = token.get('scope', '').split()
+        http.request.env['oauth.provider.token'].sudo().create({
+            'token': token['access_token'],
+            'token_type': token['token_type'],
+            'refresh_token': token.get('refresh_token'),
+            'client_id': request.client.id,
+            'user_id': token.get('odoo_user_id', request.odoo_user.id),
+            'scope_ids': [(6, 0, request.client.scope_ids.filtered(
+                lambda record: record.code in scopes).ids)],
+            'expires_at': fields.Datetime.to_string(
+                datetime.now() + timedelta(seconds=token['expires_in'])),
+        })
+        return request.client.redirect_uri_ids[0].name
+
+    def validate_bearer_token(self, token, scopes, request):
+        """ Ensure the supplied bearer token is valid, and allowed for the scopes
+        """
+        token = http.request.env['oauth.provider.token'].search([
+            ('token', '=', token),
+        ])
+        if scopes is None:
+            scopes = ''
+
+        return set(scopes.split()).issubset(
+            set(token.scope_ids.mapped('code')))
+
+    def validate_client_id(self, client_id, request, *args, **kwargs):
+        """ Ensure client_id belong to a valid and active client """
+        self._load_client(request)
+        return bool(request.client)
+
+    def validate_code(self, client_id, code, client, request, *args, **kwargs):
+        """ Check that the code is valid, and assigned to the given client """
+        code = http.request.env['oauth.provider.authorization.code'].search([
+            ('client_id.identifier', '=', client_id),
+            ('code', '=', code),
+        ])
+        request.odoo_user = code.user_id
+        return bool(code)
+
+    def validate_grant_type(
+            self, client_id, grant_type, client, request, *args, **kwargs):
+        """ Ensure the client is authorized to use the requested grant_type """
+        return client.identifier == client_id and grant_type in (
+            client.grant_type, 'refresh_token'
+        )
+
+    def validate_redirect_uri(
+            self, client_id, redirect_uri, request, *args, **kwargs):
+        """ Ensure the client is allowed to use the requested redurect_uri """
+        return request.client.identifier == client_id and \
+            redirect_uri in request.client.mapped('redirect_uri_ids.name')
+
+    def validate_refresh_token(
+            self, refresh_token, client, request, *args, **kwargs):
+        """ Ensure the refresh token is valid and associated to the client """
+        token = http.request.env['oauth.provider.token'].search([
+            ('client_id', '=', client.id),
+            ('refresh_token', '=', refresh_token),
+        ])
+        return bool(token)
+
+    def validate_response_type(
+            self, client_id, response_type, client, request, *args, **kwargs):
+        """ Ensure the client is allowed to use the requested response_type """
+        return request.client.identifier == client_id and \
+            response_type == request.client.response_type
+
+    def validate_scopes(
+            self, client_id, scopes, client, request, *args, **kwargs):
+        """ Ensure the client is allowed to access all requested scopes """
+        return request.client.identifier == client_id and set(scopes).issubset(
+            set(request.client.mapped('scope_ids.code')))
+
+    def validate_user(
+            self, username, password, client, request, *args, **kwargs):
+        """ Ensure the usernamd and password are valid """
+        uid = http.request.session.authenticate(
+            http.request.session.db, username, password)
+        request.odoo_user = http.request.env['res.users'].browse(uid)
+        return bool(uid)

--- a/oauth_provider/oauth2/validator.py
+++ b/oauth_provider/oauth2/validator.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import base64
 import logging
 from datetime import datetime, timedelta
-from openerp import http
-from openerp import fields
+from odoo import http
+from odoo import fields
 
 _logger = logging.getLogger(__name__)
 
@@ -185,7 +185,8 @@ class OdooValidator(RequestValidator):
             'expires_at': fields.Datetime.to_string(
                 datetime.now() + timedelta(seconds=token['expires_in'])),
         })
-        return request.client.redirect_uri_ids[0].name
+        redirect_uris = request.client.redirect_uri_ids
+        return redirect_uris[:1].name
 
     def validate_bearer_token(self, token, scopes, request):
         """ Ensure the supplied bearer token is valid, and allowed for the scopes

--- a/oauth_provider/security/ir.model.access.csv
+++ b/oauth_provider/security/ir.model.access.csv
@@ -1,0 +1,9 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"oauth_provider_client_all_users","OAuth Client All Users","model_oauth_provider_client",,1,0,0,0
+"oauth_provider_client_manager","OAuth Client Manager","model_oauth_provider_client",group_oauth_provider_manager,1,1,1,1
+"oauth_provider_scope_all_users","OAuth Scope All Users","model_oauth_provider_scope",,1,0,0,0
+"oauth_provider_scope_manager","OAuth Scope Manager","model_oauth_provider_scope",group_oauth_provider_manager,1,1,1,1
+"oauth_provider_redirect_uri_all_users","OAuth Redirect URI All Users","model_oauth_provider_redirect_uri",,1,0,0,0
+"oauth_provider_redirect_uri_manager","OAuth Redirect URI Manager","model_oauth_provider_redirect_uri",group_oauth_provider_manager,1,1,1,1
+"oauth_provider_authorization_code_all_users","OAuth Authorization Code All Users","model_oauth_provider_authorization_code",,1,0,0,0
+"oauth_provider_token_all_users","OAuth Token All Users","model_oauth_provider_token",,1,0,0,0

--- a/oauth_provider/security/oauth_provider_security.xml
+++ b/oauth_provider/security/oauth_provider_security.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2016 SYLEAM
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="group_oauth_provider_manager" model="res.groups">
+        <field name="name">OAuth Provider Manager</field>
+    </record>
+
+    <record id="ir_rule_authorization_code_restricted_to_current_user" model="ir.rule">
+        <field name="name">Authorization Code access restricted to current user</field>
+        <field name="domain_force">[('user_id', '=', uid)]</field>
+        <field name="groups" eval="[]"/>
+        <field name="model_id" ref="model_oauth_provider_authorization_code"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_read" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+        <field name="perm_write" eval="0"/>
+    </record>
+
+    <record id="ir_rule_token_restricted_to_current_user" model="ir.rule">
+        <field name="name">Token access restricted to current user</field>
+        <field name="domain_force">[('user_id', '=', uid)]</field>
+        <field name="groups" eval="[]"/>
+        <field name="model_id" ref="model_oauth_provider_token"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_read" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+        <field name="perm_write" eval="0"/>
+    </record>
+</odoo>

--- a/oauth_provider/security/oauth_provider_security.xml
+++ b/oauth_provider/security/oauth_provider_security.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2016 SYLEAM
-    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 -->
 <odoo>
     <record id="group_oauth_provider_manager" model="res.groups">

--- a/oauth_provider/templates/authorization.xml
+++ b/oauth_provider/templates/authorization.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2016 SYLEAM
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <template id="oauth_provider.authorization" name="OAuth Authorization Error">
+        <t t-set="disable_footer" t-value="True"/>
+        <t t-call="web.login_layout">
+            <form class="oe_login_form" role="form" method="post" action="/oauth2/authorize">
+                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                <div>
+                    <h3 t-esc="oauth_client"/>
+                    This application would like to access these resources :
+                </div>
+                <div class="list-group">
+                    <span t-foreach="oauth_scopes" t-as="scope" class="list-group-item">
+                        <h4 t-field="scope.name" class="list-group-item-heading"/>
+                        <p t-field="scope.description" class="list-group-item-text"/>
+                    </span>
+                </div>
+                <div class="clearfix oe_login_buttons text-center">
+                    <button type="submit" class="btn btn-primary">Authorize</button>
+                </div>
+            </form>
+        </t>
+    </template>
+    <template id="oauth_provider.authorization_error" name="OAuth Authorization Error">
+        <t t-set="disable_footer" t-value="True"/>
+        <t t-call="web.login_layout">
+            <div class="panel panel-danger">
+                <div class="panel-heading">
+                    <h3 t-esc="title"/>
+                </div>
+                <div class="panel-body" t-esc="message"/>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/oauth_provider/templates/authorization.xml
+++ b/oauth_provider/templates/authorization.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright 2016 SYLEAM
-    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 -->
 <odoo>
     <template id="oauth_provider.authorization" name="OAuth Authorization Error">
@@ -11,7 +11,7 @@
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                 <div>
                     <h3 t-esc="oauth_client"/>
-                    This application would like to access these resources :
+                    This application would like to access these resources:
                 </div>
                 <div class="list-group">
                     <span t-foreach="oauth_scopes" t-as="scope" class="list-group-item">

--- a/oauth_provider/tests/__init__.py
+++ b/oauth_provider/tests/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_oauth_provider_client
+from . import test_oauth_provider_token
+from . import test_oauth_provider_scope
+from . import test_oauth_provider_controller_web_application
+from . import test_oauth_provider_controller_mobile_application
+from . import test_oauth_provider_controller_legacy_application

--- a/oauth_provider/tests/__init__.py
+++ b/oauth_provider/tests/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from . import test_oauth_provider_client
 from . import test_oauth_provider_token
@@ -8,3 +8,4 @@ from . import test_oauth_provider_scope
 from . import test_oauth_provider_controller_web_application
 from . import test_oauth_provider_controller_mobile_application
 from . import test_oauth_provider_controller_legacy_application
+from . import test_rest_api_controller

--- a/oauth_provider/tests/common_test_controller.py
+++ b/oauth_provider/tests/common_test_controller.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import mock
+import logging
+from datetime import datetime, timedelta
+from werkzeug.test import Client
+from werkzeug.wrappers import BaseResponse
+from openerp import fields
+from openerp.service import wsgi_server
+from openerp.tests.common import TransactionCase
+from openerp.tools.misc import consteq
+
+_logger = logging.getLogger(__name__)
+
+
+class OAuthProviderControllerTransactionCase(TransactionCase):
+    def setUp(self, application_type):
+        super(OAuthProviderControllerTransactionCase, self).setUp()
+
+        # Initialize controller test stuff
+        self.werkzeug_environ = {
+            'REMOTE_ADDR': '127.0.0.1',
+        }
+        self.user = self.env.ref('base.user_demo')
+        self.logged_user = False
+        self.initialize_test_client()
+
+        # Initialize common stuff
+        self.redirect_uri_base = 'http://example.com'
+        self.filter = self.env['ir.filters'].create({
+            'name': 'Current user',
+            'model_id': 'res.users',
+            'domain': "[('id', '=', uid)]",
+        })
+        self.client = self.env['oauth.provider.client'].create({
+            'name': 'Client',
+            'identifier': 'client',
+            'application_type': application_type,
+            'redirect_uri_ids': [(0, 0, {'name': self.redirect_uri_base})],
+            'scope_ids': [(0, 0, {
+                'name': 'Email',
+                'code': 'email',
+                'description': 'Access to your email address.',
+                'model_id': self.env.ref('base.model_res_users').id,
+                'filter_id': self.filter.id,
+                'field_ids': [
+                    (6, 0, [self.env.ref('base.field_res_users_email').id]),
+                ],
+            }), (0, 0, {
+                'name': 'Profile',
+                'code': 'profile',
+                'description': 'Access to your profile details (name, etc.)',
+                'model_id': self.env.ref('base.model_res_users').id,
+                'filter_id': self.filter.id,
+                'field_ids': [
+                    (6, 0, [
+                        self.env.ref('base.field_res_users_name').id,
+                        self.env.ref('base.field_res_users_city').id,
+                    ]),
+                ],
+            })],
+        })
+
+    def initialize_test_client(self):
+        # Instantiate a test client
+        self.test_client = Client(wsgi_server.application, BaseResponse)
+        # Select the database
+        self.get_request('/web', data={'db': self.env.cr.dbname})
+
+    def login(self, username, password):
+        # Login as demo user
+        self.post_request('/web/login', data={
+            'login': username,
+            'password': password,
+        })
+        self.logged_user = self.env['res.users'].search([
+            ('login', '=', username)])
+
+    def logout(self):
+        # Login as demo user
+        self.get_request('/web/session/logout')
+        self.logged_user = False
+
+    @mock.patch('openerp.http.WebRequest.env', new_callable=mock.PropertyMock)
+    def get_request(self, uri, request_env, data=None, headers=None):
+        """ Execute a GET request on the test client """
+        # Mock the http request's environ to allow it to see test records
+        user = self.logged_user or self.env.ref('base.public_user')
+        request_env.return_value = self.env(user=user)
+
+        return self.test_client.get(
+            uri, query_string=data, environ_base=self.werkzeug_environ,
+            headers=headers)
+
+    @mock.patch('openerp.http.WebRequest.env', new_callable=mock.PropertyMock)
+    @mock.patch('openerp.http.WebRequest.validate_csrf')
+    def post_request(
+            self, uri, validate_csrf, request_env, data=None, headers=None):
+        """ Execute a POST request on the test client """
+        # Mock the http request's environ to allow it to see test records
+        user = self.logged_user or self.env.ref('base.public_user')
+        request_env.return_value = self.env(user=user)
+        # Disable CSRF tokens check during tests
+        validate_csrf.return_value = consteq('', '')
+
+        return self.test_client.post(
+            uri, data=data, environ_base=self.werkzeug_environ,
+            headers=headers)
+
+    def new_token(self):
+        return self.env['oauth.provider.token'].create({
+            'token': 'token',
+            'token_type': 'Bearer',
+            'refresh_token': 'refresh token',
+            'client_id': self.client.id,
+            'user_id': self.user.id,
+            'expires_at': fields.Datetime.to_string(
+                datetime.now() + timedelta(seconds=3600)),
+        })

--- a/oauth_provider/tests/common_test_oauth_provider_controller.py
+++ b/oauth_provider/tests/common_test_oauth_provider_controller.py
@@ -1,0 +1,419 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import hashlib
+import json
+import mock
+import logging
+from datetime import datetime
+from openerp import fields
+
+_logger = logging.getLogger(__name__)
+
+
+class TestOAuthProviderAurhorizeController(object):
+    def test_authorize_error_missing_arguments(self):
+        """ Call /oauth2/authorize without any argument
+
+        Must return an unknown client identifier error
+        """
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Unknown Client Identifier!' in response.data)
+        self.assertTrue('This client identifier is invalid.' in response.data)
+
+    def test_authorize_error_invalid_request(self):
+        """ Call /oauth2/authorize with only the client_id argument
+
+        Must return an invalid_request error
+        """
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Error: invalid_request' in response.data)
+        self.assertTrue('An unknown error occured! Please contact your '
+                        'administrator' in response.data)
+
+    def test_authorize_error_unsupported_response_type(self):
+        """ Call /oauth2/authorize with an unsupported response type
+
+        Must return an unsupported_response_type error
+        """
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': 'wrong response type',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Error: unsupported_response_type' in response.data)
+        self.assertTrue('An unknown error occured! Please contact your '
+                        'administrator' in response.data)
+
+    def test_authorize_error_wrong_scopes(self):
+        """ Call /oauth2/authorize with wrong scopes
+
+        Must return an invalid_scope error
+        """
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'scope': 'wrong scope',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Error: invalid_scope' in response.data)
+        self.assertTrue('An unknown error occured! Please contact your '
+                        'administrator' in response.data)
+
+    def test_authorize_error_wrong_uri(self):
+        """ Call the authorize method with a wrong redirect_uri
+
+        Must return an invalid_request error
+        """
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'redirect_uri': 'http://wrong.redirect.uri',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Error: invalid_request' in response.data)
+        self.assertTrue('Mismatching redirect URI' in response.data)
+
+    def test_authorize_error_missing_uri(self):
+        """ Call /oauth2/authorize without any configured redirect URI
+
+        Must return an invalid_request error
+        """
+        self.client.redirect_uri_ids.unlink()
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'scope': self.client.scope_ids[0].code,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Error: invalid_request' in response.data)
+        self.assertTrue('Missing redirect URI.' in response.data)
+
+    def test_authorize_post_errors(self):
+        """ Call /oauth2/authorize in POST without any session
+
+        Must return an unknown client identifier error
+        """
+        self.login('demo', 'demo')
+        response = self.post_request('/oauth2/authorize')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Unknown Client Identifier!' in response.data)
+        self.assertTrue('This client identifier is invalid.' in response.data)
+
+    @mock.patch('openerp.http.WebRequest.env', new_callable=mock.PropertyMock)
+    def test_authorize_unsafe_chars(self, request_env):
+        """ Call /oauth2/authorize with unsafe chars in the query string """
+        # Mock the http request's environ to allow it to see test records
+        request_env.return_value = self.env(user=self.user)
+
+        query_string = 'client_id=%s&response_type=%s&state={}' % (
+            self.client.identifier,
+            self.client.response_type,
+        )
+        self.login('demo', 'demo')
+        response = self.test_client.get(
+            '/oauth2/authorize', query_string=query_string,
+            environ_base=self.werkzeug_environ)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.client.name in response.data)
+
+
+class TestOAuthProviderRefreshTokenController(object):
+    def test_refresh_token_error_too_much_scopes(self):
+        """ Call /oauth2/token using a refresh token, with too much scopes """
+        token = self.new_token()
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids.mapped('code'),
+            'grant_type': 'refresh_token',
+            'refresh_token': token.refresh_token,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {'error': 'invalid_scope'})
+
+    def test_refresh_token(self):
+        """ Get a new token using the refresh token """
+        token = self.new_token()
+        token.scope_ids = self.client.scope_ids[0]
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': ' '.join(token.scope_ids.mapped('code')),
+            'grant_type': 'refresh_token',
+            'refresh_token': token.refresh_token,
+        })
+        response_data = json.loads(response.data)
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        new_token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id)
+        ], order='id DESC', limit=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(new_token.token, response_data['access_token'])
+        self.assertEqual(new_token.token_type, response_data['token_type'])
+        self.assertEqual(
+            new_token.refresh_token, response_data['refresh_token'])
+        self.assertEqual(new_token.scope_ids, token.scope_ids)
+        self.assertEqual(new_token.user_id, self.user)
+
+
+class TestOAuthProviderTokeninfoController(object):
+    def test_tokeninfo_error_missing_arguments(self):
+        """ Call /oauth2/tokeninfo without any argument
+
+        Must retun an invalid_or_expired_token error
+        """
+        response = self.get_request('/oauth2/tokeninfo')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_or_expired_token'})
+
+    def test_tokeninfo(self):
+        """ Retrieve token information """
+        token = self.new_token()
+        token.scope_ids = self.client.scope_ids[0]
+        response = self.get_request('/oauth2/tokeninfo', data={
+            'access_token': token.token,
+        })
+        token_lifetime = (fields.Datetime.from_string(token.expires_at) -
+                          datetime.now()).seconds
+        response_data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_data['audience'], token.client_id.identifier)
+        self.assertEqual(
+            response_data['scopes'], ' '.join(token.scope_ids.mapped('code')))
+        # Test a range because the test might not be accurate, depending on the
+        # test system load
+        self.assertTrue(
+            token_lifetime - 5 < response_data['expires_in'] <
+            token_lifetime + 5)
+        self.assertEqual(
+            response_data['user_id'],
+            hashlib.sha256(token.client_id.identifier +
+                           token.user_id.oauth_identifier).hexdigest())
+
+    def test_tokeninfo_without_scopes(self):
+        """ Call /oauth2/tokeninfo without any scope
+
+        Retrieve token information without any scopes on the token
+        The user_id field should not be included
+        """
+        token = self.new_token()
+        token.scope_ids = self.env['oauth.provider.scope']
+        response = self.get_request('/oauth2/tokeninfo', data={
+            'access_token': token.token,
+        })
+        token_lifetime = (fields.Datetime.from_string(token.expires_at) -
+                          datetime.now()).seconds
+        response_data = json.loads(response.data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_data['audience'], token.client_id.identifier)
+        self.assertEqual(
+            response_data['scopes'], ' '.join(token.scope_ids.mapped('code')))
+        # Test a range because the test might not be accurate, depending on the
+        # test system load
+        self.assertTrue(
+            token_lifetime - 5 < response_data['expires_in'] <
+            token_lifetime + 5)
+
+
+class TestOAuthProviderUserinfoController(object):
+    def test_userinfo_error_missing_arguments(self):
+        """ Call /oauth2/userinfo without any argument
+
+        Must return an invalid_or_expired_token error
+        """
+        response = self.get_request('/oauth2/userinfo')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_or_expired_token'})
+
+    def test_userinfo_single_scope(self):
+        """ Retrieve user information with only a single scope """
+        token = self.new_token()
+        token.scope_ids = self.client.scope_ids[0]
+
+        # Retrieve user information
+        response = self.get_request('/oauth2/userinfo', data={
+            'access_token': token.token,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.data), {
+            'id': self.user.id,
+            'email': self.user.email,
+        })
+
+    def test_userinfo_multiple_scope(self):
+        """ Retrieve user information with only a all test scopes """
+        token = self.new_token()
+        token.scope_ids = self.client.scope_ids
+
+        # Retrieve user information
+        response = self.get_request('/oauth2/userinfo', data={
+            'access_token': token.token,
+        })
+        # The Email scope allows to read the email
+        # The Profile scope allows to read the name and city
+        # The id of the recod is always added (standard Odoo behaviour)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.data), {
+            'id': self.user.id,
+            'name': self.user.name,
+            'email': self.user.email,
+            'city': self.user.city,
+        })
+
+
+class TestOAuthProviderOtherinfoController(object):
+    def test_otherinfo_error_missing_arguments(self):
+        """ Call /oauth2/otherinfo method without any argument
+
+        Must return an invalid_or_expired_token error
+        """
+        response = self.get_request('/oauth2/otherinfo')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_or_expired_token'})
+
+    def test_otherinfo_error_missing_model(self):
+        """ Call /oauth2/otherinfo method without the model argument
+
+        Must return an invalid_model error
+        """
+        token = self.new_token()
+        response = self.get_request(
+            '/oauth2/otherinfo', data={'access_token': token.token})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data), {'error': 'invalid_model'})
+
+    def test_otherinfo_error_invalid_model(self):
+        """ Call /oauth2/otherinfo method withan invalid model
+
+        Must return an invalid_model error
+        """
+        token = self.new_token()
+        response = self.get_request(
+            '/oauth2/otherinfo',
+            data={'access_token': token.token, 'model': 'invalid.model'})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data), {'error': 'invalid_model'})
+
+    def test_otherinfo_user_information(self):
+        """ Call /oauth2/otherinfo to retrieve information using the token """
+        token = self.new_token()
+        token.scope_ids = self.client.scope_ids
+
+        # Add a new scope to test informations retrieval
+        token.scope_ids += self.env['oauth.provider.scope'].create({
+            'name': 'Groups',
+            'code': 'groups',
+            'description': 'List of accessible groups',
+            'model_id': self.env.ref('base.model_res_groups').id,
+            'filter_id': False,
+            'field_ids': [
+                (6, 0, [self.env.ref('base.field_res_groups_name').id]),
+            ],
+        })
+        # Retrieve user information
+        response = self.get_request('/oauth2/otherinfo', data={
+            'access_token': token.token,
+            'model': 'res.users',
+        })
+        # The Email scope allows to read the email
+        # The Profile scope allows to read the name and city
+        # The id of the recod is always added (standard Odoo behaviour)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.data), {str(self.user.id): {
+            'id': self.user.id,
+            'name': self.user.name,
+            'email': self.user.email,
+            'city': self.user.city,
+        }})
+
+    def test_otherinfo_group_information(self):
+        """ Call /oauth2/otherinfo to retrieve information using the token """
+        token = self.new_token()
+        token.scope_ids = self.client.scope_ids
+
+        # Add a new scope to test informations retrieval
+        token.scope_ids += self.env['oauth.provider.scope'].create({
+            'name': 'Groups',
+            'code': 'groups',
+            'description': 'List of accessible groups',
+            'model_id': self.env.ref('base.model_res_groups').id,
+            'filter_id': False,
+            'field_ids': [
+                (6, 0, [self.env.ref('base.field_res_groups_name').id]),
+            ],
+        })
+
+        # Retrieve groups information
+        all_groups = self.env['res.groups'].search([])
+        response = self.get_request('/oauth2/otherinfo', data={
+            'access_token': token.token,
+            'model': 'res.groups',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            sorted(json.loads(response.data).keys()),
+            sorted(map(str, all_groups.ids)))
+
+
+class TestOAuthProviderRevokeTokenController(object):
+    def test_revoke_token_error_missing_arguments(self):
+        """ Call /oauth2/revoke_token method without any argument """
+        response = self.post_request('/oauth2/revoke_token')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_or_expired_token'})
+
+    def test_revoke_token_error_missing_client_id(self):
+        """ Call /oauth2/revoke_token method without client identifier """
+        token = self.new_token()
+        response = self.post_request('/oauth2/revoke_token', data={
+            'token': token.token,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client'})
+
+    def test_revoke_token_error_missing_token(self):
+        """ Call /oauth2/revoke_token method without token """
+        response = self.post_request('/oauth2/revoke_token', data={
+            'client_id': self.client.identifier,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_or_expired_token'})
+
+    def test_revoke_access_token(self):
+        """ Revoke an access token """
+        token = self.new_token()
+        self.post_request('/oauth2/revoke_token', data={
+            'client_id': self.client.identifier,
+            'token': token.token,
+        })
+        self.assertFalse(token.exists())
+
+    def test_revoke_refresh_token(self):
+        """ Revoke a refresh token """
+        token = self.new_token()
+        self.post_request('/oauth2/revoke_token', data={
+            'client_id': self.client.identifier,
+            'token': token.refresh_token,
+        })
+        self.assertTrue(token.exists())
+        self.assertFalse(token.refresh_token)

--- a/oauth_provider/tests/test_oauth_provider_client.py
+++ b/oauth_provider/tests/test_oauth_provider_client.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from openerp.tests.common import TransactionCase
+from ..oauth2.validator import OdooValidator
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from oauthlib import oauth2
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class TestOAuthProviderClient(TransactionCase):
+
+    def setUp(self):
+        super(TestOAuthProviderClient, self).setUp()
+        self.client_vals = {
+            'name': 'Client',
+            'identifier': 'client',
+        }
+
+    def new_client(self, vals=None):
+        values = self.client_vals.copy()
+        if vals is not None:
+            values.update(vals)
+
+        return self.env['oauth.provider.client'].create(values)
+
+    def test_grant_response_type_default(self):
+        """ Check the value of the grant_type and response_type fields """
+        # Default : Web Application
+        client = self.new_client({'identifier': 'default'})
+        self.assertEqual(client.grant_type, 'authorization_code')
+        self.assertEqual(client.response_type, 'code')
+
+    def test_grant_response_type_web_application(self):
+        """ Check the value of the grant_type and response_type fields """
+        # Web Application
+        client = self.new_client(vals={'application_type': 'web application'})
+        self.assertEqual(client.grant_type, 'authorization_code')
+        self.assertEqual(client.response_type, 'code')
+
+    def test_grant_response_type_mobile_application(self):
+        """ Check the value of the grant_type and response_type fields """
+        # Mobile Application
+        client = self.new_client(
+            vals={'application_type': 'mobile application'})
+        self.assertEqual(client.grant_type, 'implicit')
+        self.assertEqual(client.response_type, 'token')
+
+    def test_grant_response_type_legacy_application(self):
+        """ Check the value of the grant_type and response_type fields """
+        # Legacy Application
+        client = self.new_client(
+            vals={'application_type': 'legacy application'})
+        self.assertEqual(client.grant_type, 'password')
+        self.assertEqual(client.response_type, 'none')
+
+    def test_grant_response_type_backend_application(self):
+        """ Check the value of the grant_type and response_type fields """
+        # Backend Application
+        client = self.new_client(
+            vals={'application_type': 'backend application'})
+        self.assertEqual(client.grant_type, 'client_credentials')
+        self.assertEqual(client.response_type, 'none')
+
+    def test_get_oauth2_server_default(self):
+        """ Check the returned server, depending on the application type """
+        # Default : Web Application
+        client = self.new_client({'identifier': 'default'})
+        self.assertTrue(
+            isinstance(client.get_oauth2_server(),
+                       oauth2.WebApplicationServer))
+
+    def test_get_oauth2_server_web_application(self):
+        """ Check the returned server, depending on the application type """
+        # Web Application
+        client = self.new_client(vals={'application_type': 'web application'})
+        self.assertTrue(
+            isinstance(client.get_oauth2_server(),
+                       oauth2.WebApplicationServer))
+
+    def test_get_oauth2_server_mobile_application(self):
+        """ Check the returned server, depending on the application type """
+        # Mobile Application
+        client = self.new_client(
+            vals={'application_type': 'mobile application'})
+        self.assertTrue(
+            isinstance(client.get_oauth2_server(),
+                       oauth2.MobileApplicationServer))
+
+    def test_get_oauth2_server_legacy_applicaton(self):
+        """ Check the returned server, depending on the application type """
+        # Legacy Application
+        client = self.new_client(
+            vals={'application_type': 'legacy application'})
+        self.assertTrue(
+            isinstance(client.get_oauth2_server(),
+                       oauth2.LegacyApplicationServer))
+
+    def test_get_oauth2_server_backend_application(self):
+        """ Check the returned server, depending on the application type """
+        # Backend Application
+        client = self.new_client(
+            vals={'application_type': 'backend application'})
+        self.assertTrue(
+            isinstance(client.get_oauth2_server(),
+                       oauth2.BackendApplicationServer))
+
+    def test_get_oauth2_server_validator(self):
+        """ Check the validator of the returned server """
+        client = self.new_client()
+        # No defined validator: Check that an OdooValidator instance is created
+        self.assertTrue(
+            isinstance(client.get_oauth2_server().request_validator,
+                       OdooValidator))
+
+    def test_get_oauth2_server_validator_custom(self):
+        """ Check the validator of the returned server """
+        client = self.new_client()
+        # Passed validator : Check that the validator instance is used
+        validator = OdooValidator()
+        self.assertEqual(
+            client.get_oauth2_server(validator).request_validator, validator)

--- a/oauth_provider/tests/test_oauth_provider_client.py
+++ b/oauth_provider/tests/test_oauth_provider_client.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import logging
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 from ..oauth2.validator import OdooValidator
 
 _logger = logging.getLogger(__name__)
@@ -14,10 +14,10 @@ except ImportError:
     _logger.debug('Cannot `import oauthlib`.')
 
 
-class TestOAuthProviderClient(TransactionCase):
+class TestOauthProviderClient(TransactionCase):
 
     def setUp(self):
-        super(TestOAuthProviderClient, self).setUp()
+        super(TestOauthProviderClient, self).setUp()
         self.client_vals = {
             'name': 'Client',
             'identifier': 'client',

--- a/oauth_provider/tests/test_oauth_provider_controller_legacy_application.py
+++ b/oauth_provider/tests/test_oauth_provider_controller_legacy_application.py
@@ -1,0 +1,374 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import base64
+import json
+import logging
+from .common_test_controller import OAuthProviderControllerTransactionCase
+from .common_test_oauth_provider_controller import \
+    TestOAuthProviderRefreshTokenController, \
+    TestOAuthProviderTokeninfoController, \
+    TestOAuthProviderUserinfoController, \
+    TestOAuthProviderOtherinfoController, \
+    TestOAuthProviderRevokeTokenController
+
+_logger = logging.getLogger(__name__)
+
+
+class TestOAuthProviderController(
+        OAuthProviderControllerTransactionCase,
+        TestOAuthProviderRefreshTokenController,
+        TestOAuthProviderTokeninfoController,
+        TestOAuthProviderUserinfoController,
+        TestOAuthProviderOtherinfoController,
+        TestOAuthProviderRevokeTokenController):
+    def setUp(self):
+        super(TestOAuthProviderController, self).setUp('legacy application')
+
+    def test_token_error_missing_arguments(self):
+        """ Check /oauth2/token without any argument
+
+        Must return an unsupported_grant_type error
+        """
+        response = self.post_request('/oauth2/token')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_wrong_grant_type(self):
+        """ Check /oauth2/token with an invalid grant type
+
+        Must return an unsupported_grant_type error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'grant_type': 'Wrong grant type',
+            'username': 'Wrong username',
+            'password': 'Wrong password',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'unsupported_grant_type'})
+
+    def test_token_error_missing_username(self):
+        """ Check /oauth2/token without username
+
+        Must return an invalid_request error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'grant_type': self.client.grant_type,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data), {
+            'error': 'invalid_request',
+            'error_description': 'Request is missing username parameter.',
+        })
+
+    def test_token_error_missing_password(self):
+        """ Check /oauth2/token without password
+
+        Must return an invalid_request error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'grant_type': self.client.grant_type,
+            'username': 'Wrong username',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data), {
+            'error': 'invalid_request',
+            'error_description': 'Request is missing password parameter.',
+        })
+
+    def test_token_error_missing_client_id(self):
+        """ Check /oauth2/token without client
+
+        Must return an unauthorized_client error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_wrong_client_identifier(self):
+        """ Check /oauth2/token with a wrong client identifier
+
+        Must return an invalid_client_id error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': 'Wrong client identifier',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_wrong_username(self):
+        """ Check /oauth2/token with a wrong username
+
+        Must return an invalid_grant error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': self.client.identifier,
+            'username': 'Wrong username',
+            'password': 'demo',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {
+            'error': 'invalid_grant',
+            'error_description': 'Invalid credentials given.',
+        })
+
+    def test_token_error_wrong_password(self):
+        """ Check /oauth2/token with a wrong password
+
+        Must return an invalid_grant error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': self.client.identifier,
+            'username': self.user.login,
+            'password': 'Wrong password',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {
+            'error': 'invalid_grant',
+            'error_description': 'Invalid credentials given.',
+        })
+
+    def test_token_error_wrong_client_id(self):
+        """ Check /oauth2/token with a wrong client id
+
+        Must return an invalid_client_id error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': 'Wrong client id',
+            'scope': self.client.scope_ids[0].code,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_missing_refresh_token(self):
+        """ Check /oauth2/token in refresh token mode without refresh token
+
+        Must return an invalid_request error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': 'refresh_token',
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data), {
+            'error': 'invalid_request',
+            'error_description': 'Missing refresh token parameter.',
+        })
+
+    def test_token_error_invalid_refresh_token(self):
+        """ Check /oauth2/token in refresh token mode with an invalid refresh token
+
+        Must return an invalid_grant error
+        """
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': 'refresh_token',
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'refresh_token': 'Wrong refresh token',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {'error': 'invalid_grant'})
+
+    def test_token_with_missing_secret(self):
+        """ Check client authentication without the secret provided
+
+        Must return an invalid_client error
+        """
+        # Define a secret for the client
+        self.client.secret = 'OAuth Client secret'
+
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client'})
+
+    def test_token_with_unexpected_secret(self):
+        """ Check client authentication with an unexpected secret provided
+
+        Must return an invalid_client error
+        """
+        # Don't define a secret for the client
+        auth_string = base64.b64encode(
+            '{client.identifier}:secret'.format(client=self.client))
+
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        }, headers=[(
+            'Authorization',
+            'Basic {auth_string}'.format(auth_string=auth_string)),
+        ])
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client'})
+
+    def test_token_with_wrong_secret(self):
+        """ Check client authentication with a wrong secret
+
+        Must return an invalid_client error
+        """
+        # Define a secret for the client
+        self.client.secret = 'OAuth Client secret'
+        auth_string = base64.b64encode(
+            '{client.identifier}:secret'.format(client=self.client))
+
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        }, headers=[(
+            'Authorization',
+            'Basic {auth_string}'.format(auth_string=auth_string)),
+        ])
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client'})
+
+    def test_token_with_secret(self):
+        """ Check client authentication from Authorization header """
+        # Define a secret for the client
+        self.client.secret = 'OAuth Client secret'
+        auth_string = base64.b64encode(
+            '{client.identifier}:{client.secret}'.format(client=self.client))
+
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        }, headers=[(
+            'Authorization',
+            'Basic {auth_string}'.format(auth_string=auth_string)),
+        ])
+        response_data = json.loads(response.data)
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(token.token, response_data['access_token'])
+        self.assertEqual(token.token_type, response_data['token_type'])
+        self.assertEqual(token.refresh_token, response_data['refresh_token'])
+        self.assertEqual(token.scope_ids, self.client.scope_ids[0])
+        self.assertEqual(token.user_id, self.user)
+
+    def test_token_with_wrong_non_basic_authorization(self):
+        """ Check client authentication with a non-Basic Authorization header
+
+        Must generate a token : Non basic authorization headers are ignored
+        """
+        # Don't define a secret for the client
+        auth_string = base64.b64encode(
+            '{client.identifier}:secret'.format(client=self.client))
+
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        }, headers=[(
+            'Authorization',
+            'Digest {auth_string}'.format(auth_string=auth_string)),
+        ])
+        response_data = json.loads(response.data)
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(token.token, response_data['access_token'])
+        self.assertEqual(token.token_type, response_data['token_type'])
+        self.assertEqual(token.refresh_token, response_data['refresh_token'])
+        self.assertEqual(token.scope_ids, self.client.scope_ids[0])
+        self.assertEqual(token.user_id, self.user)
+
+    def test_token_with_right_non_basic_authorization(self):
+        """ Check client authentication with a non-Basic Authorization header
+
+        Must return an invalid_client error : Non basic authorization headers
+        are ignored
+        """
+        # Define a secret for the client
+        self.client.secret = 'OAuth Client secret'
+        auth_string = base64.b64encode(
+            '{client.identifier}:{client.secret}'.format(client=self.client))
+
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        }, headers=[(
+            'Authorization',
+            'Digest {auth_string}'.format(auth_string=auth_string)),
+        ])
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client'})
+
+    def test_successful_token_retrieval(self):
+        """ Check the full process for a LegacyApplication
+
+        GET, then POST, token and informations retrieval
+        """
+        # Ask a token to the server
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'scope': self.client.scope_ids[0].code,
+            'grant_type': self.client.grant_type,
+            'username': self.user.login,
+            'password': 'demo',
+        })
+        response_data = json.loads(response.data)
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(token.token, response_data['access_token'])
+        self.assertEqual(token.token_type, response_data['token_type'])
+        self.assertEqual(token.refresh_token, response_data['refresh_token'])
+        self.assertEqual(token.scope_ids, self.client.scope_ids[0])
+        self.assertEqual(token.user_id, self.user)

--- a/oauth_provider/tests/test_oauth_provider_controller_legacy_application.py
+++ b/oauth_provider/tests/test_oauth_provider_controller_legacy_application.py
@@ -1,30 +1,30 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import base64
 import json
 import logging
-from .common_test_controller import OAuthProviderControllerTransactionCase
+from .common_test_controller import OauthProviderControllerTransactionCase
 from .common_test_oauth_provider_controller import \
-    TestOAuthProviderRefreshTokenController, \
-    TestOAuthProviderTokeninfoController, \
-    TestOAuthProviderUserinfoController, \
-    TestOAuthProviderOtherinfoController, \
-    TestOAuthProviderRevokeTokenController
+    TestOauthProviderRefreshTokenController, \
+    TestOauthProviderTokeninfoController, \
+    TestOauthProviderUserinfoController, \
+    TestOauthProviderOtherinfoController, \
+    TestOauthProviderRevokeTokenController
 
 _logger = logging.getLogger(__name__)
 
 
-class TestOAuthProviderController(
-        OAuthProviderControllerTransactionCase,
-        TestOAuthProviderRefreshTokenController,
-        TestOAuthProviderTokeninfoController,
-        TestOAuthProviderUserinfoController,
-        TestOAuthProviderOtherinfoController,
-        TestOAuthProviderRevokeTokenController):
+class TestOauthProviderController(
+        OauthProviderControllerTransactionCase,
+        TestOauthProviderRefreshTokenController,
+        TestOauthProviderTokeninfoController,
+        TestOauthProviderUserinfoController,
+        TestOauthProviderOtherinfoController,
+        TestOauthProviderRevokeTokenController):
     def setUp(self):
-        super(TestOAuthProviderController, self).setUp('legacy application')
+        super(TestOauthProviderController, self).setUp('legacy application')
 
     def test_token_error_missing_arguments(self):
         """ Check /oauth2/token without any argument

--- a/oauth_provider/tests/test_oauth_provider_controller_mobile_application.py
+++ b/oauth_provider/tests/test_oauth_provider_controller_mobile_application.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+from .common_test_controller import OAuthProviderControllerTransactionCase
+from .common_test_oauth_provider_controller import \
+    TestOAuthProviderAurhorizeController, \
+    TestOAuthProviderTokeninfoController, \
+    TestOAuthProviderUserinfoController, \
+    TestOAuthProviderOtherinfoController, \
+    TestOAuthProviderRevokeTokenController
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import oauthlib
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class TestOAuthProviderController(
+        OAuthProviderControllerTransactionCase,
+        TestOAuthProviderAurhorizeController,
+        TestOAuthProviderTokeninfoController,
+        TestOAuthProviderUserinfoController,
+        TestOAuthProviderOtherinfoController,
+        TestOAuthProviderRevokeTokenController):
+    def setUp(self):
+        super(TestOAuthProviderController, self).setUp('mobile application')
+
+    def test_authorize_skip_authorization(self):
+        """ Call /oauth2/authorize while skipping the authorization page """
+        # Configure the client to skip the authorization page
+        self.client.skip_authorization = True
+
+        # Login as demo user
+        self.login(self.user.login, self.user.login)
+
+        # Call the authorize method with good values
+        state = 'Some custom state'
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'state': state,
+        })
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        # The response should be a redirect to the redirect URI, with the
+        # authorization_code added as GET parameter
+        self.assertEqual(response.status_code, 302)
+        query_string = oauthlib.common.urlencode({
+            'state': state,
+            'access_token': token.token,
+            'token_type': token.token_type,
+            'expires_in': 3600,
+            'scope': token.scope_ids.code,
+        }.items())
+        self.assertEqual(
+            response.headers['Location'], '{uri_base}#{query_string}'.format(
+                uri_base=self.redirect_uri_base, query_string=query_string))
+        self.assertEqual(token.user_id, self.user)
+
+    def test_successful_token_retrieval(self):
+        """ Check the full process for a MobileApplication
+
+        GET, then POST, token and informations retrieval
+        """
+        # Call the authorize method with good values to fill the session scopes
+        # and credentials variables
+        state = 'Some custom state'
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'state': state,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.client.name in response.data)
+        self.assertTrue(self.client.scope_ids[0].name in response.data)
+        self.assertTrue(self.client.scope_ids[0].description in response.data)
+
+        # Then, call the POST route to validate the authorization
+        response = self.post_request('/oauth2/authorize')
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        # The response should be a redirect to the redirect URI, with the
+        # token added as GET parameter
+        self.assertEqual(response.status_code, 302)
+        query_string = oauthlib.common.urlencode({
+            'state': state,
+            'access_token': token.token,
+            'token_type': token.token_type,
+            'expires_in': 3600,
+            'scope': token.scope_ids.code,
+        }.items())
+        self.assertEqual(
+            response.headers['Location'], '{uri_base}#{query_string}'.format(
+                uri_base=self.redirect_uri_base, query_string=query_string))
+        self.assertEqual(token.user_id, self.user)

--- a/oauth_provider/tests/test_oauth_provider_controller_mobile_application.py
+++ b/oauth_provider/tests/test_oauth_provider_controller_mobile_application.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import logging
-from .common_test_controller import OAuthProviderControllerTransactionCase
+from .common_test_controller import OauthProviderControllerTransactionCase
 from .common_test_oauth_provider_controller import \
-    TestOAuthProviderAurhorizeController, \
-    TestOAuthProviderTokeninfoController, \
-    TestOAuthProviderUserinfoController, \
-    TestOAuthProviderOtherinfoController, \
-    TestOAuthProviderRevokeTokenController
+    TestOauthProviderAuthorizeController, \
+    TestOauthProviderTokeninfoController, \
+    TestOauthProviderUserinfoController, \
+    TestOauthProviderOtherinfoController, \
+    TestOauthProviderRevokeTokenController
 
 _logger = logging.getLogger(__name__)
 
@@ -19,15 +19,15 @@ except ImportError:
     _logger.debug('Cannot `import oauthlib`.')
 
 
-class TestOAuthProviderController(
-        OAuthProviderControllerTransactionCase,
-        TestOAuthProviderAurhorizeController,
-        TestOAuthProviderTokeninfoController,
-        TestOAuthProviderUserinfoController,
-        TestOAuthProviderOtherinfoController,
-        TestOAuthProviderRevokeTokenController):
+class TestOauthProviderController(
+        OauthProviderControllerTransactionCase,
+        TestOauthProviderAuthorizeController,
+        TestOauthProviderTokeninfoController,
+        TestOauthProviderUserinfoController,
+        TestOauthProviderOtherinfoController,
+        TestOauthProviderRevokeTokenController):
     def setUp(self):
-        super(TestOAuthProviderController, self).setUp('mobile application')
+        super(TestOauthProviderController, self).setUp('mobile application')
 
     def test_authorize_skip_authorization(self):
         """ Call /oauth2/authorize while skipping the authorization page """

--- a/oauth_provider/tests/test_oauth_provider_controller_web_application.py
+++ b/oauth_provider/tests/test_oauth_provider_controller_web_application.py
@@ -1,0 +1,358 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import json
+import logging
+from .common_test_controller import OAuthProviderControllerTransactionCase
+from .common_test_oauth_provider_controller import \
+    TestOAuthProviderRefreshTokenController, \
+    TestOAuthProviderAurhorizeController, \
+    TestOAuthProviderTokeninfoController, \
+    TestOAuthProviderUserinfoController, \
+    TestOAuthProviderOtherinfoController, \
+    TestOAuthProviderRevokeTokenController
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import oauthlib
+except ImportError:
+    _logger.debug('Cannot `import oauthlib`.')
+
+
+class TestOAuthProviderController(
+        OAuthProviderControllerTransactionCase,
+        TestOAuthProviderRefreshTokenController,
+        TestOAuthProviderAurhorizeController,
+        TestOAuthProviderTokeninfoController,
+        TestOAuthProviderUserinfoController,
+        TestOAuthProviderOtherinfoController,
+        TestOAuthProviderRevokeTokenController):
+    def setUp(self):
+        super(TestOAuthProviderController, self).setUp('web application')
+
+    def new_code(self):
+        # Configure the client to skip the authorization page
+        self.client.skip_authorization = True
+
+        # Call the authorize method with good values
+        state = 'Some custom state'
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'state': state,
+        })
+        # A new authorization code should have been generated
+        # We can safely pick the latest generated code here, because no other
+        # code could have been generated during the test
+        code = self.env['oauth.provider.authorization.code'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        # The response should be a redirect to the redirect URI, with the
+        # authorization_code added as GET parameter
+        self.assertEqual(response.status_code, 302)
+        query_string = oauthlib.common.urlencode(
+            {'state': state, 'code': code.code}.items())
+        self.assertEqual(
+            response.headers['Location'], '{uri_base}?{query_string}'.format(
+                uri_base=self.redirect_uri_base, query_string=query_string))
+        self.assertEqual(code.user_id, self.user)
+
+        self.logout()
+
+        return code
+
+    def test_token_error_missing_session(self):
+        """ Check /oauth2/token without any session set
+
+        Must return an invalid_client_id error
+        """
+        response = self.post_request('/oauth2/token')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_missing_arguments(self):
+        """ Check /oauth2/token without any argument
+
+        Must return an invalid_client_id error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_wrong_grant_type(self):
+        """ Check /oauth2/token with an invalid grant type
+
+        Must return an invalid_client_id error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': 'Wrong grant type',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_missing_code(self):
+        """ Check /oauth2/token without code
+
+        Must return an invalid_client_id error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_missing_client_id(self):
+        """ Check /oauth2/token without client
+
+        Must return an invalid_client_id error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'code': 'Wrong code',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_wrong_client_identifier(self):
+        """ Check /oauth2/token with a wrong client identifier
+
+        Must return an invalid_client_id error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': 'Wrong client identifier',
+            'code': 'Wrong code',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_wrong_code(self):
+        """ Check /oauth2/token with a wrong code
+
+        Must return an invalid_grant error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': self.client.identifier,
+            'code': 'Wrong code',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {'error': 'invalid_grant'})
+
+    def test_token_error_missing_redirect_uri(self):
+        """ Check /oauth2/token without redirect_uri
+
+        Must return an access_denied error
+        """
+        # Generate an authorization code
+        code = self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': self.client.identifier,
+            'code': code.code,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {'error': 'access_denied'})
+
+    def test_token_error_wrong_redirect_uri(self):
+        """ Check /oauth2/token with a wrong redirect_uri
+
+        Must return an access_denied error
+        """
+        # Generate an authorization code
+        code = self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': self.client.identifier,
+            'code': code.code,
+            'redirect_uri': 'Wrong redirect URI',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {'error': 'access_denied'})
+
+    def test_token_error_wrong_client_id(self):
+        """ Check /oauth2/token with a wrong client id
+
+        Must return an invalid_client_id error
+        """
+        # Generate an authorization code
+        code = self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': self.client.grant_type,
+            'client_id': 'Wrong client id',
+            'code': code.code,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            json.loads(response.data), {'error': 'invalid_client_id'})
+
+    def test_token_error_missing_refresh_token(self):
+        """ Check /oauth2/token in refresh token mode without refresh token
+
+        Must return an invalid_request error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': 'refresh_token',
+            'client_id': self.client.identifier,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data), {
+            'error': 'invalid_request',
+            'error_description': 'Missing refresh token parameter.',
+        })
+
+    def test_token_error_invalid_refresh_token(self):
+        """ Check /oauth2/token in refresh token mode with an invalid refresh token
+
+        Must return an invalid_grant error
+        """
+        # Generate an authorization code to set the session
+        self.new_code()
+
+        response = self.post_request('/oauth2/token', data={
+            'grant_type': 'refresh_token',
+            'client_id': self.client.identifier,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'refresh_token': 'Wrong refresh token',
+        })
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(json.loads(response.data), {'error': 'invalid_grant'})
+
+    def test_authorize_skip_authorization(self):
+        """ Call /oauth2/authorize while skipping the authorization page """
+        # Configure the client to skip the authorization page
+        self.client.skip_authorization = True
+
+        # Call the authorize method with good values
+        state = 'Some custom state'
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'state': state,
+        })
+        # A new authorization code should have been generated
+        # We can safely pick the latest generated code here, because no other
+        # code could have been generated during the test
+        code = self.env['oauth.provider.authorization.code'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        # The response should be a redirect to the redirect URI, with the
+        # authorization_code added as GET parameter
+        self.assertEqual(response.status_code, 302)
+        query_string = oauthlib.common.urlencode({
+            'state': state,
+            'code': code.code,
+        }.items())
+        self.assertEqual(
+            response.headers['Location'], '{uri_base}?{query_string}'.format(
+                uri_base=self.redirect_uri_base, query_string=query_string))
+        self.assertEqual(code.user_id, self.user)
+
+    def test_successful_token_retrieval(self):
+        """ Check the full process for a WebApplication
+
+        GET, then POST, token and informations retrieval
+        """
+        # Call the authorize method with good values to fill the session scopes
+        # and credentials variables
+        state = 'Some custom state'
+        self.login('demo', 'demo')
+        response = self.get_request('/oauth2/authorize', data={
+            'client_id': self.client.identifier,
+            'response_type': self.client.response_type,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'state': state,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(self.client.name in response.data)
+        self.assertTrue(self.client.scope_ids[0].name in response.data)
+        self.assertTrue(self.client.scope_ids[0].description in response.data)
+
+        # Then, call the POST route to validate the authorization
+        response = self.post_request('/oauth2/authorize')
+        # A new authorization code should have been generated
+        # We can safely pick the latest generated code here, because no other
+        # code could have been generated during the test
+        code = self.env['oauth.provider.authorization.code'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        # The response should be a redirect to the redirect URI, with the
+        # authorization_code added as GET parameter
+        self.assertEqual(response.status_code, 302)
+        query_string = oauthlib.common.urlencode({
+            'state': state,
+            'code': code.code,
+        }.items())
+        self.assertEqual(
+            response.headers['Location'], '{uri_base}?{query_string}'.format(
+                uri_base=self.redirect_uri_base, query_string=query_string))
+        self.assertEqual(code.user_id, self.user)
+
+        self.logout()
+
+        # Now that the user vaidated the authorization, we can ask for a token,
+        # using the returned code
+        response = self.post_request('/oauth2/token', data={
+            'client_id': self.client.identifier,
+            'redirect_uri': self.redirect_uri_base,
+            'scope': self.client.scope_ids[0].code,
+            'code': code.code,
+            'grant_type': self.client.grant_type,
+        })
+        response_data = json.loads(response.data)
+        # A new token should have been generated
+        # We can safely pick the latest generated token here, because no other
+        # token could have been generated during the test
+        token = self.env['oauth.provider.token'].search([
+            ('client_id', '=', self.client.id),
+        ], order='id DESC', limit=1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(token.token, response_data['access_token'])
+        self.assertEqual(token.token_type, response_data['token_type'])
+        self.assertEqual(token.refresh_token, response_data['refresh_token'])
+        self.assertEqual(token.scope_ids, code.scope_ids)
+        self.assertEqual(token.user_id, self.user)

--- a/oauth_provider/tests/test_oauth_provider_controller_web_application.py
+++ b/oauth_provider/tests/test_oauth_provider_controller_web_application.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import json
 import logging
-from .common_test_controller import OAuthProviderControllerTransactionCase
+from .common_test_controller import OauthProviderControllerTransactionCase
 from .common_test_oauth_provider_controller import \
-    TestOAuthProviderRefreshTokenController, \
-    TestOAuthProviderAurhorizeController, \
-    TestOAuthProviderTokeninfoController, \
-    TestOAuthProviderUserinfoController, \
-    TestOAuthProviderOtherinfoController, \
-    TestOAuthProviderRevokeTokenController
+    TestOauthProviderRefreshTokenController, \
+    TestOauthProviderAuthorizeController, \
+    TestOauthProviderTokeninfoController, \
+    TestOauthProviderUserinfoController, \
+    TestOauthProviderOtherinfoController, \
+    TestOauthProviderRevokeTokenController
 
 _logger = logging.getLogger(__name__)
 
@@ -21,16 +21,16 @@ except ImportError:
     _logger.debug('Cannot `import oauthlib`.')
 
 
-class TestOAuthProviderController(
-        OAuthProviderControllerTransactionCase,
-        TestOAuthProviderRefreshTokenController,
-        TestOAuthProviderAurhorizeController,
-        TestOAuthProviderTokeninfoController,
-        TestOAuthProviderUserinfoController,
-        TestOAuthProviderOtherinfoController,
-        TestOAuthProviderRevokeTokenController):
+class TestOauthProviderController(
+        OauthProviderControllerTransactionCase,
+        TestOauthProviderRefreshTokenController,
+        TestOauthProviderAuthorizeController,
+        TestOauthProviderTokeninfoController,
+        TestOauthProviderUserinfoController,
+        TestOauthProviderOtherinfoController,
+        TestOauthProviderRevokeTokenController):
     def setUp(self):
-        super(TestOAuthProviderController, self).setUp('web application')
+        super(TestOauthProviderController, self).setUp('web application')
 
     def new_code(self):
         # Configure the client to skip the authorization page

--- a/oauth_provider/tests/test_oauth_provider_scope.py
+++ b/oauth_provider/tests/test_oauth_provider_scope.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestOAuthProviderScope(TransactionCase):
+
+    def setUp(self):
+        super(TestOAuthProviderScope, self).setUp()
+        self.filter = self.env['ir.filters'].create({
+            'name': 'Current user',
+            'model_id': 'res.users',
+            'domain': "[('id', '=', uid)]",
+        })
+        self.scope_vals = {
+            'name': 'Scope',
+            'code': 'scope',
+            'description': 'Description of the scope',
+            'model_id': self.env.ref('base.model_res_users').id,
+            'filter_id': self.filter.id,
+            'field_ids': [
+                (6, 0, [self.env.ref('base.field_res_users_email').id]),
+            ],
+        }
+
+    def new_scope(self, vals=None):
+        values = self.scope_vals
+        if vals is not None:
+            values.update(vals)
+
+        return self.env['oauth.provider.scope'].create(values)
+
+    def test_get_data_from_model_without_filter(self):
+        """ Check the values returned by the get_data_for_model method when no
+        filter is defined
+        """
+        scope = self.new_scope({'filter_id': False})
+
+        # Check a simple call with the right model
+        data = scope.get_data_for_model('res.users')
+        # Check that we have multiple users (otherwise this test is useless)
+        self.assertTrue(len(self.env['res.users'].search([]).ids) > 1)
+        self.assertEqual(
+            set(data.keys()), set(self.env['res.users'].search([]).ids))
+
+    def test_get_data_from_model_without_filter_wrong_model(self):
+        """ Check the values returned by the get_data_for_model method when no
+        filter is defined
+        """
+        scope = self.new_scope({'filter_id': False})
+
+        # Check a simple call with a wrong model
+        data = scope.get_data_for_model('res.partner')
+        self.assertEqual(data, {})
+
+    def test_get_data_from_model_with_filter(self):
+        """ Check the values returned by the get_data_for_model method when no
+        res_id is supplied
+        """
+        scope = self.new_scope()
+
+        # Check a simple call with the right model
+        data = scope.get_data_for_model('res.users')
+        self.assertEqual(data, {
+            self.env.user.id: {
+                'id': self.env.user.id,
+                'email': self.env.user.email,
+            },
+        })
+
+    def test_get_data_from_model_with_filter_wrong_model(self):
+        """ Check the values returned by the get_data_for_model method when no
+        res_id is supplied
+        """
+        scope = self.new_scope()
+
+        # Check a simple call with a wrong model
+        data = scope.get_data_for_model('res.partner')
+        self.assertEqual(data, {})
+
+    def test_get_data_from_model_with_res_id_and_no_filter(self):
+        """ Check the values returned by the get_data_for_model method when a
+        res_id is supplied
+        """
+        scope = self.new_scope({'filter_id': False})
+
+        # Check a simple call with the right model
+        data = scope.get_data_for_model('res.users', res_id=self.env.user.id)
+        self.assertEqual(data, {
+            'id': self.env.user.id,
+            'email': self.env.user.email,
+        })
+
+    def test_get_data_from_model_with_res_id_and_no_filter_wrong_model(self):
+        """ Check the values returned by the get_data_for_model method when a
+        res_id is supplied
+        """
+        scope = self.new_scope({'filter_id': False})
+
+        # Check a simple call with a wrong model
+        data = scope.get_data_for_model(
+            'res.partner', res_id=self.env.user.id + 1)
+        self.assertEqual(data, {})
+
+    def test_get_data_from_model_with_res_id(self):
+        """ Check the values returned by the get_data_for_model method when a
+        res_id is supplied
+        """
+        scope = self.new_scope()
+
+        # Check a simple call with the right model
+        data = scope.get_data_for_model('res.users', res_id=self.env.user.id)
+        self.assertEqual(data, {
+            'id': self.env.user.id,
+            'email': self.env.user.email,
+        })
+
+    def test_get_data_from_model_with_res_id_wrong_model(self):
+        """ Check the values returned by the get_data_for_model method when a
+        res_id is supplied
+        """
+        scope = self.new_scope()
+
+        # Check a simple call with a wrong model
+        data = scope.get_data_for_model(
+            'res.partner', res_id=self.env.user.id + 1)
+        self.assertEqual(data, {})
+
+    def _generate_multiple_scopes(self):
+        scopes = self.new_scope()
+        scopes += self.new_scope({
+            'code': 'Profile',
+            'field_ids': [(6, 0, [
+                self.env.ref('base.field_res_users_name').id,
+                self.env.ref('base.field_res_users_city').id,
+                self.env.ref('base.field_res_users_country_id').id,
+            ])],
+        })
+        scopes += self.new_scope({
+            'model_id': self.env.ref('base.model_res_groups').id,
+            'code': 'All groups',
+            'filter_id': False,
+            'field_ids': [
+                (6, 0, [self.env.ref('base.field_res_groups_name').id]),
+            ],
+        })
+
+        return scopes
+
+    def test_get_data_from_model_with_multiple_scopes_empty_fields(self):
+        """ Check the values returned by the get_data_for_model method when
+        calling on multiple scopes
+        """
+        scopes = self._generate_multiple_scopes()
+
+        # Check a simple call with the right model with empty fields
+        self.env.user.city = False
+        self.env.user.country_id = False
+        data = scopes.get_data_for_model('res.users')
+        self.assertEqual(data, {self.env.user.id: {
+            'id': 1,
+            'email': self.env.user.email,
+            'name': self.env.user.name,
+            'city': False,
+            'country_id': False,
+        }})
+
+    def test_get_data_from_model_with_multiple_scopesfirst_model(self):
+        """ Check the values returned by the get_data_for_model method when
+        calling on multiple scopes
+        """
+        scopes = self._generate_multiple_scopes()
+
+        # Check a simple call with the right model without empty fields
+        country = self.env.ref('base.fr')
+        self.env.user.city = 'Paris'
+        self.env.user.country_id = country
+        data = scopes.get_data_for_model('res.users')
+        self.assertEqual(data, {self.env.user.id: {
+            'id': 1,
+            'email': self.env.user.email,
+            'name': self.env.user.name,
+            'city': self.env.user.city,
+            'country_id': country.name,
+        }})
+
+    def test_get_data_from_model_with_multiple_scopes_second_model(self):
+        """ Check the values returned by the get_data_for_model method when
+        calling on multiple scopes
+        """
+        scopes = self._generate_multiple_scopes()
+
+        # Check a simple call with another right model
+        data = scopes.get_data_for_model('res.groups')
+        self.assertEqual(
+            set(data.keys()), set(self.env['res.groups'].search([]).ids))
+
+    def test_get_data_from_model_with_multiple_scopes_wrong_model(self):
+        """ Check the values returned by the get_data_for_model method when
+        calling on multiple scopes
+        """
+        scopes = self._generate_multiple_scopes()
+
+        # Check a simple call with a wrong model
+        data = scopes.get_data_for_model('res.partner')
+        self.assertEqual(data, {})
+
+    def _generate_multiple_scopes_match(self):
+        scopes = self.new_scope()
+        scopes += self.new_scope({
+            'code': 'All users',
+            'filter_id': False,
+        })
+        scopes += self.new_scope({
+            'model_id': self.env.ref('base.model_res_groups').id,
+            'code': 'All groups',
+            'filter_id': False,
+            'field_ids': [
+                (6, 0, [self.env.ref('base.field_res_groups_name').id]),
+            ],
+        })
+
+        return scopes
+
+    def test_get_data_from_model_with_all_scopes_match(self):
+        """ Check the values returned by the get_data_for_model method when all
+        scopes are required to match
+        """
+        scopes = self._generate_multiple_scopes_match()
+
+        # Check a simple call with the right model with any scope match
+        # returned records
+        data = scopes.get_data_for_model('res.users')
+        self.assertEqual(
+            set(data.keys()), set(self.env['res.users'].search([]).ids))
+
+    def test_get_data_from_model_with_all_scopes_match_first_model(self):
+        """ Check the values returned by the get_data_for_model method when all
+        scopes are required to match
+        """
+        scopes = self._generate_multiple_scopes_match()
+
+        # Check a simple call with the right model with all scopes required to
+        # match returned records
+        data = scopes.get_data_for_model('res.users', all_scopes_match=True)
+        self.assertEqual(data, {self.env.user.id: {
+            'id': 1,
+            'email': self.env.user.email,
+        }})
+
+    def test_get_data_from_model_with_all_scopes_match_second_model(self):
+        """ Check the values returned by the get_data_for_model method when all
+        scopes are required to match
+        """
+        scopes = self._generate_multiple_scopes_match()
+
+        # Check a simple call with another right model
+        data = scopes.get_data_for_model('res.groups')
+        self.assertEqual(
+            set(data.keys()), set(self.env['res.groups'].search([]).ids))
+
+    def test_get_data_from_model_with_all_scopes_match_wrong_model(self):
+        """ Check the values returned by the get_data_for_model method when all
+        scopes are required to match
+        """
+        scopes = self._generate_multiple_scopes_match()
+
+        # Check a simple call with a wrong model
+        data = scopes.get_data_for_model('res.partner')
+        self.assertEqual(data, {})

--- a/oauth_provider/tests/test_oauth_provider_scope.py
+++ b/oauth_provider/tests/test_oauth_provider_scope.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from openerp.tests.common import TransactionCase
+from odoo.tests.common import TransactionCase
 
 
-class TestOAuthProviderScope(TransactionCase):
+class TestOauthProviderScope(TransactionCase):
 
     def setUp(self):
-        super(TestOAuthProviderScope, self).setUp()
+        super(TestOauthProviderScope, self).setUp()
         self.filter = self.env['ir.filters'].create({
             'name': 'Current user',
             'model_id': 'res.users',
@@ -32,37 +32,37 @@ class TestOAuthProviderScope(TransactionCase):
 
         return self.env['oauth.provider.scope'].create(values)
 
-    def test_get_data_from_model_without_filter(self):
-        """ Check the values returned by the get_data_for_model method when no
+    def test_get_data_without_filter(self):
+        """ Check the values returned by the get_data method when no
         filter is defined
         """
         scope = self.new_scope({'filter_id': False})
 
         # Check a simple call with the right model
-        data = scope.get_data_for_model('res.users')
+        data = scope.get_data('res.users')
         # Check that we have multiple users (otherwise this test is useless)
         self.assertTrue(len(self.env['res.users'].search([]).ids) > 1)
         self.assertEqual(
             set(data.keys()), set(self.env['res.users'].search([]).ids))
 
-    def test_get_data_from_model_without_filter_wrong_model(self):
-        """ Check the values returned by the get_data_for_model method when no
+    def test_get_data_without_filter_wrong_model(self):
+        """ Check the values returned by the get_data method when no
         filter is defined
         """
         scope = self.new_scope({'filter_id': False})
 
         # Check a simple call with a wrong model
-        data = scope.get_data_for_model('res.partner')
+        data = scope.get_data('res.partner')
         self.assertEqual(data, {})
 
-    def test_get_data_from_model_with_filter(self):
-        """ Check the values returned by the get_data_for_model method when no
-        res_id is supplied
+    def test_get_data_with_filter(self):
+        """ Check the values returned by the get_data method when no
+        record_ids is supplied
         """
         scope = self.new_scope()
 
         # Check a simple call with the right model
-        data = scope.get_data_for_model('res.users')
+        data = scope.get_data('res.users')
         self.assertEqual(data, {
             self.env.user.id: {
                 'id': self.env.user.id,
@@ -70,62 +70,62 @@ class TestOAuthProviderScope(TransactionCase):
             },
         })
 
-    def test_get_data_from_model_with_filter_wrong_model(self):
-        """ Check the values returned by the get_data_for_model method when no
-        res_id is supplied
+    def test_get_data_with_filter_wrong_model(self):
+        """ Check the values returned by the get_data method when no
+        record_ids is supplied
         """
         scope = self.new_scope()
 
         # Check a simple call with a wrong model
-        data = scope.get_data_for_model('res.partner')
+        data = scope.get_data('res.partner')
         self.assertEqual(data, {})
 
-    def test_get_data_from_model_with_res_id_and_no_filter(self):
-        """ Check the values returned by the get_data_for_model method when a
-        res_id is supplied
+    def test_get_data_with_record_ids_and_no_filter(self):
+        """ Check the values returned by the get_data method when a
+        record_ids is supplied
         """
         scope = self.new_scope({'filter_id': False})
 
         # Check a simple call with the right model
-        data = scope.get_data_for_model('res.users', res_id=self.env.user.id)
+        data = scope.get_data('res.users', record_ids=self.env.user.ids)
         self.assertEqual(data, {
             'id': self.env.user.id,
             'email': self.env.user.email,
         })
 
-    def test_get_data_from_model_with_res_id_and_no_filter_wrong_model(self):
-        """ Check the values returned by the get_data_for_model method when a
-        res_id is supplied
+    def test_get_data_with_record_ids_and_no_filter_wrong_model(self):
+        """ Check the values returned by the get_data method when a
+        record_ids is supplied
         """
         scope = self.new_scope({'filter_id': False})
 
         # Check a simple call with a wrong model
-        data = scope.get_data_for_model(
-            'res.partner', res_id=self.env.user.id + 1)
+        data = scope.get_data(
+            'res.partner', record_ids=[self.env.user.id + 1])
         self.assertEqual(data, {})
 
-    def test_get_data_from_model_with_res_id(self):
-        """ Check the values returned by the get_data_for_model method when a
-        res_id is supplied
+    def test_get_data_with_record_ids(self):
+        """ Check the values returned by the get_data method when a
+        record_ids is supplied
         """
         scope = self.new_scope()
 
         # Check a simple call with the right model
-        data = scope.get_data_for_model('res.users', res_id=self.env.user.id)
+        data = scope.get_data('res.users', record_ids=self.env.user.ids)
         self.assertEqual(data, {
             'id': self.env.user.id,
             'email': self.env.user.email,
         })
 
-    def test_get_data_from_model_with_res_id_wrong_model(self):
-        """ Check the values returned by the get_data_for_model method when a
-        res_id is supplied
+    def test_get_data_with_record_ids_wrong_model(self):
+        """ Check the values returned by the get_data method when a
+        record_ids is supplied
         """
         scope = self.new_scope()
 
         # Check a simple call with a wrong model
-        data = scope.get_data_for_model(
-            'res.partner', res_id=self.env.user.id + 1)
+        data = scope.get_data(
+            'res.partner', record_ids=[self.env.user.id + 1])
         self.assertEqual(data, {})
 
     def _generate_multiple_scopes(self):
@@ -149,8 +149,8 @@ class TestOAuthProviderScope(TransactionCase):
 
         return scopes
 
-    def test_get_data_from_model_with_multiple_scopes_empty_fields(self):
-        """ Check the values returned by the get_data_for_model method when
+    def test_get_data_with_multiple_scopes_empty_fields(self):
+        """ Check the values returned by the get_data method when
         calling on multiple scopes
         """
         scopes = self._generate_multiple_scopes()
@@ -158,7 +158,7 @@ class TestOAuthProviderScope(TransactionCase):
         # Check a simple call with the right model with empty fields
         self.env.user.city = False
         self.env.user.country_id = False
-        data = scopes.get_data_for_model('res.users')
+        data = scopes.get_data('res.users')
         self.assertEqual(data, {self.env.user.id: {
             'id': 1,
             'email': self.env.user.email,
@@ -167,8 +167,8 @@ class TestOAuthProviderScope(TransactionCase):
             'country_id': False,
         }})
 
-    def test_get_data_from_model_with_multiple_scopesfirst_model(self):
-        """ Check the values returned by the get_data_for_model method when
+    def test_get_data_with_multiple_scopesfirst_model(self):
+        """ Check the values returned by the get_data method when
         calling on multiple scopes
         """
         scopes = self._generate_multiple_scopes()
@@ -177,7 +177,7 @@ class TestOAuthProviderScope(TransactionCase):
         country = self.env.ref('base.fr')
         self.env.user.city = 'Paris'
         self.env.user.country_id = country
-        data = scopes.get_data_for_model('res.users')
+        data = scopes.get_data('res.users')
         self.assertEqual(data, {self.env.user.id: {
             'id': 1,
             'email': self.env.user.email,
@@ -186,25 +186,25 @@ class TestOAuthProviderScope(TransactionCase):
             'country_id': country.name,
         }})
 
-    def test_get_data_from_model_with_multiple_scopes_second_model(self):
-        """ Check the values returned by the get_data_for_model method when
+    def test_get_data_with_multiple_scopes_second_model(self):
+        """ Check the values returned by the get_data method when
         calling on multiple scopes
         """
         scopes = self._generate_multiple_scopes()
 
         # Check a simple call with another right model
-        data = scopes.get_data_for_model('res.groups')
+        data = scopes.get_data('res.groups')
         self.assertEqual(
             set(data.keys()), set(self.env['res.groups'].search([]).ids))
 
-    def test_get_data_from_model_with_multiple_scopes_wrong_model(self):
-        """ Check the values returned by the get_data_for_model method when
+    def test_get_data_with_multiple_scopes_wrong_model(self):
+        """ Check the values returned by the get_data method when
         calling on multiple scopes
         """
         scopes = self._generate_multiple_scopes()
 
         # Check a simple call with a wrong model
-        data = scopes.get_data_for_model('res.partner')
+        data = scopes.get_data('res.partner')
         self.assertEqual(data, {})
 
     def _generate_multiple_scopes_match(self):
@@ -224,49 +224,49 @@ class TestOAuthProviderScope(TransactionCase):
 
         return scopes
 
-    def test_get_data_from_model_with_all_scopes_match(self):
-        """ Check the values returned by the get_data_for_model method when all
+    def test_get_data_with_all_scopes_match(self):
+        """ Check the values returned by the get_data method when all
         scopes are required to match
         """
         scopes = self._generate_multiple_scopes_match()
 
         # Check a simple call with the right model with any scope match
         # returned records
-        data = scopes.get_data_for_model('res.users')
+        data = scopes.get_data('res.users')
         self.assertEqual(
             set(data.keys()), set(self.env['res.users'].search([]).ids))
 
-    def test_get_data_from_model_with_all_scopes_match_first_model(self):
-        """ Check the values returned by the get_data_for_model method when all
+    def test_get_data_with_all_scopes_match_first_model(self):
+        """ Check the values returned by the get_data method when all
         scopes are required to match
         """
         scopes = self._generate_multiple_scopes_match()
 
         # Check a simple call with the right model with all scopes required to
         # match returned records
-        data = scopes.get_data_for_model('res.users', all_scopes_match=True)
+        data = scopes.get_data('res.users', all_scopes_match=True)
         self.assertEqual(data, {self.env.user.id: {
             'id': 1,
             'email': self.env.user.email,
         }})
 
-    def test_get_data_from_model_with_all_scopes_match_second_model(self):
-        """ Check the values returned by the get_data_for_model method when all
+    def test_get_data_with_all_scopes_match_second_model(self):
+        """ Check the values returned by the get_data method when all
         scopes are required to match
         """
         scopes = self._generate_multiple_scopes_match()
 
         # Check a simple call with another right model
-        data = scopes.get_data_for_model('res.groups')
+        data = scopes.get_data('res.groups')
         self.assertEqual(
             set(data.keys()), set(self.env['res.groups'].search([]).ids))
 
-    def test_get_data_from_model_with_all_scopes_match_wrong_model(self):
-        """ Check the values returned by the get_data_for_model method when all
+    def test_get_data_with_all_scopes_match_wrong_model(self):
+        """ Check the values returned by the get_data method when all
         scopes are required to match
         """
         scopes = self._generate_multiple_scopes_match()
 
         # Check a simple call with a wrong model
-        data = scopes.get_data_for_model('res.partner')
+        data = scopes.get_data('res.partner')
         self.assertEqual(data, {})

--- a/oauth_provider/tests/test_oauth_provider_token.py
+++ b/oauth_provider/tests/test_oauth_provider_token.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 SYLEAM
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime, timedelta
+from openerp import fields, exceptions
+from openerp.tests.common import TransactionCase
+
+
+class TestOAuthProviderToken(TransactionCase):
+
+    def setUp(self):
+        super(TestOAuthProviderToken, self).setUp()
+        self.client = self.env['oauth.provider.client'].create({
+            'name': 'Client',
+            'identifier': 'client',
+        })
+        self.token_vals = {
+            'user_id': self.env.user.id,
+            'client_id': self.client.id,
+            'token': 'token',
+            'expires_at': fields.Datetime.now(),
+        }
+        self.filter = self.env['ir.filters'].create({
+            'name': 'Current user',
+            'model_id': 'res.users',
+            'domain': "[('id', '=', uid)]",
+        })
+        self.scope_vals = {
+            'name': 'Scope',
+            'code': 'scope',
+            'description': 'Description of the scope',
+            'model_id': self.env.ref('base.model_res_users').id,
+            'filter_id': self.filter.id,
+            'field_ids': [
+                (6, 0, [self.env.ref('base.field_res_users_email').id]),
+            ],
+        }
+
+    def new_token(self, vals=None):
+        values = self.token_vals
+        if vals is not None:
+            values.update(vals)
+
+        return self.env['oauth.provider.token'].create(values)
+
+    def new_scope(self, vals=None):
+        values = self.scope_vals
+        if vals is not None:
+            values.update(vals)
+
+        return self.env['oauth.provider.scope'].create(values)
+
+    def test_inactive(self):
+        """ Check the value of the active field, for an expired token """
+        not_expired = datetime.now() + timedelta(days=1)
+        token = self.new_token(vals={
+            'token': 'Active',
+            'expires_at': fields.Datetime.to_string(not_expired),
+        })
+        self.assertEqual(token.active, True)
+
+    def test_active(self):
+        """ Check the value of the active field, for a not expired token """
+        expired = datetime.now() - timedelta(minutes=1)
+        token = self.new_token(vals={
+            'token': 'Not active',
+            'expires_at': fields.Datetime.to_string(expired),
+        })
+        self.assertEqual(token.active, False)
+
+    def _generate_tokens_for_active_search(self):
+        not_expired = datetime.now() + timedelta(days=1)
+        not_expired_tokens = self.new_token(vals={
+            'token': 'Not expired',
+            'expires_at': fields.Datetime.to_string(not_expired),
+        })
+        not_expired_tokens += not_expired_tokens.copy(default={
+            'token': 'Other not expired',
+        })
+
+        expired = datetime.now() - timedelta(minutes=1)
+        expired_tokens = self.new_token(vals={
+            'token': 'Expired',
+            'expires_at': fields.Datetime.to_string(expired),
+        })
+        expired_tokens += expired_tokens.copy(default={
+            'token': 'Other expired',
+        })
+
+        return expired_tokens, not_expired_tokens
+
+    def test_search_empty_domain(self):
+        """ Check the results of searching tokens with an empty domain
+
+        Only active tokens should be returned
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([]), not_expired_tokens)
+
+    def test_active_search_equal_true(self):
+        """ Check the results of searching tokens with explicit active = True domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', '=', True),
+        ]), not_expired_tokens)
+
+    def test_active_search_equal_false(self):
+        """ Check the results of searching tokens with active = False domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', '=', False),
+        ]), expired_tokens)
+
+    def test_active_search_not_equal_true(self):
+        """ Check the results of searching tokens with active != True domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', '!=', True),
+        ]), expired_tokens)
+
+    def test_active_search_not_equal_false(self):
+        """ Check the results of searching tokens with active != False domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', '!=', False),
+        ]), not_expired_tokens)
+
+    def test_active_search_in_true(self):
+        """ Check the results of searching tokens with active in (True,) domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', 'in', (True,)),
+        ]), not_expired_tokens)
+
+    def test_active_search_in_false(self):
+        """ Check the results of searching tokens with active in (False,) domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', 'in', (False,)),
+        ]), expired_tokens)
+
+    def test_active_search_not_in_true(self):
+        """ Check the results of searching tokens with active not in (True,) domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', 'not in', (True,)),
+        ]), expired_tokens)
+
+    def test_active_search_not_in_false(self):
+        """ Check the results of searching tokens with active not in (False,) domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', 'not in', (False,)),
+        ]), not_expired_tokens)
+
+    def test_active_search_in_true_false(self):
+        """ Check the results of searching tokens with active in (True, False) domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', 'in', (True, False)),
+        ]), not_expired_tokens + expired_tokens)
+
+    def test_active_search_not_in_true_false(self):
+        """ Check the results of searching tokens with active notin (True,False) domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        self.assertEqual(token_obj.search([
+            ('active', 'not in', (True, False)),
+        ]), token_obj)
+
+    def test_active_search_invalid_operator(self):
+        """ Check the results of searching tokens with an invalid operatr in domain
+        """
+        token_obj = self.env['oauth.provider.token']
+        expired_tokens, not_expired_tokens = \
+            self._generate_tokens_for_active_search()
+
+        with self.assertRaises(exceptions.UserError):
+            token_obj.search([('active', '>', True)])
+
+    def test_get_data_from_model_with_at_least_one_scope_matching(self):
+        """ Check the values returned by the get_data_for_model method with
+        at least one scope matching the data
+        """
+        scopes = self.new_scope()
+        scopes += self.new_scope({
+            'code': 'All users',
+            'filter_id': False,
+        })
+        token = self.new_token(vals={
+            'scope_ids': [(6, 0, scopes.ids)],
+        })
+
+        # Check a simple call with the right model with empty fields
+        data = token.get_data_for_model('res.users')
+        self.assertEqual(
+            sorted(data.keys()), sorted(self.env['res.users'].search([]).ids))
+
+    def test_get_data_from_model_with_all_scopes_matching(self):
+        """ Check the values returned by the get_data_for_model method with
+        all scopes required to match the data
+        """
+        scopes = self.new_scope()
+        scopes += self.new_scope({
+            'code': 'All users',
+            'filter_id': False,
+        })
+        token = self.new_token(vals={
+            'scope_ids': [(6, 0, scopes.ids)],
+        })
+
+        # Check a simple call with the right model without empty fields
+        data = token.get_data_for_model('res.users', all_scopes_match=True)
+        self.assertEqual(data, {self.env.user.id: {
+            'id': 1,
+            'email': self.env.user.email,
+        }})
+
+    def test_get_data_from_model_with_no_scope_matching(self):
+        """ Check the values returned by the get_data_for_model method with
+        an unauthorized model
+        """
+        token = self.new_token()
+
+        # Check a simple call with a wrong model
+        data = token.get_data_for_model('res.partner')
+        self.assertEqual(data, {})

--- a/oauth_provider/tests/test_oauth_provider_token.py
+++ b/oauth_provider/tests/test_oauth_provider_token.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 SYLEAM
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from datetime import datetime, timedelta
-from openerp import fields, exceptions
-from openerp.tests.common import TransactionCase
+from odoo import fields, exceptions
+from odoo.tests.common import TransactionCase
 
 
-class TestOAuthProviderToken(TransactionCase):
+class TestOauthProviderToken(TransactionCase):
 
     def setUp(self):
-        super(TestOAuthProviderToken, self).setUp()
+        super(TestOauthProviderToken, self).setUp()
         self.client = self.env['oauth.provider.client'].create({
             'name': 'Client',
             'identifier': 'client',
@@ -222,7 +222,7 @@ class TestOAuthProviderToken(TransactionCase):
             token_obj.search([('active', '>', True)])
 
     def test_get_data_from_model_with_at_least_one_scope_matching(self):
-        """ Check the values returned by the get_data_for_model method with
+        """ Check the values returned by the get_data method with
         at least one scope matching the data
         """
         scopes = self.new_scope()
@@ -235,12 +235,12 @@ class TestOAuthProviderToken(TransactionCase):
         })
 
         # Check a simple call with the right model with empty fields
-        data = token.get_data_for_model('res.users')
+        data = token.get_data('res.users')
         self.assertEqual(
             sorted(data.keys()), sorted(self.env['res.users'].search([]).ids))
 
     def test_get_data_from_model_with_all_scopes_matching(self):
-        """ Check the values returned by the get_data_for_model method with
+        """ Check the values returned by the get_data method with
         all scopes required to match the data
         """
         scopes = self.new_scope()
@@ -253,18 +253,18 @@ class TestOAuthProviderToken(TransactionCase):
         })
 
         # Check a simple call with the right model without empty fields
-        data = token.get_data_for_model('res.users', all_scopes_match=True)
+        data = token.get_data('res.users', all_scopes_match=True)
         self.assertEqual(data, {self.env.user.id: {
             'id': 1,
             'email': self.env.user.email,
         }})
 
     def test_get_data_from_model_with_no_scope_matching(self):
-        """ Check the values returned by the get_data_for_model method with
+        """ Check the values returned by the get_data method with
         an unauthorized model
         """
         token = self.new_token()
 
         # Check a simple call with a wrong model
-        data = token.get_data_for_model('res.partner')
+        data = token.get_data('res.partner')
         self.assertEqual(data, {})

--- a/oauth_provider/tests/test_rest_api_controller.py
+++ b/oauth_provider/tests/test_rest_api_controller.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import json
+
+from .common_test_controller import OauthProviderControllerTransactionCase
+
+
+class TestRestApiController(OauthProviderControllerTransactionCase):
+
+    API_BASE = '/api/rest/1.0/res.users'
+
+    def setUp(self):
+        super(TestRestApiController, self).setUp('legacy application')
+        self.logged_user = self.env.user
+        self.user = self.env.user
+        self.token = self.new_token(True).token
+        self.filter.domain = []
+        self.admin_user_data = {"city": self.user.city,
+                                "login": self.user.login,
+                                "id": self.user.id,
+                                "name": self.user.name,
+                                "email": self.user.email}
+
+    def _test_json_response(self, response, expect, res_id=None):
+        # Python does some funny things on the object encode.
+        # Must encode/decode the expect object to get compatible data.
+        expect = json.loads(json.dumps(expect))
+        response = json.loads(response.data)
+        expect = {
+            u"jsonrpc": u"2.0",
+            u"id": res_id,
+            u"result": expect,
+        }
+        self.assertDictEqual(response, expect)
+
+    def test_rest_list_all(self):
+        """ It should return all of the scoped data. """
+        self.filter.domain = [('id', '=', self.env.uid)]
+        data = {'access_token': self.token}
+        response = self.get_request(self.API_BASE, data=data, json=True)
+        self._test_json_response(response, {self.uid: self.admin_user_data})
+
+    def test_rest_list_domain(self):
+        """ It should only return scoped data indicated by the query. """
+        data = {
+            'access_token': self.token,
+            'domain': [("name", "=", self.admin_user_data['name'])],
+        }
+        response = self.get_request(self.API_BASE, data=data, json=True)
+        self._test_json_response(response, {self.uid: self.admin_user_data})
+
+    def test_rest_read(self):
+        """ It should return the proper record. """
+        response = self.get_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': self.token,
+                  'domain': [('name', '=', self.admin_user_data['name'])],
+                  },
+            json=True,
+        )
+        self._test_json_response(response, self.admin_user_data)
+
+    def test_rest_create(self):
+        """ It should create and return a new record. """
+        response = self.post_request(
+            self.API_BASE,
+            data={'access_token': self.token,
+                  'name': 'Test User',
+                  'login': 'tuser@example.com',
+                  },
+            json=True,
+        )
+        expect = {"city": False,
+                  "login": "tuser@example.com",
+                  "id": json.loads(response.data)['result']['id'],
+                  "name": "Test User",
+                  "email": False}
+        self._test_json_response(response, expect)
+
+    def test_rest_write(self):
+        """ It should write to and return the updated record data. """
+        response = self.put_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': self.token,
+                  'name': 'Edited User',
+                  },
+            json=True,
+        )
+        self.admin_user_data['name'] = 'Edited User'
+        self._test_json_response(response, self.admin_user_data)
+
+    def test_rest_delete(self):
+        """ It should delete the record and return True """
+        user = self.env.ref('base.user_demo')
+        response = self.delete_request(
+            '%s/%s' % (self.API_BASE, user.id),
+            data={'access_token': self.token},
+            json=True,
+        )
+        self._test_json_response(response, True)
+
+    def test_rest_create_token_validate(self):
+        """ It should raise on invalid token. """
+        response = self.post_request(
+            self.API_BASE,
+            data={'access_token': 'Bad Token'},
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 401)
+
+    def test_rest_create_bad_scope_field(self):
+        """ It should raise on field mutation not within scope. """
+        response = self.post_request(
+            self.API_BASE,
+            data={'access_token': self.token,
+                  'signatunre': 'Some non-allowed data',
+                  },
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 403)
+
+    def test_rest_update_token_validate(self):
+        """ It should raise on invalid token. """
+        response = self.put_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': 'Bad Token'},
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 401)
+
+    def test_rest_update_bad_scope_field(self):
+        """ It should raise on field mutation not within scope. """
+        response = self.put_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': self.token,
+                  'signatunre': 'Some non-allowed data',
+                  },
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 403)
+
+    def test_rest_update_bad_scope_record(self):
+        """ It should raise on record not within scope. """
+        self.filter.domain = [('id', '=', self.env.ref('base.user_demo').id)]
+        response = self.put_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': self.token,
+                  'name': 'Test User',
+                  },
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 403)
+
+    def test_rest_delete_token_validate(self):
+        """ It should raise on invalid token. """
+        response = self.delete_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': 'Bad Token'},
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 401)
+
+    def test_rest_delete_bad_scope_record(self):
+        """ It should raise on record not within scope. """
+        self.filter.domain = [('id', '=', self.env.ref('base.user_demo').id)]
+        response = self.delete_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': self.token},
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 403)
+
+    def test_rest_list_token_validate(self):
+        """ It should raise on invalid token. """
+        response = self.get_request(
+            self.API_BASE,
+            data={'access_token': 'Bad Token'},
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 401)
+
+    def test_rest_read_token_validate(self):
+        """ It should raise on invalid token. """
+        response = self.get_request(
+            '%s/%s' % (self.API_BASE, self.env.uid),
+            data={'access_token': 'Bad Token'},
+            json=True,
+        )
+        response = json.loads(response.data)
+        self.assertEqual(response.get('error', {}).get('code'), 401)

--- a/oauth_provider/views/oauth_provider_client.xml
+++ b/oauth_provider/views/oauth_provider_client.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2016 SYLEAM
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_oauth_provider_client_tree" model="ir.ui.view">
+        <field name="name">oauth.provider.client.tree</field>
+        <field name="model">oauth.provider.client</field>
+        <field name="arch" type="xml">
+            <tree string="OAuth Provider Clients">
+                <field name="name"/>
+                <field name="identifier"/>
+                <field name="application_type"/>
+                <field name="scope_ids"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_oauth_provider_client_form" model="ir.ui.view">
+        <field name="name">oauth.provider.client.form</field>
+        <field name="model">oauth.provider.client</field>
+        <field name="arch" type="xml">
+            <form string="OAuth Provider Clients">
+                <sheet>
+                    <h1>
+                        <field name="name"/>
+                    </h1>
+                    <group>
+                        <group>
+                            <field name="identifier"/>
+                            <field name="secret"/>
+                            <field name="application_type"/>
+                        </group>
+                        <group>
+                            <field name="skip_authorization" attrs="{'invisible': [('application_type', 'not in', ('mobile application', 'web application'))]}"/>
+                            <field name="scope_ids" widget="many2many_tags"/>
+                            <field name="token_type"/>
+                        </group>
+                    </group>
+                    <notebook colspan="4">
+                        <page string="Allowed Redirect URIs" attrs="{'invisible': [('application_type', 'not in', ('mobile application', 'web application'))]}">
+                            <field name="redirect_uri_ids">
+                                <tree string="Redirect URIs" editable="bottom">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="name"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="view_oauth_provider_client_search" model="ir.ui.view">
+        <field name="name">oauth.provider.client.search</field>
+        <field name="model">oauth.provider.client</field>
+        <field name="arch" type="xml">
+            <search string="OAuth Provider Clients">
+                <field name="name"/>
+                <field name="identifier"/>
+                <field name="application_type"/>
+                <field name="scope_ids"/>
+            </search>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="act_open_oauth_provider_client_view">
+        <field name="name">OAuth Provider Clients</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">oauth.provider.client</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_oauth_provider_client_search"/>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+    <record model="ir.actions.act_window.view" id="act_open_oauth_provider_client_view_form">
+        <field name="act_window_id" ref="act_open_oauth_provider_client_view"/>
+        <field name="sequence" eval="20"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_oauth_provider_client_form"/>
+    </record>
+    <record model="ir.actions.act_window.view" id="act_open_oauth_provider_client_view_tree">
+        <field name="act_window_id" ref="act_open_oauth_provider_client_view"/>
+        <field name="sequence" eval="10"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_oauth_provider_client_tree"/>
+    </record>
+    <menuitem id="menu_oauth_provider_client" parent="base.menu_users" sequence="40" action="act_open_oauth_provider_client_view"/>
+</odoo>

--- a/oauth_provider/views/oauth_provider_client.xml
+++ b/oauth_provider/views/oauth_provider_client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2016 SYLEAM
-    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 -->
 <odoo>
     <record id="view_oauth_provider_client_tree" model="ir.ui.view">

--- a/oauth_provider/views/oauth_provider_scope.xml
+++ b/oauth_provider/views/oauth_provider_scope.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2016 SYLEAM
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="view_oauth_provider_scope_tree" model="ir.ui.view">
+        <field name="name">oauth.provider.scope.tree</field>
+        <field name="model">oauth.provider.scope</field>
+        <field name="arch" type="xml">
+            <tree string="OAuth Provider Scopes">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="description"/>
+                <field name="model_id"/>
+            </tree>
+        </field>
+    </record>
+    <record id="view_oauth_provider_scope_form" model="ir.ui.view">
+        <field name="name">oauth.provider.scope.form</field>
+        <field name="model">oauth.provider.scope</field>
+        <field name="arch" type="xml">
+            <form string="OAuth Provider Scopes">
+                <sheet>
+                    <h1>
+                        <field name="name"/>
+                    </h1>
+                    <group>
+                        <group>
+                            <field name="code"/>
+                            <field name="description"/>
+                            <separator string="Filter settings" colspan="2"/>
+                            <field name="model_id"/>
+                            <field name="filter_id"/>
+                            <field name="model" invisible="1"/>
+                        </group>
+                        <group>
+                            <separator string="Fields" colspan="2"/>
+                            <field name="field_ids" nolabel="1">
+                                <tree string="Fields">
+                                    <field name="name"/>
+                                    <field name="field_description"/>
+                                    <field name="ttype"/>
+                                </tree>
+                            </field>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="view_oauth_provider_scope_search" model="ir.ui.view">
+        <field name="name">oauth.provider.scope.search</field>
+        <field name="model">oauth.provider.scope</field>
+        <field name="arch" type="xml">
+            <search string="OAuth Provider Scopes">
+                <field name="name"/>
+                <field name="code"/>
+                <field name="description"/>
+                <field name="model_id"/>
+            </search>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="act_open_oauth_provider_scope_view">
+        <field name="name">OAuth Provider Scopes</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">oauth.provider.scope</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_oauth_provider_scope_search"/>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+    <record model="ir.actions.act_window.view" id="act_open_oauth_provider_scope_view_form">
+        <field name="act_window_id" ref="act_open_oauth_provider_scope_view"/>
+        <field name="sequence" eval="20"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_oauth_provider_scope_form"/>
+    </record>
+    <record model="ir.actions.act_window.view" id="act_open_oauth_provider_scope_view_tree">
+        <field name="act_window_id" ref="act_open_oauth_provider_scope_view"/>
+        <field name="sequence" eval="10"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_oauth_provider_scope_tree"/>
+    </record>
+    <menuitem id="menu_oauth_provider_scope" parent="base.menu_users" sequence="40" action="act_open_oauth_provider_scope_view"/>
+</odoo>

--- a/oauth_provider/views/oauth_provider_scope.xml
+++ b/oauth_provider/views/oauth_provider_scope.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2016 SYLEAM
-    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 -->
 <odoo>
     <record id="view_oauth_provider_scope_tree" model="ir.ui.view">

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ unidecode
 acme_tiny
 IPy
 email_validator
+validate_email
+oauthlib
 pyotp
 pysftp
 fdb


### PR DESCRIPTION
This is a complete overhaul of the OAuth2 provider module, as well as a migration to v10. I added an abstract REST API as well, following are the docs:


REST API
========

This module also includes a basic REST-style CRUD interface backed by OAuth2 authentication.

List
----

Return allowed information from all records, with optional query.

Route: /api/rest/1.0/&lt;string:model&gt;

Accepts: GET

Args:  
access\_token (str): OAuth2 access token to utilize for the  
operation.

model (str): Name of model to operate on. domain (array, optional): Domain to apply to the search, in the standard Odoo format. This will be appended to the scope’s pre-existing filter.

Returns:  
array of objs: List of data mappings matching query.

Example:

Bash:

``` sourceCode
curl -H "Content-Type: application/json" \
   -X GET \
   http://localhost:8060/api/gogo/1.0/res.partner?access_token=2J391BkHipPmM9nXv2BF6V07fehWtM&domain=%5B%5B%22company_id%22%2C%20%22%3D%22%2C%201%5D%5D

{"jsonrpc": "2.0", "id": 5602, "result": [{"name": "Test Partner", "id": 5602}]}
```

Python:

``` sourceCode
json_data = {
    'access_token': token['access_token'],
    'domain': [('company_id', '=', 1)],
}
response = requests.get(
    'http://localhost:8060/api/gogo/1.0/res.partner/',
    params=json_data,
)
response_data = response.json()

{u'jsonrpc': u'2.0', u'id': 5602, u'result': [{u'name': u'Test Partner', u'id': 5602}]}
```

Read
----

Return allowed information from specific records.

Route: /api/rest/1.0/&lt;string:model&gt;/&lt;int:record\_id&gt;

Accepts: GET

Args:  
access\_token (str): OAuth2 access token to utilize for the  
operation.

model (str): Name of model to operate on. record\_id (int): ID of record to get.

Returns:  
obj: Record data.

Example:

Bash:

``` sourceCode
curl -H "Content-Type: application/json" \
   -X GET \
   http://localhost:8060/api/gogo/1.0/res.partner/5602?access_token=2J391BkHipPmM9nXv2BF6V07fehWtM

{"jsonrpc": "2.0", "id": 5602, "result": [{"name": "Test Partner", "id": 5602}]}
```

Python:

``` sourceCode
json_data = {
    'access_token': token['access_token'],
}
response = requests.post(
    'http://localhost:8060/api/gogo/1.0/res.partner/5602',
   params=json_data,
)
response_data = response.json()

{u'jsonrpc': u'2.0', u'id': 5602, u'result': [{u'name': u'Test Partner', u'id': 5602}]}
```

Create
------

Return allowed information from specific records.

Route: /api/rest/1.0/&lt;string:model&gt;

Accepts: POST

Args:  
access\_token (str): OAuth2 access token to utilize for the  
operation.

model (str): Name of model to operate on. kwargs (mixed): All other named arguments are used as the data for record mutation.

Returns:  
obj: Record data.

Example:

Bash:

``` sourceCode
curl -H "Content-Type: application/json" \
   -X POST \
   -d '{ "params": { "access_token": "2J391BkHipPmM9nXv2BF6V07fehWtM", "name": "Test Partner" }' \
   http://localhost:8060/api/gogo/1.0/res.partner

{"jsonrpc": "2.0", "id": 5602, "result": [{"name": "T
```