### PR TITLE
[10.0][ADD] website_password_security: Glue fix module

### DIFF
--- a/website_password_security/README.rst
+++ b/website_password_security/README.rst
@@ -1,0 +1,51 @@
+.. image:: https://img.shields.io/badge/license-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+=========================
+Website Password Security
+=========================
+
+This is a glue module to allow password security to work smoothly when
+website is installed.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+    :alt: Try me on Runbot
+    :target: https://runbot.odoo-community.org/runbot/149/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/LasLabs/odoo-base/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us to smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/website_password_security/__init__.py
+++ b/website_password_security/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).

--- a/website_password_security/__manifest__.py
+++ b/website_password_security/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+{
+
+    'name': 'Website Password Security',
+    "summary": "Glue module for when website is installed.",
+    'version': '10.0.1.0.0',
+    'author': "LasLabs, Odoo Community Association (OCA)",
+    'category': 'Base',
+    'depends': [
+        'password_security',
+        'website',
+    ],
+    "website": "https://laslabs.com",
+    "license": "LGPL-3",
+    "data": [
+        'templates/website_template.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/website_password_security/templates/website_template.xml
+++ b/website_password_security/templates/website_template.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright 2017 LasLabs Inc.
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+-->
+
+<odoo>
+
+    <template id="layout" inherit_id="website.layout">
+        <xpath expr="//script[contains(text(), 'session_info')]" position="replace">
+            <script type="application/javacscript">
+                odoo.session_info = {
+                    is_superuser: <t t-esc="json.dumps(request.env.user and request.env.user._is_superuser() or False)"/>,
+                    is_frontend: true,
+                };
+            </script>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
* Add conditional logic in the event that the user is not in the env due to password security failure; fixes OCA#914

This is a resubmission of #936, which I can't reopen due to me deleting the branch. The proposed solution in #938 is running into issues, but the one here is still holding up. 

We'll need to decide which strategy to go with, because the glue module definitely isn't preferred. I'm not sure of how to fix https://github.com/OCA/server-tools/pull/938#issuecomment-324515293 though.

cc @nguyenductamlhp 