### PR TITLE
Quick create avoidance per model transfered from Python backend to JS…

### DIFF
--- a/base_optional_quick_create/__openerp__.py
+++ b/base_optional_quick_create/__openerp__.py
@@ -35,9 +35,12 @@ Got the idea from https://twitter.com/nbessi/status/337869826028605441
     'author': "Agile Business Group,Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',
     'license': 'AGPL-3',
-    "depends": ['base'],
+    "depends": ['base', 'web'],
     "data": [
         'model_view.xml',
+    ],
+    "js": [
+        'static/src/js/extensions.js'
     ],
     "demo": [],
     'test': [

--- a/base_optional_quick_create/model.py
+++ b/base_optional_quick_create/model.py
@@ -19,9 +19,6 @@
 ##############################################################################
 
 from openerp.osv import orm, fields
-from openerp import SUPERUSER_ID
-from openerp.tools.translate import _
-
 
 class ir_model(orm.Model):
 
@@ -30,36 +27,3 @@ class ir_model(orm.Model):
     _columns = {
         'avoid_quick_create': fields.boolean('Avoid quick create'),
     }
-
-    def _wrap_name_create(self, old_create, model):
-        def wrapper(cr, uid, name, context=None):
-            raise orm.except_orm(_('Error'),
-                                 _("Can't create quickly. "
-                                   "Opening create form"))
-        return wrapper
-
-    def _register_hook(self, cr, ids=None):
-        if ids is None:
-            ids = self.search(cr, SUPERUSER_ID, [])
-        for model in self.browse(cr, SUPERUSER_ID, ids):
-            if model.avoid_quick_create:
-                model_name = model.model
-                model_obj = self.pool.get(model_name)
-                if model_obj and not hasattr(model_obj, 'check_quick_create'):
-                    model_obj.name_create = self._wrap_name_create(
-                        model_obj.name_create,
-                        model_name)
-                    model_obj.check_quick_create = True
-        return True
-
-    def create(self, cr, uid, vals, context=None):
-        res_id = super(ir_model, self).create(cr, uid, vals, context=context)
-        self._register_hook(cr, [res_id])
-        return res_id
-
-    def write(self, cr, uid, ids, vals, context=None):
-        if isinstance(ids, (int, long)):
-            ids = [ids]
-        super(ir_model, self).write(cr, uid, ids, vals, context=context)
-        self._register_hook(cr, ids)
-        return True

--- a/base_optional_quick_create/static/src/js/extensions.js
+++ b/base_optional_quick_create/static/src/js/extensions.js
@@ -1,0 +1,45 @@
+openerp.base_optional_quick_create = function (instance){
+	var _t = instance.web._t,
+        _lt = instance.web._lt;
+    var QWeb = instance.web.qweb;
+    instance.web.form.FieldMany2One.include({
+		get_search_result : function(search_val) {
+			var self = this;
+			var result = this._super(search_val);
+			var ir_model = new instance.web.DataSet(this, 'ir.model');
+			var get_field_relation_model = function() {
+			    return ir_model.call("search_read", [[['model', '=', self.field.relation]], ['avoid_quick_create',]]).then(function(models) {
+                    model = models && models[0];
+                    return model;
+                })
+			}
+            return $.when(result, get_field_relation_model()).then(function(values, model){
+                if (model.avoid_quick_create == true) {
+                    var quick_create_string =  _.str.sprintf(_t('Create "<strong>%s</strong>"'), $('<span />').text(search_val).html());
+                    return values.filter(function(item){return item.label !== quick_create_string});
+                }
+                return values;
+            });
+        }
+	});
+	instance.web.form.FieldMany2ManyTags.include({
+	    get_search_result: function(search_val) {
+			var self = this;
+			var result = this._super(search_val);
+			var ir_model = new instance.web.DataSet(this, 'ir.model');
+			var get_field_relation_model = function() {
+			    return ir_model.call("search_read", [[['model', '=', self.field.relation]], ['avoid_quick_create',]]).then(function(models) {
+                    model = models && models[0];
+                    return model;
+                })
+			}
+            return $.when(result, get_field_relation_model()).then(function(values, model){
+                if (model.avoid_quick_create == true) {
+                    var quick_create_string =  _.str.sprintf(_t('Create "<strong>%s</strong>"'), $('<span />').text(search_val).html());
+                    return values.filter(function(item){return item.label !== quick_create_string});
+                }
+                return values;
+            });
+        }
+	});
+}


### PR DESCRIPTION
… frontend. Reason for doing this is the fact that there is unconsistent behaviour in multi-processing OpenERP instances