### PR TITLE
[FIX] missing sudo in server_environment_ir_config_param

### DIFF
--- a/server_environment_ir_config_parameter/__manifest__.py
+++ b/server_environment_ir_config_parameter/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Server Environment Ir Config Parameter',
     'summary': """
         Override System Parameters from server environment file""",
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'author': 'ACSONE SA/NV,Odoo Community Association (OCA)',
     'website': 'https://odoo-community.org/',

--- a/server_environment_ir_config_parameter/models/ir_config_parameter.py
+++ b/server_environment_ir_config_parameter/models/ir_config_parameter.py
@@ -28,7 +28,7 @@ class IrConfigParameter(models.Model):
                 # should we have preloaded values in database at,
                 # server startup, modules loading their parameters
                 # from data files would break on unique key error.
-                self.set_param(key, cvalue)
+                self.sudo().set_param(key, cvalue)
                 value = cvalue
         if value is None:
             return default


### PR DESCRIPTION
Without this sudo get_param would fail when the first user reading a parameter that has changed in the configuration file does not have write access to system parameters.