### PR TITLE
corrects AttributeError: 'HttpRequest' object has no attribute 'http'

### DIFF
--- a/auth_session_timeout/__manifest__.py
+++ b/auth_session_timeout/__manifest__.py
@@ -14,7 +14,7 @@
     'maintainer': 'Odoo Community Association (OCA)',
     'website': "http://acsone.eu",
     'category': 'Tools',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
     'data': [
         'data/ir_config_parameter_data.xml'

--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -90,7 +90,7 @@ class ResUsers(models.Model):
         # Else, conditionally update session modified and access times
         ignored_urls = self._auth_timeout_get_ignored_urls()
 
-        if http.request.http.request.path not in ignored_urls:
+        if http.request.httprequest.path not in ignored_urls:
             if 'path' not in locals():
                 path = http.root.session_store.get_session_filename(
                     session.sid,


### PR DESCRIPTION
2017-11-25 21:27:58,259 1 INFO test odoo.addons.base.ir.ir_http: Generating routing map
2017-11-25 21:27:58,306 1 INFO test odoo.addons.base.ir.ir_http: Exception during request Authentication.
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/odoo/addons/base/ir/ir_http.py", line 103, in _authenticate
    request.session.check_security()
  File "/usr/lib/python2.7/dist-packages/odoo/http.py", line 1058, in check_security
    security.check(self.db, self.uid, self.password)
  File "/usr/lib/python2.7/dist-packages/odoo/service/security.py", line 13, in check
    return res_users.check(db, uid, passwd)
  File "/mnt/extra-addons/auth_session_timeout/models/res_users.py", line 108, in check
    http.request.env.user._auth_timeout_check()
  File "/mnt/extra-addons/auth_session_timeout/models/res_users.py", line 93, in _auth_timeout_check
    if http.request.http.request.path not in ignored_urls:
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: 'HttpRequest' object has no attribute 'http'
