### PR TITLE
[FIX] don't break when an attribute node in an xpath makes the

### DIFF
--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Extended view inheritance",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "category": "Hidden/Dependency",

--- a/base_view_inheritance_extension/demo/ir_ui_view.xml
+++ b/base_view_inheritance_extension/demo/ir_ui_view.xml
@@ -11,6 +11,10 @@
                     <attribute name="context" operation="python_dict" key="default_name">'The company name'</attribute>
                     <attribute name="context" operation="python_dict" key="default_company_id">context.get('company_id', context.get('company'))</attribute>
                 </field>
+                <!-- without operations, the standard handler should be called /-->
+                <field name="parent_id" position="attributes">
+                    <attribute name="name">parent_id</attribute>
+                </field>
                 <form position="inside">
                     <notebook>
                         <page string="Phone numbers" name="phone_book" />

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -55,6 +55,9 @@ class IrUiView(models.Model):
                     yield node, handler
             return
         if spec.get('position') == 'attributes':
+            if all(not c.get('operation') for c in spec):
+                yield spec, self._get_inheritance_handler(spec)
+                return
             for child in spec:
                 node = etree.Element(spec.tag, **spec.attrib)
                 node.insert(0, child)


### PR DESCRIPTION
expression not match the node any more. Fixes #885 @sebastienbeau @StefanRijnhart 