### PR TITLE
[10.0] date_range: improve 'name' for generator wizard

### DIFF
--- a/date_range/__manifest__.py
+++ b/date_range/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Date Range",
     "summary": "Manage all kind of date range",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Uncategorized",
     "website": "https://odoo-community.org/",
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/date_range/security/date_range_security.xml
+++ b/date_range/security/date_range_security.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <data noupdate="1">
-        <record id="date_range_type_comp_rule" model="ir.rule">
-            <field name="name">Date Range Type multi-company</field>
-            <field name="model_id" ref="model_date_range_type"/>
-            <field eval="True" name="global"/>
-            <field name="domain_force"> ['|',('company_id','=',user.company_id.id),('company_id','=',False)]</field>
-            <field eval="False" name="active"/>
-        </record>
-        <record id="date_range_comp_rule" model="ir.rule">
-            <field name="name">Date Range multi-company</field>
-            <field name="model_id" ref="model_date_range"/>
-            <field eval="True" name="global"/>
-            <field name="domain_force"> ['|',('company_id','=',user.company_id.id),('company_id','=',False)]</field>
-            <field eval="False" name="active"/>
-        </record>
-    </data>
+<odoo noupdate="1">
+    <record id="date_range_type_comp_rule" model="ir.rule">
+        <field name="name">Date Range Type multi-company</field>
+        <field name="model_id" ref="model_date_range_type"/>
+        <field name="domain_force"> ['|',('company_id','=',user.company_id.id),('company_id','=',False)]</field>
+    </record>
+    <record id="date_range_comp_rule" model="ir.rule">
+        <field name="name">Date Range multi-company</field>
+        <field name="model_id" ref="model_date_range"/>
+        <field name="domain_force"> ['|',('company_id','=',user.company_id.id),('company_id','=',False)]</field>
+    </record>
 </odoo>

--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -43,7 +43,7 @@ class DateRangeGenerator(models.TransientModel):
                      count=self.count+1)
         vals = list(vals)
         date_ranges = []
-        month_digits = len(unicode(self.count))
+        count_digits = len(unicode(self.count))
         for idx, dt_start in enumerate(vals[:-1]):
             date_start = fields.Date.to_string(dt_start.date())
             # always remove 1 day for the date_end since range limits are
@@ -51,9 +51,8 @@ class DateRangeGenerator(models.TransientModel):
             dt_end = vals[idx+1].date() - relativedelta(days=1)
             date_end = fields.Date.to_string(dt_end)
             date_ranges.append({
-                'name': '%s%s' % (
-                    self.name_prefix,
-                    unicode(idx + 1).zfill(month_digits)),
+                'name': '%s%0*d' % (
+                    self.name_prefix, count_digits, idx + 1),
                 'date_start': date_start,
                 'date_end': date_end,
                 'type_id': self.type_id.id,

--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -51,7 +51,7 @@ class DateRangeGenerator(models.TransientModel):
             dt_end = vals[idx+1].date() - relativedelta(days=1)
             date_end = fields.Date.to_string(dt_end)
             date_ranges.append({
-                'name': '%s-%s' % (
+                'name': '%s%s' % (
                     self.name_prefix,
                     unicode(idx + 1).zfill(month_digits)),
                 'date_start': date_start,

--- a/date_range/wizard/date_range_generator.py
+++ b/date_range/wizard/date_range_generator.py
@@ -43,6 +43,7 @@ class DateRangeGenerator(models.TransientModel):
                      count=self.count+1)
         vals = list(vals)
         date_ranges = []
+        month_digits = len(unicode(self.count))
         for idx, dt_start in enumerate(vals[:-1]):
             date_start = fields.Date.to_string(dt_start.date())
             # always remove 1 day for the date_end since range limits are
@@ -50,7 +51,9 @@ class DateRangeGenerator(models.TransientModel):
             dt_end = vals[idx+1].date() - relativedelta(days=1)
             date_end = fields.Date.to_string(dt_end)
             date_ranges.append({
-                'name': '%s-%d' % (self.name_prefix, idx + 1),
+                'name': '%s-%s' % (
+                    self.name_prefix,
+                    unicode(idx + 1).zfill(month_digits)),
                 'date_start': date_start,
                 'date_end': date_end,
                 'type_id': self.type_id.id,


### PR DESCRIPTION
With the current code, when you run the wizard for monthly period over the year 2017 you get:
- 2017-1
- 2017-2
...
- 2017-11
- 2017-12

With this PR, you will get:
- 2017-01
- 2017-02
...
- 2017-11
- 2017-12

That way, the alphabetical order corresponds to the date order.

ir.rule should be active by default (it is very uncommon/strange to create inactive ir.rule).