### PR TITLE
[FIX] password_security: Default last write date

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -21,6 +21,7 @@ class ResUsers(models.Model):
 
     password_write_date = fields.Datetime(
         'Last password update',
+        default=fields.Datetime.now,
         readonly=True,
     )
     password_history_ids = fields.One2many(


### PR DESCRIPTION
* Add a default `password_write_date` to circumvent need for immediate password reset, fixing #1083