### PR TITLE
[FIX] oauth_provider: Guard for instances of no redirects

### DIFF
--- a/oauth_provider/__openerp__.py
+++ b/oauth_provider/__openerp__.py
@@ -15,7 +15,7 @@
         'python': ['oauthlib'],
     },
     'depends': [
-        'base',
+        'web',
     ],
     'data': [
         'security/oauth_provider_security.xml',

--- a/oauth_provider/oauth2/validator.py
+++ b/oauth_provider/oauth2/validator.py
@@ -186,7 +186,7 @@ class OdooValidator(RequestValidator):
                 datetime.now() + timedelta(seconds=token['expires_in'])),
         })
         redirect_uris = request.client.redirect_uri_ids
-        return redirect_uris and redirect_uris[0].name or ''
+        return redirect_uris[:1].name
 
     def validate_bearer_token(self, token, scopes, request):
         """ Ensure the supplied bearer token is valid, and allowed for the scopes

--- a/oauth_provider/oauth2/validator.py
+++ b/oauth_provider/oauth2/validator.py
@@ -185,7 +185,8 @@ class OdooValidator(RequestValidator):
             'expires_at': fields.Datetime.to_string(
                 datetime.now() + timedelta(seconds=token['expires_in'])),
         })
-        return request.client.redirect_uri_ids[0].name
+        redirect_uris = request.client.redirect_uri_ids
+        return redirect_uris and redirect_uris[0].name or ''
 
     def validate_bearer_token(self, token, scopes, request):
         """ Ensure the supplied bearer token is valid, and allowed for the scopes


### PR DESCRIPTION
* Legacy application workflow does not have redirect_uris, so it was throwing an error on token generation. Return empty string in event of no redirect.