### PR TITLE
[FIX] setup.py mail_environment dependency on server_environment_files

### DIFF
--- a/setup/mail_environment/setup.py
+++ b/setup/mail_environment/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'depends_override': {
+            # server_environment_file does not exist as a packaged addon,
+            # as it must be provided locally
+            'server_environment_files': '',
+        },
+    }
 )


### PR DESCRIPTION
same as in 8.0 and 9.0 https://github.com/OCA/server-tools/pull/819