### PR TITLE
[FIX] base_kanban_stage: extend search_domain only for fields belong to 'base.kanban.stage'

### DIFF
--- a/base_kanban_stage/models/base_kanban_abstract.py
+++ b/base_kanban_stage/models/base_kanban_abstract.py
@@ -108,6 +108,9 @@ class BaseKanbanAbstract(models.AbstractModel):
     @api.multi
     def _read_group_stage_ids(self, stages, domain, order):
         search_domain = [('res_model_id.model', '=', self._name)]
-        if domain:
-            search_domain.extend(domain)
+        stage_fields_names = self.env['ir.model.fields'].search(
+            [('model', '=', stages._name)]).mapped('name')
+        for el in domain:
+            if el[0].split('.')[0] in stage_fields_names:
+                search_domain.appen(el)
         return stages.search(search_domain, order=order)


### PR DESCRIPTION
This PR is intended to cover the following scenario:

* have a module as https://github.com/OCA/server-tools/pull/964 [1]
* have another module [2] where the model `calendar.event` is further extended with other fields
* use the kanban view created in [1] in which the search view has a filter with domain based on a field added by [2]

Without this I get the following error:

```
File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/addons/calendar/models/calendar.py", line 1454, in read_group
    return super(Meeting, self.with_context(virtual_id=False)).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/models.py", line 1932, in read_group
    result = self._read_group_raw(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/models.py", line 2045, in _read_group_raw
    aggregated_fields, count_field, result, read_group_order=order,
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/models.py", line 1686, in _read_group_fill_results
    groups = getattr(self, field.group_expand)(groups, domain, order)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/server-tools/base_kanban_stage/models/base_kanban_abstract.py", line 113, in _read_group_stage_ids
    return stages.search(search_domain, order=order)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/models.py", line 1518, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/models.py", line 4220, in _search
    query = self._where_calc(args)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/models.py", line 4019, in _where_calc
    e = expression.expression(domain, self)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/osv/expression.py", line 643, in __init__
    self.parse()
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/osv/expression.py", line 821, in parse
    raise ValueError("Invalid field %r in leaf %r" % (left, str(leaf)))
ValueError: Invalid field u'related_installed_component' in leaf "<osv.ExtendedLeaf: (u'related_installed_component', u'!=', False) on base_kanban_stage (ctx: )>"
```
Does this belong to https://github.com/OCA/server-tools/tree/10.0/base_kanban_stage#known-issues--roadmap?

In that case, could you please explain me better the reason for https://github.com/OCA/server-tools/blob/10.0/base_kanban_stage/models/base_kanban_abstract.py#L109?

Thank you in advance.