### PR TITLE
[FIX] Underscore is a special character

### DIFF
--- a/password_security/__openerp__.py
+++ b/password_security/__openerp__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.1.1',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -78,7 +78,7 @@ class ResUsers(models.Model):
         if company_id.password_numeric:
             password_regex.append(r'(?=.*?\d)')
         if company_id.password_special:
-            password_regex.append(r'(?=.*?\W)')
+            password_regex.append(r'(?=.*?[\W_])')
         password_regex.append('.{%d,}$' % company_id.password_length)
         if not re.search(''.join(password_regex), password):
             raise PassError(_(self.password_match_message()))

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -155,3 +155,8 @@ class TestResUsers(TransactionCase):
         self.assertEqual(
             True, rec_id._validate_pass_reset(),
         )
+
+    def test_underscore_is_special_character(self):
+        self.assertTrue(self.main_comp.password_special)
+        rec_id = self._new_record()
+        rec_id.check_password('asdQWE12345_3')


### PR DESCRIPTION
For legacy reasons, \W does not match the underscore (see https://stackoverflow.com/questions/35942067/why-cant-the-underscore-be-matched-by-w-in-python). I would argue that the underscore is a special character and should be interpreted as such by this module.