### PR TITLE
[FIX] As an ERP manager, allow to reset users' passwords

### DIFF
--- a/password_security/__openerp__.py
+++ b/password_security/__openerp__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/security/res_users_pass_history.xml
+++ b/password_security/security/res_users_pass_history.xml
@@ -17,6 +17,13 @@
         ]</field>
     </record>
 
+    <record id="res_users_pass_history_rule_manager" model="ir.rule">
+        <field name="name">Res Users Pass History Access/Managers</field>
+        <field name="model_id" ref="password_security.model_res_users_pass_history"/>
+        <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+    </record>
+
 </data>
 </openerp>
 

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -13,6 +13,16 @@ class TestResUsers(TransactionCase):
 
     def setUp(self):
         super(TestResUsers, self).setUp()
+        self.main_comp = self.env.ref('base.main_company')
+        # Modify users as privileged, but non-root user
+        privileged_user = self.env['res.users'].create({
+            'name': 'Privileged User',
+            'login': 'privileged_user@example.com',
+            'company_id': self.main_comp.id,
+            'groups_id': [(4, self.env.ref('base.group_erp_manager').id)],
+        })
+        privileged_user.email = privileged_user.login
+        self.env = self.env(user=privileged_user)
         self.login = 'foslabs@example.com'
         self.partner_vals = {
             'name': 'Partner',
@@ -20,7 +30,6 @@ class TestResUsers(TransactionCase):
             'email': self.login,
         }
         self.password = 'asdQWE123$%^'
-        self.main_comp = self.env.ref('base.main_company')
         self.vals = {
             'name': 'User',
             'login': self.login,


### PR DESCRIPTION
As only SUPERUSER_ID can work with password history records for other users than the own user, users in the Settings group can no longer reset other users' passwords when `password_security` is installed. This fix makes it possible for them again to do so.