### PR TITLE
[IMP] Make groups readonly in the user form if roles are selected

### DIFF
--- a/base_user_role/README.rst
+++ b/base_user_role/README.rst
@@ -65,6 +65,7 @@ Contributors
 ------------
 
 * Sébastien Alix <sebastien.alix@osiell.com>
+* Stefan Rijnhart <stefan@opener.amsterdam>
 
 Maintainer
 ----------

--- a/base_user_role/__init__.py
+++ b/base_user_role/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import models
+from .hooks import post_init_hook

--- a/base_user_role/__openerp__.py
+++ b/base_user_role/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'User roles',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'category': 'Tools',
     'author': 'ABF OSIELL, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
@@ -21,4 +21,5 @@
     ],
     'installable': True,
     'auto_install': False,
+    'post_init_hook': 'post_init_hook',
 }

--- a/base_user_role/hooks.py
+++ b/base_user_role/hooks.py
@@ -1,0 +1,8 @@
+# coding: utf-8
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import api, SUPERUSER_ID
+
+
+def post_init_hook(cr, pool):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['res.groups'].update_user_groups_view()

--- a/base_user_role/migrations/8.0.1.2.0/post-migrate.py
+++ b/base_user_role/migrations/8.0.1.2.0/post-migrate.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openerp import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['res.groups'].update_user_groups_view()

--- a/base_user_role/models/__init__.py
+++ b/base_user_role/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from . import res_groups
 from . import role
 from . import user

--- a/base_user_role/models/res_groups.py
+++ b/base_user_role/models/res_groups.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright 2014 ABF OSIELL <http://osiell.com>
+# Copyright 2017 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from lxml import etree
+
+from openerp import api, models
+
+
+class ResGroups(models.Model):
+    _inherit = 'res.groups'
+
+    @api.model
+    def update_user_groups_view(self):
+        """ Make group selection and checkboxes appear readonly when there
+        are roles on the user """
+        res = super(ResGroups, self).update_user_groups_view()
+        view = self.env.ref('base.user_groups_view')
+        xml = etree.fromstring(view.arch.encode('utf-8'))
+        for field in xml.findall('field'):
+            field.attrib['attrs'] = (
+                "{'readonly': [('role_line_ids', '!=', [])]}")
+        xml_content = etree.tostring(
+            xml, pretty_print=True, xml_declaration=True, encoding="utf-8")
+        view.write({'arch': xml_content})
+        return res


### PR DESCRIPTION
As it says in this module's README: `you can not set groups manually on a user as long as there is roles configured on it`. This was only true in the backend, where manual modifications were ignored upon saving them. This change also makes the group selection fields and checkboxes on the user form readonly when there are roles configured.

@sebalix what do you think?