### PR TITLE
[11.0][FIX] base_exception: enable post_install for tests

### DIFF
--- a/base_exception/tests/common.py
+++ b/base_exception/tests/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -9,6 +9,8 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
+@common.at_install(False)
+@common.post_install(True)
 class TestBaseException(common.SavepointCase):
 
     # pylint: disable=missing-return


### PR DESCRIPTION
While porting `auto_backup` #1158 to V11, I got a Travis error:

```
2018-02-15 10:30:25,711 5277 INFO openerp_test odoo.addons.base_exception.tests.test_base_exception: test_purchase_order_exception (odoo.addons.base_exception.tests.test_base_exception.TestBaseException)
2018-02-15 10:30:26,039 5277 INFO openerp_test odoo.addons.base_exception.tests.test_base_exception: Ran 1 test in 1.395s
2018-02-15 10:30:26,039 5277 INFO openerp_test odoo.addons.base_exception.tests.test_base_exception: OK
2018-02-15 10:30:26,844 5277 INFO openerp_test odoo.modules.registry: module auto_backup: creating or updating database tables
2018-02-15 10:30:27,105 5277 INFO openerp_test odoo.models: Storing computed values of db.backup.name
2018-02-15 10:30:27,208 5277 WARNING openerp_test odoo.modules.registry: Models have no table: base.exception.test.purchase, base.exception.test.purchase.line.
2018-02-15 10:30:27,227 5277 INFO openerp_test odoo.modules.registry: Recreate table of model base.exception.test.purchase.line.
2018-02-15 10:30:27,228 5277 INFO openerp_test odoo.modules.registry: Recreate table of model base.exception.test.purchase.
2018-02-15 10:30:27,239 5277 ERROR openerp_test odoo.modules.registry: Model base.exception.test.purchase.line has no table.
2018-02-15 10:30:27,242 5277 ERROR openerp_test odoo.modules.registry: Model base.exception.test.purchase has no table.
2018-02-15 10:30:27,565 5277 INFO openerp_test odoo.modules.loading: loading auto_backup/data/ir_cron.xml
```

The error is caused by the tests of `base_exception`. The code present in file [base_exception/tests/purchase_test.py](https://github.com/OCA/server-tools/blob/11.0/base_exception/tests/purchase_test.py) somehow generates side effects during the installation of the next module (`auto_backup` in this case).

In this PR, I'm proposing to execute the tests of `base_exception` after the installation of all the modules.
This way, the error above will not occur.


