### PR TITLE
[FIX] base_technical_features: add base_import dependency

### DIFF
--- a/base_technical_features/__manifest__.py
+++ b/base_technical_features/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Usability",
     "website": "https://github.com/oca/server-tools",
     "author": "Opener B.V., Odoo Community Association (OCA)",
-    "depends": ['web'],
+    "depends": ['web', 'base_import'],
     "data": [
         'security/res_groups.xml',
         'views/res_users.xml',


### PR DESCRIPTION
This dependency is needed if you're working with advanced testing or Odoo.sh.
If you do not have the dependency set to `base_import` the test ` test_shallow` will fail from the module `base_import` (actually, much like my other fix at https://github.com/OCA/server-tools/pull/1191) .
When you add this dependency all Odoo.sh projects and tests will build fine. This is because the dependency for `base_import` will be installed before the module `base_technical_features`. Without this item there is a `diff` which makes the test fail.
This is very similar to https://github.com/OCA/server-tools/pull/1191 but I didn't notice it because I originally did it against 11.0 on my tests, where this works fine without the `base_import` dependency.


The output of the test without this dependency:
```

Date | Level | Type | Message
-- | -- | -- | --
03/20/2018 11:22:57 | ERROR | server | FAIL
03/20/2018 11:22:58 | ERROR | server | FAIL: test_shallow (odoo.addons.base_import.tests.test_base_import.TestO2M)
03/20/2018 11:22:58 | ERROR | server | Traceback (most recent call last):
03/20/2018 11:22:58 | ERROR | server | `   File "/home/odoo/src/odoo/addons/base_import/tests/test_base_import.py", line 106, in test_shallow
03/20/2018 11:22:58 | ERROR | server | `     {'id': 'value', 'name': 'value', 'string': 'Value', 'required': False, 'fields': [], 'type': 'integer'},
03/20/2018 11:22:58 | ERROR | server | `   File "/home/odoo/src/odoo/addons/base_import/tests/test_base_import.py", line 40, in assertEqualFields
03/20/2018 11:22:58 | ERROR | server | `     self.assertEqual(sorted_fields(fields1), sorted_fields(fields2))
03/20/2018 11:22:58 | ERROR | server | ` AssertionError: Lists differ: [{'string': u'External ID', 'f... != [{'string': 'External ID', 'fi...
03/20/2018 11:22:58 | ERROR | server | `
03/20/2018 11:22:58 | ERROR | server | ` First differing element 1:
03/20/2018 11:22:58 | ERROR | server | ` {'string': 'Value', 'fields': [{'string': u'Database ID', 'fields': [], 'required': False, 'type': 'id', 'id': '.id', 'name': '.id'}, {'string': u'External ID', 'fields': [], 'required': False, 'type': 'id', 'id': 'id', 'name': 'id'}, {'string': 'Parent id', 'fields': [{'string': u'External ID', 'fields': [], 'required': False, 'type': 'id', 'id': 'parent_id', 'name': 'id'}, {'string': u'Database ID', 'fields': [], 'required': False, 'type': 'id', 'id': 'parent_id', 'name': '.id'}], 'required': False, 'type': 'many2one', 'id': 'parent_id', 'name': 'parent_id'}, {'string': 'Value', 'fields': [], 'required': False, 'type': 'integer', 'id': 'value', 'name': 'value'}], 'required': False, 'type': 'one2many', 'id': 'value', 'name': 'value'}
03/20/2018 11:22:58 | ERROR | server | ` {'string': 'Value', 'fields': [{'string': 'External ID', 'fields': [], 'required': False, 'type': 'id', 'id': 'id', 'name': 'id'}, {'string': 'Parent id', 'fields': [{'string': 'External ID', 'fields': [], 'required': False, 'type': 'id', 'id': 'parent_id', 'name': 'id'}, {'string': 'Database ID', 'fields': [], 'required': False, 'type': 'id', 'id': 'parent_id', 'name': '.id'}], 'required': False, 'type': 'many2one', 'id': 'parent_id', 'name': 'parent_id'}, {'string': 'Value', 'fields': [], 'required': False, 'type': 'integer', 'id': 'value', 'name': 'value'}], 'required': False, 'type': 'one2many', 'id': 'value', 'name': 'value'}
03/20/2018 11:22:58 | ERROR | server | `
03/20/2018 11:22:58 | ERROR | server | ` Diff is 1869 characters long. Set self.maxDiff to None to see it.
03/20/2018 11:22:58 | ERROR | server | FAILED
03/20/2018 11:22:58 | ERROR | server | Module base_import: 1 failures, 0 errors
03/20/2018 11:22:59 | ERROR | server | At least one test failed when loading the modules.
```


A similar proposal was done at https://github.com/OCA/server-tools/pull/443 but was denied. Quoting:

> Sorry but I'm not in favor of adding a dependency to a module to solve a problem that occurs when you run tests due to the way you run your tests

However with Odoo.sh you cannot control the way tests are executed and as you can only fix this failing error because of the added dependency I believe now there is a good requirement to add it in.