### PR TITLE
[10.0][MIG] base_cron_exclusion

### DIFF
--- a/base_cron_exclusion/README.rst
+++ b/base_cron_exclusion/README.rst
@@ -1,0 +1,64 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===================
+Base Cron Exclusion
+===================
+
+This module extends the functionality of scheduled actions to allow you to
+select the ones that should not run simultaneously.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to *Settings > Technical > Automation > Scheduled Actions*.
+#. In the form view go to the tab *Mutually Exclusive Scheduled Actions*.
+#. Fill it with the actions that should be blocked while running the action
+   you are editing. Note that this is mutual and the selected actions will
+   block the initial action when running.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/149/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_cron_exclusion/README.rst
+++ b/base_cron_exclusion/README.rst
@@ -22,7 +22,7 @@ To use this module, you need to:
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/149/9.0
+   :target: https://runbot.odoo-community.org/runbot/149/10.0
 
 Bug Tracker
 ===========

--- a/base_cron_exclusion/__init__.py
+++ b/base_cron_exclusion/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/base_cron_exclusion/__manifest__.py
+++ b/base_cron_exclusion/__manifest__.py
@@ -7,7 +7,7 @@
     "name": "Base Cron Exclusion",
     "summary": "Allow you to select scheduled actions that should not run "
                "simultaneously.",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "author": "Eficent, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-tools",
     "category": "Tools",

--- a/base_cron_exclusion/__openerp__.py
+++ b/base_cron_exclusion/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Base Cron Exclusion",
+    "summary": "Allow you to select scheduled actions that should not run "
+               "simultaneously.",
+    "version": "9.0.1.0.0",
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/server-tools",
+    "category": "Tools",
+    "depends": [
+        "base",
+    ],
+    "data": [
+        "views/ir_cron_view.xml",
+    ],
+    "license": "AGPL-3",
+    'installable': True,
+}

--- a/base_cron_exclusion/models/__init__.py
+++ b/base_cron_exclusion/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import ir_cron

--- a/base_cron_exclusion/models/ir_cron.py
+++ b/base_cron_exclusion/models/ir_cron.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from openerp import sql_db
+from openerp import api, fields, models, _
+from openerp.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class IrCron(models.Model):
+    _inherit = "ir.cron"
+
+    @api.one
+    @api.constrains('mutually_exclusive_cron_ids')
+    def _check_auto_exclusion(self):
+        if self in self.mutually_exclusive_cron_ids:
+            raise ValidationError(_(
+                "You can not mutually exclude a scheduled actions with "
+                "itself."))
+
+    mutually_exclusive_cron_ids = fields.Many2many(
+        comodel_name="ir.cron", relation="ir_cron_exclusion",
+        column1="ir_cron1_id", column2="ir_cron2_id",
+        string="Mutually Exclusive Scheduled Actions")
+
+    @staticmethod
+    def _lock_mutually_exclusive_cron(db, job_id):
+        lock_cr = db.cursor()
+        lock_cr.execute("""
+            WITH Q1 AS (SELECT ir_cron2_id as cron_id FROM ir_cron_exclusion
+                            WHERE ir_cron1_id=%s
+                        UNION ALL
+                        SELECT ir_cron1_id as cron_id FROM ir_cron_exclusion
+                            WHERE ir_cron2_id=%s)
+                SELECT * FROM Q1
+                GROUP BY cron_id;""", (job_id, job_id))
+        locked_ids = tuple([row[0] for row in lock_cr.fetchall()])
+        if locked_ids:
+            lock_cr.execute("""SELECT *
+                               FROM ir_cron
+                               WHERE numbercall != 0
+                                  AND active
+                                  AND id IN %s
+                               FOR UPDATE NOWAIT""",
+                            (locked_ids,), log_exceptions=False)
+            lock_cr.fetchall()
+        return lock_cr
+
+    def _process_job(self, job_cr, job, cron_cr):
+        db = sql_db.db_connect(self.pool._db.dbname)
+        locked_crons = self._lock_mutually_exclusive_cron(db, job['id'])
+        try:
+            res = super(IrCron, self)._process_job(job_cr, job, cron_cr)
+        finally:
+            locked_crons.close()
+            _logger.debug("released blocks for cron job %s" % job['name'])
+        return res

--- a/base_cron_exclusion/models/ir_cron.py
+++ b/base_cron_exclusion/models/ir_cron.py
@@ -5,9 +5,9 @@
 
 import logging
 
-from openerp import sql_db
-from openerp import api, fields, models, _
-from openerp.exceptions import ValidationError
+from odoo import sql_db
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -51,11 +51,12 @@ class IrCron(models.Model):
             lock_cr.fetchall()
         return lock_cr
 
-    def _process_job(self, job_cr, job, cron_cr):
-        db = sql_db.db_connect(self.pool._db.dbname)
-        locked_crons = self._lock_mutually_exclusive_cron(db, job['id'])
+    @classmethod
+    def _process_job(cls, job_cr, job, cron_cr):
+        db = sql_db.db_connect(cls.pool._db.dbname)
+        locked_crons = cls._lock_mutually_exclusive_cron(db, job['id'])
         try:
-            res = super(IrCron, self)._process_job(job_cr, job, cron_cr)
+            res = super(IrCron, cls)._process_job(job_cr, job, cron_cr)
         finally:
             locked_crons.close()
             _logger.debug("released blocks for cron job %s" % job['name'])

--- a/base_cron_exclusion/views/ir_cron_view.xml
+++ b/base_cron_exclusion/views/ir_cron_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
+
+<odoo>
+
+    <record id="ir_cron_view" model="ir.ui.view">
+        <field name="name">ir.cron.form - base_cron_exclusion</field>
+        <field name="model">ir.cron</field>
+        <field name="inherit_id" ref="base.ir_cron_view"/>
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page name="exclusive_cron" groups="base.group_no_one"
+                      string="Mutually Exclusive Scheduled Actions">
+                    <field name="mutually_exclusive_cron_ids"/>
+                </page>
+            </notebook>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Base Cron Exclusion
===================

This module extends the functionality of scheduled actions to allow you to
select the ones that should not run simultaneously.

Usage
=====

To use this module, you need to:

#. Go to *Settings > Technical > Automation > Scheduled Actions*.
#. In the form view go to the tab *Mutually Exclusive Scheduled Actions*.
#. Fill it with the actions that should be blocked while running the action
   you are editing. Note that this is mutual and the selected actions will
   block the initial action when running.


-------

Migration based on https://github.com/OCA/server-tools/pull/999