### PR TITLE
[10.0][FIX] User group not updating when removing a user from the role view

### DIFF
--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -85,3 +85,10 @@ class ResUsersRoleLine(models.Model):
                 date_to = fields.Date.from_string(role_line.date_to)
                 if today > date_to:
                     role_line.is_enabled = False
+
+    @api.multi
+    def unlink(self):
+        users = self.mapped('user_id')
+        res = super(ResUsersRoleLine, self).unlink()
+        users.set_groups_from_roles()
+        return res


### PR DESCRIPTION
If you remove users from a role, users groups won't be updated. This PR fixes this behavior.