### PR TITLE
[FIX] base_optional_quick_create clears _api field of name_create method

### DIFF
--- a/base_optional_quick_create/__manifest__.py
+++ b/base_optional_quick_create/__manifest__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-# © 2013 Agile Business Group sagl (<http://www.agilebg.com>)
-# © 2016 ACSONE SA/NA (<http://acsone.eu>)
+# Copyright 2013 Agile Business Group sagl (<http://www.agilebg.com>)
+# Copyright 2016 ACSONE SA/NA (<http://acsone.eu>)
 
 {
     'name': "Optional quick create",
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Tools',
     'summary': "Avoid 'quick create' on m2o fields, on a 'by model' basis",
     'author': "Agile Business Group,Odoo Community Association (OCA)",

--- a/base_optional_quick_create/i18n/it.po
+++ b/base_optional_quick_create/i18n/it.po
@@ -1,33 +1,30 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * base_optional_quick_create
-# 
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
+#	* base_optional_quick_create
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0\n"
+"Project-Id-Version: Odoo Server 10.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-01 10:38+0000\n"
-"PO-Revision-Date: 2017-05-01 10:38+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"POT-Creation-Date: 2018-03-19 17:10+0000\n"
+"PO-Revision-Date: 2018-03-19 17:10+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: base_optional_quick_create
 #: model:ir.model.fields,field_description:base_optional_quick_create.field_ir_model_avoid_quick_create
 msgid "Avoid quick create"
-msgstr ""
+msgstr "Evita creazione veloce"
 
 #. module: base_optional_quick_create
 #: code:addons/base_optional_quick_create/models/ir_model.py:21
 #, python-format
-msgid "Can't create quickly. Opening create form"
-msgstr ""
+msgid "Can't create %s with name %s quickly.\nPlease contact your system administrator to disable this behaviour."
+msgstr "Non è possibile creare velocemente un %s con nome %s.\nSi prega di contattare l'amministratore di sistema per disabilitare questo comportamento."
 
 #. module: base_optional_quick_create
 #: model:ir.model,name:base_optional_quick_create.model_ir_model

--- a/base_optional_quick_create/models/ir_model.py
+++ b/base_optional_quick_create/models/ir_model.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# © 2013 Agile Business Group sagl (<http://www.agilebg.com>)
-# © 2016 ACSONE SA/NA (<http://acsone.eu>)
-# © 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# Copyright 2016 ACSONE SA/NA (<http://acsone.eu>)
+# Copyright 2016 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# Copyright 2018 Simone Rubino - Agile Business Group
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
@@ -15,21 +15,24 @@ class IrModel(models.Model):
     @api.multi
     def _patch_quick_create(self):
 
-        @api.multi
         def _wrap_name_create():
-            def wrapper(self):
-                raise UserError(_("Can't create quickly. Opening create form"))
+            @api.model
+            def wrapper(self, name):
+                raise UserError(_(
+                    "Can't create %s with name %s quickly.\n"
+                    "Please contact your system administrator to disable "
+                    "this behaviour.") % (self._name, name))
             return wrapper
 
+        method_name = 'name_create'
         for model in self:
+            model_obj = self.env.get(model.model)
             if model.avoid_quick_create:
-                model_name = model.model
-                model_obj = self.env.get(model_name)
-                if (
-                        not isinstance(model_obj, type(None)) and
-                        not hasattr(model_obj, 'check_quick_create')):
-                    model_obj._patch_method('name_create', _wrap_name_create())
-                    model_obj.check_quick_create = True
+                model_obj._patch_method(method_name, _wrap_name_create())
+            else:
+                method = getattr(model_obj, method_name, None)
+                if method and hasattr(method, 'origin'):
+                    model_obj._revert_method(method_name)
         return True
 
     def _register_hook(self):

--- a/base_optional_quick_create/tests/__init__.py
+++ b/base_optional_quick_create/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_quick_create

--- a/base_optional_quick_create/tests/test_quick_create.py
+++ b/base_optional_quick_create/tests/test_quick_create.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestQuickCreate(TransactionCase):
+
+    def setUp(self, *args, **kwargs):
+        super(TestQuickCreate, self).setUp()
+        model_model = self.env['ir.model']
+        self.partner_model = model_model.search([
+            ('model', '=', 'res.partner')])
+
+    def test_quick_create(self):
+        partner_id = self.env['res.partner'].name_create('TEST partner')
+        self.assertEqual(bool(partner_id), True)
+
+        # Setting the flag, patches the method
+        self.partner_model.avoid_quick_create = True
+        with self.assertRaises(UserError):
+            self.env['res.partner'].name_create('TEST partner')
+
+        # Unsetting the flag, unpatches the method
+        self.partner_model.avoid_quick_create = False
+        partner_id = self.env['res.partner'].name_create('TEST partner')
+        self.assertEqual(bool(partner_id), True)


### PR DESCRIPTION
The wrapper was clearing the `@api.model` decorator of method `name_create`, causing a `TypeError` exception when wrapper was called.

Added also automated tests and italian translations, please check.
Thanks