### PR TITLE
[9.0] base_view_inheritance_extension: Implement target_position for position="move"

### DIFF
--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -35,8 +35,14 @@ Move an element in the view
 
     <xpath expr="$xpath" position="move" target="$targetxpath" />
 
-This can also be used to wrap some element into another, create the target
-element first, then move the node youwant to wrap there.
+Availables values for position attribute:
+
+* inside (default if omited)
+* after
+* before
+
+This can also be used to wrap some element into another, create the new target
+element first, then move the element you want inside the new element.
 
 Add to values in a list (states for example)
 --------------------------------------------
@@ -60,7 +66,6 @@ Known issues / Roadmap
 ======================
 
 * add ``<attribute operation="json_dict" key="$key">$value</attribute>``
-* support ``<xpath expr="$xpath" position="move" target="xpath" target_position="position" />``
 * support an ``eval`` attribute for our new node types
 
 Bug Tracker

--- a/base_view_inheritance_extension/__openerp__.py
+++ b/base_view_inheritance_extension/__openerp__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Extended view inheritance",
-    "version": "9.0.1.1.0",
+    "version": "9.0.1.2.0",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "category": "Hidden/Dependency",

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -2,7 +2,7 @@
 # © 2016 Therp BV <http://therp.nl>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from lxml import etree
-from openerp import api, models, tools
+from openerp import api, models, tools, _
 
 
 class UnquoteObject(str):
@@ -120,7 +120,18 @@ class IrUiView(models.Model):
         target_node = self.locate_node(
             source, etree.Element(specs.tag, expr=specs.get('target'))
         )
-        target_node.append(node)
+        
+        target_position = specs.get('target_position') or 'inside'
+        
+        if target_position == 'after':
+            target_node.addnext(node)
+        elif target_position == 'before':
+            target_node.addprevious(node)
+        elif target_position == 'inside':
+            target_node.append(node)
+        else:
+            self.raise_view_error(_("Invalid target_position attribute: '%s'") % target_position, inherit_id, context=self.env.context)
+
         return source
 
     @api.model

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -120,9 +120,9 @@ class IrUiView(models.Model):
         target_node = self.locate_node(
             source, etree.Element(specs.tag, expr=specs.get('target'))
         )
-        
+
         target_position = specs.get('target_position') or 'inside'
-        
+
         if target_position == 'after':
             target_node.addnext(node)
         elif target_position == 'before':
@@ -130,7 +130,11 @@ class IrUiView(models.Model):
         elif target_position == 'inside':
             target_node.append(node)
         else:
-            self.raise_view_error(_("Invalid target_position attribute: '%s'") % target_position, inherit_id, context=self.env.context)
+            self.raise_view_error(
+                _("Invalid target_position attribute: '%s'") % target_position,
+                inherit_id,
+                context=self.env.context
+            )
 
         return source
 


### PR DESCRIPTION
By default, inheritance with spec **position="move"** append the node inside the target. 
The spec **target_position** let you choose what you want to do : 
- **inside**: append the node inside the target
- **before**: append the node before target
- **after**: append the node after target

By default, if no value is provide we use the standard behaviour **inside**