### PR TITLE
[IMP] Use default user to define default roles to create for a new user

### DIFF
--- a/base_user_role/README.rst
+++ b/base_user_role/README.rst
@@ -33,6 +33,9 @@ To configure this module, you need to go to *Configuration / Users / Roles*,
 and create a new role. From there, you can add groups to compose your role,
 and then associate users to it.
 
+You can also define default roles for a new user by editing the user called
+"Default User".
+
 Roles:
 
 .. image:: /base_user_role/static/description/roles.png

--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'User roles',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Tools',
     'author': 'ABF OSIELL, Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -9,9 +9,26 @@ class ResUsers(models.Model):
     _inherit = 'res.users'
 
     role_line_ids = fields.One2many(
-        'res.users.role.line', 'user_id', string=u"Role lines")
+        'res.users.role.line', 'user_id', string=u"Role lines",
+        default=lambda self: self._default_role_lines())
     role_ids = fields.One2many(
-        'res.users.role', string=u"Roles", compute='_compute_role_ids')
+        'res.users.role', string=u"Roles",
+        compute='_compute_role_ids')
+
+    @api.model
+    def _default_role_lines(self):
+        default_user = self.env.ref(
+            'base.default_user', raise_if_not_found=False)
+        default_values = []
+        if default_user:
+            for role_line in default_user.role_line_ids:
+                default_values.append({
+                    'role_id': role_line.role_id.id,
+                    'date_from': role_line.date_from,
+                    'date_to': role_line.date_to,
+                    'is_enabled': role_line.is_enabled,
+                })
+        return default_values
 
     @api.multi
     @api.depends('role_line_ids.role_id')

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -15,6 +15,7 @@ class TestUserRole(TransactionCase):
         self.user_model = self.env['res.users']
         self.role_model = self.env['res.users.role']
 
+        self.default_user = self.env.ref('base.default_user')
         self.user_id = self.user_model.create(
             {'name': u"USER TEST (ROLES)", 'login': 'user_test_roles'})
 
@@ -94,3 +95,21 @@ class TestUserRole(TransactionCase):
         role1_group_ids.append(self.role1_id.group_id.id)
         role_group_ids = sorted(set(role1_group_ids))
         self.assertEqual(user_group_ids, role_group_ids)
+
+    def test_default_user_roles(self):
+        self.default_user.write({
+            'role_line_ids': [
+                (0, 0, {
+                    'role_id': self.role1_id.id,
+                }),
+                (0, 0, {
+                    'role_id': self.role2_id.id,
+                })
+            ]
+        })
+        user = self.user_model.create({
+            'name': "USER TEST (DEFAULT ROLES)",
+            'login': 'user_test_default_roles'
+        })
+        roles = self.role_model.browse([self.role1_id.id, self.role2_id.id])
+        self.assertEqual(user.role_ids, roles)

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -7,7 +7,7 @@
     <field name="name">res.users.role.form</field>
     <field name="model">res.users.role</field>
     <field name="arch" type="xml">
-        <form string="Role">
+        <form>
             <sheet>
                 <group>
                     <field name="name"/>
@@ -19,7 +19,7 @@
                     </page>
                     <page string="Users">
                         <field name="line_ids" nolabel="1">
-                            <tree editable="bottom" colors="grey: not is_enabled;">
+                            <tree editable="bottom" decoration-muted="not is_enabled">
                                 <field name="user_id"/>
                                 <field name="date_from"/>
                                 <field name="date_to"/>
@@ -37,7 +37,7 @@
     <field name="name">res.users.role.tree</field>
     <field name="model">res.users.role</field>
     <field name="arch" type="xml">
-        <tree string="Role">
+        <tree>
             <field name="name"/>
             <field name="user_ids"/>
         </tree>

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -11,7 +11,7 @@
         <xpath expr="//notebook/page[1]" position="before">
             <page string="Roles">
                 <field name="role_line_ids" nolabel="1">
-                    <tree editable="bottom" colors="grey: not is_enabled;">
+                    <tree editable="bottom" decoration-muted="not is_enabled">
                         <field name="role_id" required="1"/>
                         <field name="date_from"/>
                         <field name="date_to"/>


### PR DESCRIPTION
In Odoo v10, there is a user called "Default user". This user is used to get default groups to assign to a new user. This PR makes the same behavior for the user roles.