### PR TITLE
[10.0][FIX][IMP] base_kanban_stage: Default stage and tests

### DIFF
--- a/base_kanban_stage/__manifest__.py
+++ b/base_kanban_stage/__manifest__.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 {
     'name': 'Kanban - Stage Support',
     'summary': 'Provides stage model and abstract logic for inheritance',
-    'version': '10.0.1.1.1',
-    'author': "LasLabs, Odoo Community Association (OCA)",
+    'version': '10.0.1.2.1',
+    'author': 'LasLabs, Odoo Community Association (OCA)',
     'category': 'base',
     'depends': [
         'base',
     ],
-    'website': 'https://laslabs.com',
+    'website': 'https://github.com/OCA/server-tools',
     'license': 'LGPL-3',
     'data': [
         'security/ir.model.access.csv',

--- a/base_kanban_stage/models/base_kanban_abstract.py
+++ b/base_kanban_stage/models/base_kanban_abstract.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
@@ -19,6 +19,13 @@ class BaseKanbanAbstract(models.AbstractModel):
     _group_by_full = {
         'stage_id': lambda s, *a, **k: s._read_group_stage_ids(*a, **k),
     }
+
+    @api.model
+    def _default_stage_id(self):
+        return self.env['base.kanban.stage'].search(
+            [('res_model_id.model', '=', self._name)],
+            limit=1,
+        )
 
     kanban_sequence = fields.Integer(
         default=10,
@@ -100,10 +107,6 @@ class BaseKanbanAbstract(models.AbstractModel):
              '* Special Handling: Blocked in some way (e.g. must be handled by'
              ' a specific user)\n'
     )
-
-    @api.model
-    def _default_stage_id(self):
-        return self.env['base.kanban.stage']
 
     @api.multi
     def _read_group_stage_ids(self, stages, domain, order):

--- a/base_kanban_stage/tests/test_base_kanban_abstract.py
+++ b/base_kanban_stage/tests/test_base_kanban_abstract.py
@@ -1,34 +1,21 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo import models
-from odoo.tests.common import SavepointCase
+from odoo import api, models
+from odoo.tests.common import TransactionCase
 
 
-class BaseKanbanAbstractTester(models.TransientModel):
+class BaseKanbanAbstractTester(models.Model):
     _name = 'base.kanban.abstract.tester'
     _inherit = 'base.kanban.abstract'
 
 
-class TestBaseKanbanAbstract(SavepointCase):
+class TestBaseKanbanAbstract(TransactionCase):
 
-    @classmethod
-    def _init_test_model(cls, model_cls):
-        """ It builds a model from model_cls in order to test abstract models.
-
-        Note that this does not actually create a table in the database, so
-        there may be some unidentified edge cases.
-
-        Args:
-            model_cls (openerp.models.BaseModel): Class of model to initialize
-        Returns:
-            model_cls: Instance
-        """
-        registry = cls.env.registry
-        cr = cls.env.cr
-        inst = model_cls._build_model(registry, cr)
-        model = cls.env[model_cls._name].with_context(todo=[])
+    def _init_test_model(self, model_cls):
+        model_cls._build_model(self.registry, self.cr)
+        model = self.env[model_cls._name].with_context(todo=[])
         model._prepare_setup()
         model._setup_base(partial=False)
         model._setup_fields(partial=False)
@@ -36,50 +23,64 @@ class TestBaseKanbanAbstract(SavepointCase):
         model._auto_init()
         model.init()
         model._auto_end()
-        cls.test_model_record = cls.env['ir.model'].search([
-            ('name', '=', model._name),
-        ])
-        return inst
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestBaseKanbanAbstract, cls).setUpClass()
-        cls.env.registry.enter_test_mode()
-        cls._init_test_model(BaseKanbanAbstractTester)
-        cls.test_model = cls.env[BaseKanbanAbstractTester._name]
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.env.registry.leave_test_mode()
-        super(TestBaseKanbanAbstract, cls).tearDownClass()
+        return model
 
     def setUp(self):
         super(TestBaseKanbanAbstract, self).setUp()
-        test_stage_1 = self.env['base.kanban.stage'].create({
-            'name': 'Test Stage 1',
-            'res_model_id': self.test_model_record.id,
+
+        self.registry.enter_test_mode()
+        self.old_cursor = self.cr
+        self.cr = self.registry.cursor()
+        self.env = api.Environment(self.cr, self.uid, {})
+        self.test_model = self._init_test_model(BaseKanbanAbstractTester)
+
+        test_model_record = self.env['ir.model'].search([
+            ('name', '=', self.test_model._name),
+        ])
+        self.test_stage = self.env['base.kanban.stage'].create({
+            'name': 'Test Stage',
+            'res_model_id': test_model_record.id,
+            'sequence': 2,
         })
-        test_stage_2 = self.env['base.kanban.stage'].create({
+        self.test_stage_2 = self.env['base.kanban.stage'].create({
             'name': 'Test Stage 2',
-            'res_model_id': self.test_model_record.id,
-            'fold': True,
+            'res_model_id': test_model_record.id,
+            'sequence': 1,
         })
 
-        self.id_1 = test_stage_1.id
-        self.id_2 = test_stage_2.id
+    def tearDown(self):
+        self.registry.leave_test_mode()
+        self.registry[self.test_model._name]._abstract = True
+        self.registry[self.test_model._name]._auto = False
+        self.cr = self.old_cursor
+        self.env = api.Environment(self.cr, self.uid, {})
+
+        super(TestBaseKanbanAbstract, self).tearDown()
+
+    def test_default_stage_id_no_stages(self):
+        """It should return empty recordset when model has no stages"""
+        self.env['base.kanban.stage'].search([
+            ('res_model_id.model', '=', self.test_model._name),
+        ]).unlink()
+        result = self.test_model._default_stage_id()
+
+        self.assertEqual(result, self.env['base.kanban.stage'])
+
+    def test_default_stage_id_available_stages(self):
+        """It should return lowest sequence stage when model has stages"""
+        result = self.test_model._default_stage_id()
+
+        self.assertEqual(result, self.test_stage_2)
 
     def test_read_group_stage_ids(self):
-        """It should return the correct recordset. """
-        self.assertEqual(
-            self.test_model._read_group_stage_ids(
-                self.env['base.kanban.stage'], [], 'id',
-            ),
-            self.env['base.kanban.stage'].search([], order='id'),
+        """It should return all corresponding stages in requested sort order"""
+        result = self.test_model._read_group_stage_ids(
+            self.env['base.kanban.stage'], None, 'id'
         )
 
-    def test_default_stage_id(self):
-        """ It should return an empty RecordSet """
-        self.assertEqual(
-            self.env['base.kanban.abstract']._default_stage_id(),
-            self.env['base.kanban.stage']
+        expected = self.env['base.kanban.stage'].search(
+            [('res_model_id.model', '=', self.test_model._name)],
+            order='id',
         )
+        self.assertEqual(result[0], expected[0])
+        self.assertEqual(result[1], expected[1])


### PR DESCRIPTION
* Add default ``stage_id`` logic that returns lowest sequence stage associated with inheriting model and update unit tests accordingly
* Improve ``_read_group_stage_ids`` unit test
* Implement latest abstract model testing strategy