### PR TITLE
[FIX] import for safe_eval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - python-lxml # because pip installation is slow
       - unixodbc-dev
       - python-mysqldb
+      - postfix # some tests want a local mail server
 
 env:
   global:

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -3,6 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from lxml import etree
 from odoo import api, models, tools
+from odoo.tools.safe_eval import safe_eval
 
 
 class UnquoteObject(str):
@@ -103,7 +104,7 @@ class IrUiView(models.Model):
         </$node>"""
         node = self.locate_node(source, specs)
         for attribute_node in specs:
-            python_dict = tools.safe_eval(
+            python_dict = safe_eval(
                 node.get(attribute_node.get('name')) or '{}',
                 UnquoteEvalObjectContext(),
                 nocopy=True

--- a/dead_mans_switch_client/tests/test_dead_mans_switch_client.py
+++ b/dead_mans_switch_client/tests/test_dead_mans_switch_client.py
@@ -2,6 +2,7 @@
 # © 2015 Therp BV <http://therp.nl>
 # © 2017 Avoin.Systems - Miku Laitinen
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tools import mute_logger
 from odoo.tests.common import TransactionCase
 
 
@@ -10,7 +11,11 @@ class TestDeadMansSwitchClient(TransactionCase):
         # test unconfigured case
         self.env['ir.config_parameter'].search([
             ('key', '=', 'dead_mans_switch_client.url')]).unlink()
-        self.env['dead.mans.switch.client'].alive()
+        with mute_logger(
+                'odoo.addons.dead_mans_switch_client.models'
+                '.dead_mans_switch_client'
+        ):
+            self.env['dead.mans.switch.client'].alive()
         # test configured case
         self.env['ir.config_parameter'].set_param(
             'dead_mans_switch_client.url', 'fake_url')


### PR DESCRIPTION
this works during tests because there `tools.safe_eval` is the function, but to have this work after Odoo has been fiddling with the imports (and during tests), we must use the canonical way to import this