### PR TITLE
[10.0][ADD] dead mans switch client filters

### DIFF
--- a/dead_mans_switch_client/README.rst
+++ b/dead_mans_switch_client/README.rst
@@ -7,7 +7,8 @@ Dead man's switch (client)
 
 This module is the client part of `dead_mans_switch_server`. It is responsible
 of sending the server status updates, which in turn takes action if those
-updates don't come in time.
+updates don't come in time. Using `dead_mans_switch_server` is not mandatory;
+you can use this module with any other similar service, eg. https://healthchecks.io.
 
 Configuration
 =============
@@ -26,7 +27,10 @@ works if the ``bus`` module is installed and longpolling configured correctly.
 Usage
 =====
 
-This module doesn't have any visible effect on the client.
+This module adds only one visible field for ``ir.filters``: "Is a Dead Man's Switch filter".
+If you create a filter with "Is a Dead Man's Switch filter" checked, the cron routine
+expects this filter never to yield any records. If it does, the Dead Man's Switch URL
+will not be called. For example you might want to monitor failed outgoing emails or stuck queue jobs.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
     :alt: Try me on Runbot

--- a/dead_mans_switch_client/__manifest__.py
+++ b/dead_mans_switch_client/__manifest__.py
@@ -4,8 +4,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Dead man's switch (client)",
-    "version": "10.0.1.0.0",
-    "author": "Therp BV, Odoo Community Association (OCA)",
+    "version": "10.0.1.1.0",
+    "author": "Therp BV, Avoin.Systems, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Monitoring",
     "summary": "Be notified when customers' Odoo instances go down",
@@ -15,6 +15,7 @@
     "data": [
         "data/ir_actions.xml",
         "data/ir_cron.xml",
+        "views/ir_filters_views.xml",
     ],
     "demo": [
         "demo/dead_mans_switch_client_demo.yml",

--- a/dead_mans_switch_client/models/__init__.py
+++ b/dead_mans_switch_client/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2015 Therp BV <http://therp.nl>
+# © 2017 Avoin.Systems - Miku Laitinen
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import dead_mans_switch_client
+from . import ir_filters

--- a/dead_mans_switch_client/models/ir_filters.py
+++ b/dead_mans_switch_client/models/ir_filters.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# © 2017 Avoin.Systems - Miku Laitinen
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models, fields
+
+
+class IrFilters(models.Model):
+
+    _inherit = 'ir.filters'
+
+    is_dead_mans_switch_filter = fields.Boolean(
+        "Is a Dead Man's Switch Filter",
+        help="Checking this field will include this filter in the dead "
+             "man's switch routine. If this filter returns any rows at "
+             "any time, the dead man's switch will go off.",
+    )

--- a/dead_mans_switch_client/tests/test_dead_mans_switch_client.py
+++ b/dead_mans_switch_client/tests/test_dead_mans_switch_client.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.tools import mute_logger
 from odoo.tests.common import TransactionCase
+from ..models.dead_mans_switch_client import DMSFilterException
 
 
 class TestDeadMansSwitchClient(TransactionCase):
@@ -20,4 +21,29 @@ class TestDeadMansSwitchClient(TransactionCase):
         self.env['ir.config_parameter'].set_param(
             'dead_mans_switch_client.url', 'fake_url')
         with self.assertRaises(ValueError):
+            self.env['dead.mans.switch.client'].alive()
+
+    def test_dead_mans_switch_client_filters(self):
+
+        # Seriosly, looking for failed outgoing emails would be a better
+        # example, but I don't want to add a module dependency only because
+        # of a single unit test.
+
+        # We should find Roger Scott from the demo data
+        self.env['ir.filters'].create({
+            'name': 'Roger',
+            'model_id': 'res.partner',
+            'domain': "[('name', '=', 'Roger Scott')]",
+            'is_dead_mans_switch_filter': True,
+        })
+
+        # We shouldn't find Nimrod Soames from the demo data
+        self.env['ir.filters'].create({
+            'name': 'Nimmy',
+            'model_id': 'res.partner',
+            'domain': "[('name', '=', 'Nimrod Soames')]",
+            'is_dead_mans_switch_filter': True,
+        })
+
+        with self.assertRaises(DMSFilterException):
             self.env['dead.mans.switch.client'].alive()

--- a/dead_mans_switch_client/views/ir_filters_views.xml
+++ b/dead_mans_switch_client/views/ir_filters_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- User-defined Filters form -->
+    <record id="view_ir_filters_form_dms" model="ir.ui.view">
+        <field name="name">ir.filters.form.dms</field>
+        <field name="model">ir.filters</field>
+        <field name="inherit_id" ref="base.ir_filters_view_form"/>
+        <field name="arch" type="xml">
+            <field name="active" position="after">
+                <field name="is_dead_mans_switch_filter"/>
+            </field>
+        </field>
+    </record>
+
+    <!-- User-defined Filters tree -->
+    <record id="view_ir_filters_tree_dms" model="ir.ui.view">
+        <field name="name">ir.filters.tree.dms</field>
+        <field name="model">ir.filters</field>
+        <field name="inherit_id" ref="base.ir_filters_view_tree"/>
+        <field name="arch" type="xml">
+            <field name="sort" position="after">
+                <field name="is_dead_mans_switch_filter"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
[FEAT] 10.0 dead_mans_switch_client: Dead Man's Switch filter check

You can now add filters that should always yield zero results. If they do yield results, the dead man's switch URL will not be called and the system is considered to be in an exceptional state.