### PR TITLE
[FIX][mass_editing] Allow to delete models

### DIFF
--- a/mass_editing/README.rst
+++ b/mass_editing/README.rst
@@ -91,6 +91,7 @@ Contributors
 
 * Oihane Crucelaegui <oihanecrucelaegi@gmail.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/mass_editing/__manifest__.py
+++ b/mass_editing/__manifest__.py
@@ -3,8 +3,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Mass Editing',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'author': 'Serpent Consulting Services Pvt. Ltd., '
+              'Tecnativa, '
               'Odoo Community Association (OCA)',
     'contributors': [
         'Oihane Crucelaegui <oihanecrucelaegi@gmail.com>',

--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -11,6 +11,7 @@ class MassObject(models.Model):
 
     name = fields.Char('Name', required=True, index=1)
     model_id = fields.Many2one('ir.model', 'Model', required=True,
+                               ondelete="cascade",
                                help="Model is used for Selecting Fields. "
                                     "This is editable until Sidebar menu "
                                     "is not created.")


### PR DESCRIPTION
Without this fix, it is impossible to uninstall an addon that removes a model for which we had a `mass.object`.


@Tecnativa