### PR TITLE
[FIX] password_security: Force password reset

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -50,6 +50,7 @@ class PasswordSecurityHome(AuthSignupHome):
         if not user_id._password_has_expired():
             return response
         user_id.action_expire_password()
+        request.session.logout(keep_db=True)
         redirect = user_id.partner_id.signup_url
         return http.redirect_with_hash(redirect)
 

--- a/password_security/tests/test_password_security_home.py
+++ b/password_security/tests/test_password_security_home.py
@@ -179,6 +179,18 @@ class TestPasswordSecurityHome(TransactionCase):
             with self.assertRaises(EndTestException):
                 self.password_security_home.web_login()
 
+    def test_web_login_log_out_if_expired(self):
+        """It should log out user if password expired"""
+        with self.mock_assets() as assets:
+            request = assets['request']
+            request.httprequest.method = 'POST'
+            user = request.env['res.users'].sudo().browse()
+            user._password_has_expired.return_value = True
+            self.password_security_home.web_login()
+
+            logout_mock = request.session.logout
+            logout_mock.assert_called_once_with(keep_db=True)
+
     def test_web_login_redirect(self):
         """ It should redirect w/ hash to reset after expiration """
         with self.mock_assets() as assets:


### PR DESCRIPTION
* Add logic to overloaded ``web_login`` action to log out users with expired passwords, preventing the password reset from being ignored
* Add unit test for new logic