### PR TITLE
[10.0][FIX] base_external_dbsource_firebird: add columns on execute_fdb

### DIFF
--- a/base_external_dbsource_firebird/__manifest__.py
+++ b/base_external_dbsource_firebird/__manifest__.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'External Database Source - Firebird',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Tools',
     'author': "Daniel Reis, "
               "LasLabs, "

--- a/base_external_dbsource_firebird/models/base_external_dbsource.py
+++ b/base_external_dbsource_firebird/models/base_external_dbsource.py
@@ -53,4 +53,5 @@ class BaseExternalDbsource(models.Model):
             cur = conn.cursor()
             cur.execute(sqlquery % sqlparams)
             rows = cur.fetchall()
-            return rows, [i[0] for i in cur.description]
+            cols = [d[0] for d in cur.description] if metadata else []
+            return rows, cols

--- a/base_external_dbsource_firebird/models/base_external_dbsource.py
+++ b/base_external_dbsource_firebird/models/base_external_dbsource.py
@@ -53,4 +53,4 @@ class BaseExternalDbsource(models.Model):
             cur = conn.cursor()
             cur.execute(sqlquery % sqlparams)
             rows = cur.fetchall()
-            return rows, []
+            return rows, [i[0] for i in cur.description]


### PR DESCRIPTION
When making a query to dbsource, we need the column names for making an INSERT. Otherwise a BAD QUERY error is triggered.