### PR TITLE
[FIX] base_import_match: Move to post testing

### DIFF
--- a/base_import_match/tests/test_import.py
+++ b/base_import_match/tests/test_import.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from os import path
-from openerp.tests.common import TransactionCase
+from openerp.tests.common import at_install, post_install, TransactionCase
 
 
 PATH = path.join(path.dirname(__file__), "import_data", "%s.csv")
@@ -15,6 +15,8 @@ OPTIONS = {
 }
 
 
+@at_install(False)
+@post_install(True)
 class ImportCase(TransactionCase):
     def _base_import_record(self, res_model, file_name):
         """Create and return a ``base_import.import`` record."""


### PR DESCRIPTION
Creating records on res.users or res.partner is very error-prone in integration tests; moving to post testing mode.

@Tecnativa