### PR TITLE
[FIX][9.0] date_range. Periods within the day should be allowed

### DIFF
--- a/date_range/__openerp__.py
+++ b/date_range/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Date Range",
     "summary": "Manage all kind of date range",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "category": "Uncategorized",
     "website": "https://odoo-community.org/",
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",

--- a/date_range/models/date_range.py
+++ b/date_range/models/date_range.py
@@ -38,9 +38,9 @@ class DateRange(models.Model):
         for this in self:
             start = fields.Date.from_string(this.date_start)
             end = fields.Date.from_string(this.date_end)
-            if start >= end:
+            if start > end:
                 raise ValidationError(
-                    _("%s is not a valid range (%s >= %s)") % (
+                    _("%s is not a valid range (%s > %s)") % (
                         this.name, this.date_start, this.date_end))
             if this.type_id.allow_overlap:
                 continue

--- a/date_range/tests/test_date_range.py
+++ b/date_range/tests/test_date_range.py
@@ -56,7 +56,7 @@ class DateRangeTest(TransactionCase):
             })
         self.assertEqual(
             cm.exception.name,
-            'FS2016 is not a valid range (2016-12-31 >= 2015-01-01)')
+            'FS2016 is not a valid range (2016-12-31 > 2015-01-01)')
 
     def test_overlap(self):
         date_range = self.env['date.range']


### PR DESCRIPTION
In some cases it may be necessary to create periods for just one day. For example: when generating a payroll period for a single day of work: https://github.com/OCA/hr/pull/354

As there's an option for creating overlapping periods I think this change it's not harmful. Users still can set the date_range_type to don't allow overlapping periods.