### PR TITLE
[IMP] traceback on data integration with xmlrpc call

### DIFF
--- a/auth_session_timeout/__manifest__.py
+++ b/auth_session_timeout/__manifest__.py
@@ -14,7 +14,7 @@
     'maintainer': 'Odoo Community Association (OCA)',
     'website': "http://acsone.eu",
     'category': 'Tools',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'license': 'AGPL-3',
     'data': [
         'data/ir_config_parameter_data.xml'

--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -106,7 +106,6 @@ class ResUsers(models.Model):
     def check(cls, *args, **kwargs):
         res = super(ResUsers, cls).check(*args, **kwargs)
         # Bypass call from xmlrpc
-        if http and http.request and http.request.env and\
-                http.request.env.user:
+        if http and http.request:
             http.request.env.user._auth_timeout_check()
         return res

--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -105,5 +105,8 @@ class ResUsers(models.Model):
     @classmethod
     def check(cls, *args, **kwargs):
         res = super(ResUsers, cls).check(*args, **kwargs)
-        http.request.env.user._auth_timeout_check()
+        # Bypass call from xmlrpc
+        if http and http.request and http.request.env and\
+                http.request.env.user:
+            http.request.env.user._auth_timeout_check()
         return res


### PR DESCRIPTION
this issue blocks my data integration when using XML-RPC.

Traceback (most recent call last):
File "", line 1, in 
File "/usr/lib/python2.7/xmlrpclib.py", line 1233, in call
return self.__send(self.__name, args)
File "/usr/lib/python2.7/xmlrpclib.py", line 1587, in __request
verbose=self.__verbose
File "/usr/lib/python2.7/xmlrpclib.py", line 1273, in request
return self.single_request(host, handler, request_body, verbose)
File "/usr/lib/python2.7/xmlrpclib.py", line 1306, in single_request
return self.parse_response(response)
File "/usr/lib/python2.7/xmlrpclib.py", line 1482, in parse_response
return u.close()
File "/usr/lib/python2.7/xmlrpclib.py", line 794, in close
raise Fault(**self._stack[0])
xmlrpclib.Fault: <Fault object unbound: 'Traceback (most recent call last):
File "/home/myproject/server/odoo/service/wsgi_server.py", line 56, in xmlrpc_return\n result = odoo.http.dispatch_rpc(service, method, params)
File "/home/myproject/server/odoo/http.py", line 118, in dispatch_rpc\n result = dispatch(method, params)
File "/home/myproject/server/odoo/service/model.py", line 35, in dispatch\n security.check(db,uid,passwd)
File "/home/myproject/server/odoo/service/security.py", line 13, in check\n return res_users.check(db, uid, passwd)
File "/home/myproject/extra-addons/auth_session_timeout/models/res_users.py", line 107, in check\n http.request.env.user._auth_timeout_check()
File "/usr/local/lib/python2.7/dist-packages/werkzeug/local.py", line 338, in getattr\n return getattr(self._get_current_object(), name)
File "/usr/local/lib/python2.7/dist-packages/werkzeug/local.py", line 297, in _get_current_object\n return self.__local()
File "/usr/local/lib/python2.7/dist-packages/werkzeug/local.py", line 132, in _lookup\n raise RuntimeError('object unbound')\nRuntimeError: object unbound\n