### PR TITLE
[FIX] auth_admin_passkey: normal users are not able to read the admin user email

### DIFF
--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -54,7 +54,7 @@ class ResUsers(models.Model):
         """ Send an email to the admin user to inform that
             another user has the same password as him."""
         mail_obj = self.env['mail.mail'].sudo()
-        admin_user = self.browse(SUPERUSER_ID)
+        admin_user = self.sudo().browse(SUPERUSER_ID)
 
         if admin_user.email:
             mail_obj.create({


### PR DESCRIPTION
If a normal user and the administrator have the same password, an AccessError is raised (email of the admin account can not be read) and no security alert is sent by email.