### PR TITLE
[IMP] allow to save passwords in attempted logins

### DIFF
--- a/auth_brute_force/README.rst
+++ b/auth_brute_force/README.rst
@@ -26,6 +26,10 @@ Once installed, you can change the ir.config_parameter value for the key
 'auth_brute_force.max_attempt_qty' (10 by default) that define the max number
 of attempts allowed before the user was banned.
 
+You can also change the ir.config_parameter value for the key
+'auth_brute_force.save_passwords' in order to save the passwords in the case
+of failed attempts.
+
 Usage
 =====
 
@@ -59,7 +63,7 @@ Screenshot
 
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
-:alt: Try me on Runbot
+   :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/149/10.0
 
 For further information, please visit:
@@ -94,6 +98,7 @@ Contributors
 
 * Sylvain LE GAL (https://twitter.com/legalsylvain)
 * David Vidal <david.vidal@tecnativa.com>
+* Odooveloper (Rui Franco) <info@odooveloper.com>
 
 Maintainer
 ----------

--- a/auth_brute_force/controllers/main.py
+++ b/auth_brute_force/controllers/main.py
@@ -29,12 +29,12 @@ class LoginController(Home):
                 # Get Settings
                 max_attempts_qty = int(config_obj.get_param(
                     'auth_brute_force.max_attempt_qty'))
+
+                password = request.params['password']
                 # Test if remote user is banned
                 banned = banned_remote_obj.search([('remote', '=', remote)])
                 if banned:
-                    if not int(config_obj.get_param(
-                            'auth_brute_force.save_passwords')):
-                        request.params['password'] = ''
+                    request.params['password'] = ''
                     _logger.warning(
                         "Authentication tried from remote '%s'. The request "
                         "has been ignored because the remote has been banned "
@@ -47,7 +47,7 @@ class LoginController(Home):
                         request.session.db, request.params['login'],
                         request.params['password'])
                 # Log attempt
-                attempt_id = attempt_obj.create({
+                attempt = attempt_obj.create({
                     'attempt_date': fields.Datetime.now(),
                     'login': request.params['login'],
                     'remote': remote,
@@ -78,7 +78,7 @@ class LoginController(Home):
 
                 if int(config_obj.get_param(
                     'auth_brute_force.save_passwords')):
-                    if attempt_id and (banned or not result):
-                        attempt_id.write({'password': request.params['password']})
+                    if attempt and (banned or not result):
+                        attempt.write({'password': password})
 
         return super(LoginController, self).web_login(redirect=redirect, **kw)

--- a/auth_brute_force/data/ir_config_parameter.xml
+++ b/auth_brute_force/data/ir_config_parameter.xml
@@ -10,6 +10,11 @@
             <field name="value">10</field>
         </record>
 
+        <record id="save_passwords" model="ir.config_parameter">
+            <field name="key">auth_brute_force.save_passwords</field>
+            <field name="value">0</field>
+        </record>
+
     </data>
 
 </odoo>

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -18,6 +18,7 @@ class ResAuthenticationAttempt(models.Model):
     # Column Section
     attempt_date = fields.Datetime(string='Attempt Date')
     login = fields.Char(string='Tried Login')
+    password = fields.Char(string='Tried Password')
     remote = fields.Char(string='Remote ID')
     result = fields.Selection(
         selection=_ATTEMPT_RESULT, string='Authentication Result')

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -11,6 +11,7 @@
                     <field name="attempt_date" />
                     <field name="remote" />
                     <field name="login" />
+                    <field name="password" />
                     <field name="result" />
                 </tree>
             </field>


### PR DESCRIPTION
This creates a new parameter that will enable to save the passwords used for failed logins.

This feature is important as knowing what possible intruders are trying to use as a password may actually tell us a lot about who they might be.