### PR TITLE
[FIX] base_manifest_extension tests

### DIFF
--- a/base_manifest_extension/tests/test_hooks.py
+++ b/base_manifest_extension/tests/test_hooks.py
@@ -61,7 +61,7 @@ class TestHooks(TransactionCase):
         result = _installed_modules(self.test_cr, self.test_rdepends)
 
         expected = self.test_rdepends[:2]
-        self.assertEqual(result, expected)
+        self.assertItemsEqual(result, expected)
 
     def test_installed_modules_empty_starting_list(self):
         """It should safely handle being passed an empty module list"""


### PR DESCRIPTION
Comparison of dependencies was failing because of items order.

Example https://travis-ci.org/OCA/server-tools/jobs/282626285#L1039-L1055

@hbrunn ping :)