### PR TITLE
[10.0][UPD] base_user_role: Disabled Administrator user selection in notebo…

### DIFF
--- a/base_user_role/README.rst
+++ b/base_user_role/README.rst
@@ -68,6 +68,7 @@ Contributors
 ------------
 
 * Sébastien Alix <sebastien.alix@osiell.com>
+* Antonio Russo <antonio.r@rwsdigital.com>
 
 Maintainer
 ----------

--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'User roles',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Tools',
     'author': 'ABF OSIELL, Odoo Community Association (OCA)',
     'license': 'AGPL-3',

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -67,7 +67,7 @@ class ResUsersRoleLine(models.Model):
     role_id = fields.Many2one(
         'res.users.role', string=u"Role", ondelete='cascade')
     user_id = fields.Many2one(
-        'res.users', string=u"User",domain=[('id','!=', SUPERUSER_ID)])
+        'res.users', string=u"User", domain=[('id', '!=', SUPERUSER_ID)])
     date_from = fields.Date(u"From")
     date_to = fields.Date(u"To")
     is_enabled = fields.Boolean(u"Enabled", compute='_compute_is_enabled')

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 
 from odoo import api, fields, models
+from odoo import SUPERUSER_ID
 
 
 _logger = logging.getLogger(__name__)
@@ -66,7 +67,7 @@ class ResUsersRoleLine(models.Model):
     role_id = fields.Many2one(
         'res.users.role', string=u"Role", ondelete='cascade')
     user_id = fields.Many2one(
-        'res.users', string=u"User")
+        'res.users', string=u"User",domain=[('id','!=', SUPERUSER_ID)])
     date_from = fields.Date(u"From")
     date_to = fields.Date(u"To")
     is_enabled = fields.Boolean(u"Enabled", compute='_compute_is_enabled')

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -20,7 +20,7 @@
                     <page string="Users">
                         <field name="line_ids" nolabel="1">
                             <tree editable="bottom" decoration-muted="not is_enabled">
-                                <field name="user_id" domain="[('id','!=', 1)]"/>
+                                <field name="user_id"/>
                                 <field name="date_from"/>
                                 <field name="date_to"/>
                                 <field name="is_enabled"/>

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -20,7 +20,7 @@
                     <page string="Users">
                         <field name="line_ids" nolabel="1">
                             <tree editable="bottom" decoration-muted="not is_enabled">
-                                <field name="user_id"/>
+                                <field name="user_id" domain="[('id','!=', 1)]"/>
                                 <field name="date_from"/>
                                 <field name="date_to"/>
                                 <field name="is_enabled"/>


### PR DESCRIPTION
If Administrator user is selected for error in the notebook users of the rules form, and the current rule has no admin settings, administrator can lose all the privileges and will be problematic to fix this without direct editing database records.