### PR TITLE
[IMP] base_external_system: Add create bypass

### DIFF
--- a/base_external_system/__manifest__.py
+++ b/base_external_system/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Base External System",
     "summary": "Data models allowing for connection to external systems.",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Base",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Odoo Community Association (OCA)",

--- a/base_external_system/models/external_system.py
+++ b/base_external_system/models/external_system.py
@@ -112,10 +112,11 @@ class ExternalSystem(models.Model):
     def create(self, vals):
         """Create the interface for the record and assign to ``interface``."""
         record = super(ExternalSystem, self).create(vals)
-        interface = self.env[vals['system_type']].create({
-            'system_id': record.id,
-        })
-        record.interface = interface
+        if not self.env.context.get('no_create_interface'):
+            interface = self.env[vals['system_type']].create({
+                'system_id': record.id,
+            })
+            record.interface = interface
         return record
 
     @api.multi

--- a/base_external_system/models/external_system_adapter.py
+++ b/base_external_system/models/external_system_adapter.py
@@ -79,14 +79,3 @@ class ExternalSystemAdapter(models.AbstractModel):
         record = super(ExternalSystemAdapter, context_self).create(vals)
         record.system_id.interface = record
         return record
-
-    @api.multi
-    def unlink(self):
-        if not self.env.context.get('no_interface_unlink'):
-            for record in self:
-                system = record.system_id.with_context(
-                    no_interface_unlink=True,
-                )
-                return system.unlink()
-        else:
-            return super(ExternalSystemAdapter, self).unlink()

--- a/base_external_system/models/external_system_adapter.py
+++ b/base_external_system/models/external_system_adapter.py
@@ -73,8 +73,12 @@ class ExternalSystemAdapter(models.AbstractModel):
     @api.model
     def create(self, vals):
         context_self = self.with_context(no_create_interface=True)
-        vals['system_type'] = self._name
-        return super(ExternalSystemAdapter, context_self).create(vals)
+        vals.update({
+            'system_type': self._name,
+        })
+        record = super(ExternalSystemAdapter, context_self).create(vals)
+        record.system_id.interface = record
+        return record
 
     @api.multi
     def unlink(self):

--- a/base_external_system/models/external_system_adapter.py
+++ b/base_external_system/models/external_system_adapter.py
@@ -73,4 +73,5 @@ class ExternalSystemAdapter(models.AbstractModel):
     @api.model
     def create(self, vals):
         context_self = self.with_context(no_create_interface=True)
+        vals['system_type'] = self._name
         return super(ExternalSystemAdapter, context_self).create(vals)

--- a/base_external_system/models/external_system_adapter.py
+++ b/base_external_system/models/external_system_adapter.py
@@ -75,3 +75,14 @@ class ExternalSystemAdapter(models.AbstractModel):
         context_self = self.with_context(no_create_interface=True)
         vals['system_type'] = self._name
         return super(ExternalSystemAdapter, context_self).create(vals)
+
+    @api.multi
+    def unlink(self):
+        if not self.env.context.get('no_interface_unlink'):
+            for record in self:
+                system = record.system_id.with_context(
+                    no_interface_unlink=True,
+                )
+                return system.unlink()
+        else:
+            return super(ExternalSystemAdapter, self).unlink()

--- a/base_external_system/models/external_system_adapter.py
+++ b/base_external_system/models/external_system_adapter.py
@@ -69,3 +69,8 @@ class ExternalSystemAdapter(models.AbstractModel):
             odoo.exceptions.UserError: In the event of a good connection.
         """
         raise UserError(_('The connection was a success.'))
+
+    @api.model
+    def create(self, vals):
+        context_self = self.with_context(no_create_interface=True)
+        return super(ExternalSystemAdapter, context_self).create(vals)

--- a/base_external_system/tests/test_external_system.py
+++ b/base_external_system/tests/test_external_system.py
@@ -48,6 +48,15 @@ class TestExternalSystem(Common):
             self.record.interface._name, 'external.system.os',
         )
 
+    def test_create_context_override(self):
+        """It should create and assign the interface on record create."""
+        model = self.env['external.system'].with_context(
+            no_create_interface=True,
+        )
+        self.assertFalse(
+            model.create({'name': 'Test'}).interface,
+        )
+
     def test_action_test_connection(self):
         """It should proxy to the interface connection tester."""
         with self.assertRaises(UserError):

--- a/base_external_system/tests/test_external_system.py
+++ b/base_external_system/tests/test_external_system.py
@@ -74,9 +74,3 @@ class TestExternalSystem(Common):
         self.assertTrue(interface.exists())
         self.record.unlink()
         self.assertFalse(interface.exists())
-
-    def test_unlink_delete_interface_context_override(self):
-        """It should not delete the interface when overridden in context."""
-        interface = self.record.interface
-        self.record.with_context(no_interface_unlink=True).unlink()
-        self.assertTrue(interface.exists())

--- a/base_external_system/tests/test_external_system.py
+++ b/base_external_system/tests/test_external_system.py
@@ -67,3 +67,16 @@ class TestExternalSystem(Common):
         """It should proxy to the interface connection tester."""
         with self.assertRaises(UserError):
             self.record.system_id.action_test_connection()
+
+    def test_unlink_deletes_interface(self):
+        """It should delete the interface when the system is deleted."""
+        interface = self.record.interface
+        self.assertTrue(interface.exists())
+        self.record.unlink()
+        self.assertFalse(interface.exists())
+
+    def test_unlink_delete_interface_context_override(self):
+        """It should not delete the interface when overridden in context."""
+        interface = self.record.interface
+        self.record.with_context(no_interface_unlink=True).unlink()
+        self.assertTrue(interface.exists())

--- a/base_external_system/tests/test_external_system.py
+++ b/base_external_system/tests/test_external_system.py
@@ -44,18 +44,24 @@ class TestExternalSystem(Common):
 
     def test_create_creates_and_assigns_interface(self):
         """It should create and assign the interface on record create."""
+        record = self.env['external.system'].create({
+            'name': 'Test',
+            'system_type': 'external.system.os',
+        })
         self.assertEqual(
-            self.record.interface._name, 'external.system.os',
+            record.interface._name, 'external.system.os',
         )
 
     def test_create_context_override(self):
-        """It should create and assign the interface on record create."""
+        """It should allow for interface create override with context."""
         model = self.env['external.system'].with_context(
             no_create_interface=True,
         )
-        self.assertFalse(
-            model.create({'name': 'Test'}).interface,
-        )
+        record = model.create({
+            'name': 'Test',
+            'system_type': 'external.system.os',
+        })
+        self.assertFalse(record.interface)
 
     def test_action_test_connection(self):
         """It should proxy to the interface connection tester."""


### PR DESCRIPTION
* In cases of deep inheritance, it may be required to create an adapter directly. Add an override in the create via the env context to support this.

I noticed this as working on OCA/partner-contact#500 - I had never considered the possibility of joining two adapters together like that.

This will also allow for things like connector backends to implement the system interface