### PR TITLE
[9.0][IMP] base_tier_validation: able to restart validation

### DIFF
--- a/base_tier_validation/__openerp__.py
+++ b/base_tier_validation/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "category": "Tools",
     "website": "https://github.com/OCA/server-tools",
     "author": "Eficent, Odoo Community Association (OCA)",


### PR DESCRIPTION
Need a way to restart validation process without going through cancel state, as cancellation often cancel more stuff in the chain (e.g. procurements, moves...)

cc @andhit-r you asked for a way to restart validation on `purchase_tier_validation` :wink: 