### PR TITLE
[FIX][module_auto_update] Record base addon checksum

### DIFF
--- a/module_auto_update/__openerp__.py
+++ b/module_auto_update/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Module Auto Update',
     'summary': 'Automatically update Odoo modules',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Extra Tools',
     'website': 'https://odoo-community.org/',
     'author': 'LasLabs, '

--- a/module_auto_update/tests/test_module.py
+++ b/module_auto_update/tests/test_module.py
@@ -10,6 +10,7 @@ import mock
 
 from openerp.modules import get_module_path
 from openerp.tests.common import TransactionCase
+from openerp.tools import mute_logger
 
 from .. import post_init_hook
 
@@ -77,24 +78,19 @@ class TestModule(TransactionCase):
 
     def test_store_checksum_installed_state_installed(self):
         """It should set the module's checksum_installed equal to
-        checksum_dir when vals contain state 'installed'"""
+        checksum_dir when vals contain a ``latest_version`` str."""
         self.own_module.checksum_installed = 'test'
-        self.own_module._store_checksum_installed({'state': 'installed'})
+        self.own_module._store_checksum_installed({'latest_version': '1.0'})
         self.assertEqual(
             self.own_module.checksum_installed, self.own_module.checksum_dir,
-            'Setting state to installed does not store checksum_dir '
-            'as checksum_installed',
         )
 
     def test_store_checksum_installed_state_uninstalled(self):
         """It should clear the module's checksum_installed when vals
-        contain state 'uninstalled'"""
+        contain ``"latest_version": False``"""
         self.own_module.checksum_installed = 'test'
-        self.own_module._store_checksum_installed({'state': 'uninstalled'})
-        self.assertEqual(
-            self.own_module.checksum_installed, False,
-            'Setting state to uninstalled does not clear checksum_installed',
-        )
+        self.own_module._store_checksum_installed({'latest_version': False})
+        self.assertIs(self.own_module.checksum_installed, False)
 
     def test_store_checksum_installed_vals_contain_checksum_installed(self):
         """It should not set checksum_installed to False or checksum_dir when
@@ -159,6 +155,7 @@ class TestModule(TransactionCase):
             '_store_checksum_installed',
         )
 
+    @mute_logger("openerp.modules.module")
     @mock.patch('%s.get_module_path' % model)
     def test_get_module_list(self, module_path_mock):
         """It should change the state of modules with different

--- a/module_auto_update/wizards/module_upgrade.py
+++ b/module_auto_update/wizards/module_upgrade.py
@@ -37,5 +37,9 @@ class ModuleUpgrade(models.TransientModel):
         # Update base addon checksum if its state changed
         base.invalidate_cache()
         if base.state != pre_state:
+            # This triggers the write hook that should have been triggered
+            # when the module was [un]installed/updated in the base-only
+            # module graph inside above call to super(), and updates its
+            # dir checksum as needed
             base.latest_version = base.latest_version
         return result


### PR DESCRIPTION
Base addon is a special case: when getting updated, it is updated in a limited addons graph that only contains itself. Under such graph, no behavior modifications are respected, so no matter what we do in module_auto_update, it will get ignored in that step. This means that when we first install module_auto_update, it will record current base addon's dir hash, and it will never again be updated, so the next time your base addon is updated, the auto update will update all addons (as expected), and every next times too (not expected).

To fix that behavior, now we track the base addon status before and after running an upgrade. If it has changed, then we update its checksum.

Besides that, workarounds for https://github.com/odoo/odoo/pull/18597 are removed, and a new method for knowing if an addon is being installed, updated or uninstalled is used: check the existence of `latest_version` key in the create/write dict. This is because Odoo will always set that field to `False` when removing the addon, and it will also always write to it after installing or updating, so it provides basically all the information we need to know if we have to update or remove the checksum.

@Tecnativa