### PR TITLE
[10.0][FIX] sentry: fix tests after raven 6.4.0

### DIFF
--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Sentry',
     'summary': 'Report Odoo errors to Sentry',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Extra Tools',
     'website': 'https://odoo-community.org/',
     'author': 'Mohammed Barsi,'

--- a/sentry/logutils.py
+++ b/sentry/logutils.py
@@ -101,6 +101,9 @@ class SanitizeOdooCookiesProcessor(SanitizePasswordsProcessor):
     Allows to sanitize sensitive Odoo cookies, namely the "session_id" cookie.
     '''
 
-    FIELDS = frozenset([
+    # `FIELDS` was renamed to `KEYS` in raven 6.4.0.
+    # Keep `FIELDS` for backwards compatibility.
+    # See also issue #1096 on OCA/server-tools.
+    KEYS = FIELDS = frozenset([
         'session_id',
     ])


### PR DESCRIPTION
This should fix https://github.com/OCA/server-tools/issues/1096.