### PR TITLE
[9.0][IMP] Load key from server_environment

### DIFF
--- a/keychain/README.rst
+++ b/keychain/README.rst
@@ -163,7 +163,6 @@ Go to *settings / keychain*, create a record with the following
 Known issues / Roadmap
 ======================
 - Account inheritence is not supported out-of-the-box (like defining common settings for all environments)
-- Adapted to work with `server_environnement` modules
 - Key expiration or rotation should be done manually
 - Import passwords from data.xml
 


### PR DESCRIPTION
Checks whether server_environment is installed and if so, tries to load the key from:
```
[keychain]
<env>=...
```

If it doesn't exist, it will fallback to the previous process.