### PR TITLE
[ADD] support user_ids for user specific view overrides

### DIFF
--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -8,6 +8,7 @@ Extended view inheritance
 
 This module was written to make it simple to add custom operators for view
 inheritance.
+It also adds a field `user_ids` to restrict view inheritance to certain users.
 
 Usage
 =====

--- a/base_view_inheritance_extension/demo/ir_ui_view.xml
+++ b/base_view_inheritance_extension/demo/ir_ui_view.xml
@@ -18,5 +18,15 @@
                 <xpath expr="//field[@name='child_ids']" position="move" target="//page[@name='my_new_page']" />
             </field>
         </record>
-    </data>
+        <record id="view_partner_form_demo" model="ir.ui.view">
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
+            <field name="user_ids" eval="[(4, ref('base.user_demo'))]" />
+            <field name="arch" type="xml">
+                <sheet position="inside">
+                    <div>I am a private form for the demo user</div>
+                </sheet>
+            </field>
+        </record>
+     </data>
 </openerp>

--- a/base_view_inheritance_extension/models/__init__.py
+++ b/base_view_inheritance_extension/models/__init__.py
@@ -2,3 +2,4 @@
 # © 2016 Therp BV <http://therp.nl>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from . import ir_ui_view
+from . import res_users

--- a/base_view_inheritance_extension/models/res_users.py
+++ b/base_view_inheritance_extension/models/res_users.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openerp import api, models
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    @api.multi
+    def unlink(self):
+        """
+        Finds any views assigned specifically to this user and deletes them.
+        """
+        self.env['ir.ui.view'].sudo().with_context(
+            active_test=False,
+        ).search([
+            ('user_ids', 'in', self.ids)
+            ]).with_context(
+                active_test=True).filtered(
+                    lambda x: not x.user_ids - self,
+        ).unlink()
+        return super(ResUsers, self).unlink()
+
+    @api.multi
+    def write(self, vals):
+        """
+        If a user has been set as inactive then, any views that are assigned
+        to them specifically as set as inactive as well.
+        """
+        active = vals.get('active')
+        if active is not None:
+            self.env['ir.ui.view'].sudo().with_context(
+                active_test=False,
+            ).search([
+                ('user_ids', 'in', self.ids)]).with_context(
+                    active_test=True).filtered(
+                        lambda x: not x.user_ids - self,
+            ).write({'active': active})
+        return super(ResUsers, self).write(vals)

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -111,3 +111,17 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             button_node.attrib['states'],
             'draft,valid,paid'
         )
+
+    def test_user_ids(self):
+        view_id = self.env.ref('base.view_partner_form').id
+        demo_marker = 'I am a private form for the demo user'
+        fields_view_get = self.env['res.partner'].fields_view_get(
+            view_id=view_id
+        )
+        self.assertNotIn(demo_marker, fields_view_get['arch'])
+        fields_view_get = self.env['res.partner'].sudo(
+            self.env.ref('base.user_demo')
+        ).fields_view_get(
+            view_id=view_id
+        )
+        self.assertIn(demo_marker, fields_view_get['arch'])

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -125,3 +125,70 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             view_id=view_id
         )
         self.assertIn(demo_marker, fields_view_get['arch'])
+
+    def test_view_delete_deactivate(self):
+        """
+        This function tests that the views are deleted and deactivated when
+        and if the single user they have been assigned to is deleted or
+        deactivated accordingly.
+        """
+        model_res_users = self.env['res.users']
+        model_ir_ui_view = self.env['ir.ui.view']
+        user1 = model_res_users.create({'login': 'user1', 'name': 'user1'})
+        user2 = model_res_users.create({'login': 'user2', 'name': 'user2'})
+        user3 = model_res_users.create({'login': 'user3', 'name': 'user3'})
+        user4 = model_res_users.create({
+            'login': 'user4',
+            'name': 'user4',
+            'active': False,
+        })
+        view1 = self.env.ref('base.view_partner_form')
+        view2 = model_ir_ui_view.create({
+            'name': 'view2',
+            'model': 'res.partner',
+            'inherit_id': view1.id,
+            'arch': '<div></div>',
+            'user_ids': [(6, False, user2.ids)]
+        })
+        view3 = model_ir_ui_view.create({
+            'name': 'view3',
+            'model': 'res.partner',
+            'inherit_id': view1.id,
+            'arch': '<div></div>',
+            'user_ids': [(6, False, user2.ids + user1.ids + user3.ids)]
+        })
+        view4 = model_ir_ui_view.create({
+            'name': 'view4',
+            'model': 'res.partner',
+            'inherit_id': view1.id,
+            'arch': '<div></div>',
+        })
+        view5 = model_ir_ui_view.create({
+            'name': 'view5',
+            'model': 'res.partner',
+            'inherit_id': view1.id,
+            'arch': '<div></div>',
+            'user_ids': [(6, False, user3.ids + user4.ids)],
+        })
+        # delete user2, make sure that only view2 is deleted
+        self.assertTrue(view1.exists())
+        self.assertTrue(view2.exists())
+        self.assertTrue(view3.exists())
+        self.assertTrue(view4.exists())
+        self.assertTrue(view5.exists())
+        user2.unlink()
+        self.assertTrue(view1.exists())
+        self.assertFalse(view2.exists())
+        self.assertTrue(view3.exists())
+        self.assertTrue(view4.exists())
+        self.assertTrue(view5.exists())
+        # deactivate user3, make sure that only view5 is deactivated
+        self.assertTrue(view1.active)
+        self.assertTrue(view3.active)
+        self.assertTrue(view4.active)
+        self.assertTrue(view5.active)
+        user3.write({'active': False})
+        self.assertTrue(view1.active)
+        self.assertTrue(view3.active)
+        self.assertTrue(view4.active)
+        self.assertFalse(view5.active)


### PR DESCRIPTION
this adds the analogue to `groups_id` for users on views. Will be used in https://github.com/OCA/web/pull/787