### PR TITLE
[9.0][FIX] password_security: No login success with no params

### DIFF
--- a/password_security/__openerp__.py
+++ b/password_security/__openerp__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '9.0.1.2.2',
+    'version': '9.0.1.2.3',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -36,7 +36,7 @@ class PasswordSecurityHome(AuthSignupHome):
     def web_login(self, *args, **kw):
         ensure_db()
         response = super(PasswordSecurityHome, self).web_login(*args, **kw)
-        login_success = request.params.get('login_success', True)
+        login_success = request.params.get('login_success', False)
         if not request.httprequest.method == 'POST' or not login_success:
             return response
         uid = request.session.authenticate(


### PR DESCRIPTION
* Default the `login_success` parameter to False instead of True in order to mitigate lack of parameter existence due to unknown module. Fixes OCA#1081