### PR TITLE
[10.0][IMP] auto_backup: Convert to use base_external_system

### DIFF
--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Database Auto-Backup",
     "summary": "Backups database",
-    "version": "10.0.1.0.2",
+    "version": "10.0.2.0.0",
     "author": (
         "Yenthe Van Ginneken, "
         "Agile Business Group, "
@@ -16,10 +16,11 @@
         "Odoo Community Association (OCA)"
     ),
     'license': "AGPL-3",
-    "website": "http://www.vanroey.be/applications/bedrijfsbeheer/odoo",
+    "website": "https://github.com/OCA/server-tools",
     "category": "Tools",
     "depends": [
         'mail',
+        'connector_sftp',
     ],
     "data": [
         "data/ir_cron.xml",
@@ -29,7 +30,4 @@
     ],
     "application": True,
     "installable": True,
-    "external_dependencies": {
-        "python": ["pysftp"],
-    },
 }


### PR DESCRIPTION
WIP PR that makes `auto_backup` use the external system mechanism introduced in #993 (relevant commit ea641f7).

This will theoretically make it possible for `auto_backup` to be used on any backend that conforms to the standard Python OS-style interface (`open`, `listdir`, `mkdir`, `unlink`, etc).

It also solves #782, because `base_external_system` has support for host keys.

I still need to add migrations, and test a bunch, but this is a solid PoC I think.

- [x] #993