### PR TITLE
[FIX] base_kanban_stage: kanban_user_id instead of user_id

### DIFF
--- a/base_kanban_stage/README.rst
+++ b/base_kanban_stage/README.rst
@@ -93,6 +93,7 @@ Contributors
 * Dave Lasley <dave@laslabs.com>
 * Oleg Bulkin <obulkin@laslabs.com>
 * Daniel Reis <dreis.pt@hotmail.com>
+* Alex Comba <alex.comba@agilebg.com>
 
 Maintainer
 ----------

--- a/base_kanban_stage/__openerp__.py
+++ b/base_kanban_stage/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Kanban - Stage Support',
     'summary': 'Provides stage model and abstract logic for inheritance',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'base',
     'depends': [

--- a/base_kanban_stage/models/base_kanban_abstract.py
+++ b/base_kanban_stage/models/base_kanban_abstract.py
@@ -39,7 +39,7 @@ class BaseKanbanAbstract(models.AbstractModel):
         default=lambda s: s._default_stage_id(),
         domain=lambda s: [('res_model.model', '=', s._name)],
     )
-    user_id = fields.Many2one(
+    kanban_user_id = fields.Many2one(
         string='Assigned To',
         comodel_name='res.users',
         index=True,

--- a/base_kanban_stage/views/base_kanban_abstract.xml
+++ b/base_kanban_stage/views/base_kanban_abstract.xml
@@ -19,7 +19,7 @@
                 <field name="kanban_legend_blocked"/>
                 <field name="kanban_legend_normal"/>
                 <field name="kanban_legend_done"/>
-                <field name="user_id"/>
+                <field name="kanban_user_id"/>
                 <templates>
                     <t t-name="kanban-box">
                         <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.kanban_color.raw_value)} o_kanban_record oe_kanban_global_click">


### PR DESCRIPTION
The reasons of this change are:
* all public properties are preceded with kanban_, with the exception of stage_id (see BaseKanbanAbstract docstring)
* make base_kanban_abstract_view_kanban consistent as it uses this field

Backport of https://github.com/OCA/server-tools/pull/949