### PR TITLE
[FIX][password_security] Fix internal error on wrong login

### DIFF
--- a/password_security/README.rst
+++ b/password_security/README.rst
@@ -83,6 +83,7 @@ Contributors
 
 * James Foster <jfoster@laslabs.com>
 * Dave Lasley <dave@laslabs.com>
+* Nguyen Duc Tam <nguyenductamlhp@gmail.com>
 
 Maintainer
 ----------

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -45,8 +45,6 @@ class PasswordSecurityHome(AuthSignupHome):
             request.params['password']
         )
         if not uid:
-            request.uid = old_uid
-            request.uid = request.env.ref('base.public_user').id
             return response
         users_obj = request.env['res.users'].sudo()
         user_id = users_obj.browse(request.uid)

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -35,6 +35,7 @@ class PasswordSecurityHome(AuthSignupHome):
     @http.route()
     def web_login(self, *args, **kw):
         ensure_db()
+        old_uid = request.uid
         response = super(PasswordSecurityHome, self).web_login(*args, **kw)
         if not request.httprequest.method == 'POST':
             return response
@@ -44,6 +45,7 @@ class PasswordSecurityHome(AuthSignupHome):
             request.params['password']
         )
         if not uid:
+            request.uid = old_uid
             return response
         users_obj = request.env['res.users'].sudo()
         user_id = users_obj.browse(request.uid)

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -46,6 +46,7 @@ class PasswordSecurityHome(AuthSignupHome):
         )
         if not uid:
             request.uid = old_uid
+            request.uid = request.env.ref('base.public_user').id
             return response
         users_obj = request.env['res.users'].sudo()
         user_id = users_obj.browse(request.uid)


### PR DESCRIPTION
Fix error when enter wrong password. `request.uid` is reset  to False and not reassign after authenticated.
[OCA#914](https://github.com/OCA/server-tools/issues/914)
