### PR TITLE
[8.0][sql_export] Allow to use many2one and many2many fields for query variables

### DIFF
--- a/sql_export/wizard/wizard_file.py
+++ b/sql_export/wizard/wizard_file.py
@@ -79,7 +79,12 @@ class SqlFileWizard(models.TransientModel):
         date = today_tz.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
         if sql_export.field_ids:
             for field in sql_export.field_ids:
-                variable_dict[field.name] = self[field.name]
+                if field.ttype == 'many2one':
+                    variable_dict[field.name] = self[field.name].id
+                elif field.ttype == 'many2many':
+                    variable_dict[field.name] = tuple(self[field.name].ids)
+                else:
+                    variable_dict[field.name] = self[field.name]
         if "%(company_id)s" in sql_export.query:
             variable_dict['company_id'] = self.env.user.company_id.id
         if "%(user_id)s" in sql_export.query:


### PR DESCRIPTION
It is already possible to use variables into the sql queries, using simple fields (integer, float, char...).
I just improve a little to make possible the use of many2one and many2many.

@bguillot @aheficent 