### PR TITLE
[FIX][module_auto_update] Always store changes in lower graphs

### DIFF
--- a/module_auto_update/__openerp__.py
+++ b/module_auto_update/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Module Auto Update',
     'summary': 'Automatically update Odoo modules',
-    'version': '9.0.1.0.1',
+    'version': '9.0.1.0.2',
     'category': 'Extra Tools',
     'website': 'https://odoo-community.org/',
     'author': 'LasLabs, '

--- a/module_auto_update/wizards/module_upgrade.py
+++ b/module_auto_update/wizards/module_upgrade.py
@@ -37,7 +37,7 @@ class ModuleUpgrade(models.TransientModel):
         self.env.clear()
         # Update addons checksum if state changed and I wasn't uninstalled
         own = Module.search_read(
-            [("name", "=", "module_auto_upgrade")],
+            [("name", "=", "module_auto_update")],
             ["state"],
             limit=1)
         if own and own[0]["state"] != "uninstalled":

--- a/module_auto_update/wizards/module_upgrade.py
+++ b/module_auto_update/wizards/module_upgrade.py
@@ -20,13 +20,6 @@ class ModuleUpgrade(models.TransientModel):
         return super(ModuleUpgrade, self).get_module_list()
 
     @api.multi
-    def upgrade_module_cancel(self):
-        return super(
-            ModuleUpgrade,
-            self.with_context(retain_checksum_installed=True),
-        ).upgrade_module_cancel()
-
-    @api.multi
     def upgrade_module(self):
         """Make a fully automated addon upgrade."""
         # Compute updates by checksum when called in @api.model fashion


### PR DESCRIPTION
The same problem that was fixed for the `base` addon in #948 happened with random addons that do not depend on `module_auto_update` (a.k.a. any addon) that Odoo decided to load before that one in the graph.

Now we always check for all addons if their state has changed, and make sure to trigger the udpate mechanism that stores the right value in `installed_checksum_dir` field.

@Tecnativa