### PR TITLE
[10.0][IMP] module_auto_update: Update module list before getting

### DIFF
--- a/module_auto_update/__manifest__.py
+++ b/module_auto_update/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Module Auto Update',
     'summary': 'Automatically update Odoo modules',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Extra Tools',
     'website': 'https://odoo-community.org/',
     'author': 'LasLabs, '

--- a/module_auto_update/wizards/module_upgrade.py
+++ b/module_auto_update/wizards/module_upgrade.py
@@ -22,10 +22,12 @@ class ModuleUpgrade(models.TransientModel):
     @api.multi
     def upgrade_module(self):
         """Make a fully automated addon upgrade."""
+        Module = self.env["ir.module.module"]
+        # Update the modules list to resolve new dependencies
+        Module.update_list()
         # Compute updates by checksum when called in @api.model fashion
         if not self:
             self.get_module_list()
-        Module = self.env["ir.module.module"]
         # Get every addon state before updating
         pre_states = {addon["name"]: addon["state"]
                       for addon in Module.search_read([], ["name", "state"])}


### PR DESCRIPTION
* Update the module list before getting it in order to automatically resolve new dependencies

This is required if a pre-existing module is updated to depend on a module that does not exist in the database.