### PR TITLE
[9.0][FIX] Auth_totp : ensure no special chars are passed to totp.provisioning_uri

### DIFF
--- a/auth_totp/__openerp__.py
+++ b/auth_totp/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'MFA Support',
     'summary': 'Allows users to enable MFA and add optional trusted devices',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Extra Tools',
     'website': 'https://laslabs.com/',
     'author': 'LasLabs, Odoo Community Association (OCA)',

--- a/auth_totp/wizards/res_users_authenticator_create.py
+++ b/auth_totp/wizards/res_users_authenticator_create.py
@@ -74,7 +74,7 @@ class ResUsersAuthenticatorCreate(models.TransientModel):
 
             totp = pyotp.TOTP(record.secret_key)
             provisioning_uri = totp.provisioning_uri(
-                record.user_id.display_name,
+                record.user_id.display_name.encode('utf-8'),
                 issuer_name=record.user_id.company_id.display_name,
             )
             provisioning_uri = urllib.quote(provisioning_uri)


### PR DESCRIPTION
When a user name has special character, opening the wizard will fail with such an error :
```
tools/auth_totp/wizards/res_users_authenticator_create.py", line 78, in _compute_qr_code_tag
    issuer_name=record.user_id.company_id.display_name,
  File "/usr/local/lib/python2.7/dist-packages/pyotp/totp.py", line 88, in provisioning_uri
    digits=self.digits, period=self.interval)
  File "/usr/local/lib/python2.7/dist-packages/pyotp/utils.py", line 61, in build_uri
    label = quote(name)
  File "/usr/lib/python2.7/urllib.py", line 1294, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xee'
```
As described here : https://github.com/pyotp/pyotp/issues/21

With this fix, any special character will be escaped and the QR code will be generated.