### PR TITLE
[11.0] Sentry: Enable setting a release option directly

### DIFF
--- a/sentry/README.rst
+++ b/sentry/README.rst
@@ -71,9 +71,16 @@ configuration file:
                                HTTP request and user session (if available). This has no effect
                                for Cron jobs, as no request/session is available inside a Cron job.
 
+``sentry_release``             Explicitly define a version to be sent as the release version to
+                               Sentry. Useful in conjuntion with Sentry's "Resolve in the next
+                               release"-functionality. Also useful if your production deployment
+                               does not include any Git context from which a commit might be read.
+                               Overrides *sentry_odoo_dir*.
+
 ``sentry_odoo_dir``            Absolute path to your Odoo installation directory. This is optional
                                and will only be used to extract the Odoo Git commit, which will be
                                sent to Sentry, to allow to distinguish between Odoo updates.
+                               Overridden by *sentry_release*
 =============================  ====================================================================  ==========================================================
 
 Other `client arguments
@@ -100,6 +107,7 @@ Below is an example of Odoo configuration file with *Odoo Sentry* options::
     sentry_environment = production
     sentry_auto_log_stacks = false
     sentry_odoo_dir = /home/odoo/odoo/
+    sentry_release = 1.3.2
 
 Usage
 =====
@@ -148,6 +156,7 @@ Contributors
 * Mohammed Barsi <barsintod@gmail.com>
 * Andrius Preimantas <andrius@versada.eu>
 * Naglis Jonaitis <naglis@versada.eu>
+* Atte Isopuro <atte.isopuro@avoin.systems>
 
 Maintainer
 ----------

--- a/sentry/__init__.py
+++ b/sentry/__init__.py
@@ -43,8 +43,11 @@ def initialize_raven(config, client_cls=None):
     enabled = config.get('sentry_enabled', False)
     if not (HAS_RAVEN and enabled):
         return
+
+    if config.get('sentry_odoo_dir') and config.get('sentry_release'):
+        _logger.debug('Both sentry_odoo_dir and sentry_release defined, choosing sentry_release')
     options = {
-        'release': get_odoo_commit(config.get('sentry_odoo_dir')),
+        'release': config.get('sentry_release', get_odoo_commit(config.get('sentry_odoo_dir'))),
     }
     for option in const.get_sentry_options():
         value = config.get('sentry_%s' % option.key, option.default)

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Sentry',
     'summary': 'Report Odoo errors to Sentry',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Extra Tools',
     'website': 'https://odoo-community.org/',
     'author': 'Mohammed Barsi,'

--- a/sentry/const.py
+++ b/sentry/const.py
@@ -86,4 +86,5 @@ def get_sentry_options():
             'ignore_exceptions', DEFAULT_IGNORED_EXCEPTIONS, split_multiple),
         SentryOption('processors', DEFAULT_PROCESSORS, split_multiple),
         SentryOption('environment', None, None),
+        SentryOption('release', None, None),
     ]


### PR DESCRIPTION
sentry: It is not always possible to read commit information from
a production environment. In those cases it is useful to be able
to set a release version manually.