### PR TITLE
[FIX] module_auto_update: Rollback cursor if param exists

### DIFF
--- a/module_auto_update/migrations/9.0.2.0.0/pre-migrate.py
+++ b/module_auto_update/migrations/9.0.2.0.0/pre-migrate.py
@@ -12,10 +12,12 @@ _logger = logging.getLogger(__name__)
 def migrate(cr, version):
     """Autoenable deprecated behavior."""
     try:
-        cr.execute(
-            "INSERT INTO ir_config_parameter (key, value) VALUES (%s, '1')",
-            (PARAM_DEPRECATED,)
-        )
+        with cr.savepoint():
+            cr.execute(
+                """INSERT INTO ir_config_parameter (key, value)
+                   VALUES (%s, '1')""",
+                (PARAM_DEPRECATED,)
+            )
         _logger.warn("Deprecated features have been autoenabled, see "
                      "addon's README to know how to upgrade to the new "
                      "supported autoupdate mechanism.")


### PR DESCRIPTION
Without this patch, when upgrading after you have stored the deprecated features parameter, the cursor became broken and no more migrations could happen. You got this error:

    Traceback (most recent call last):
    File "/usr/local/bin/odoo", line 6, in <module>
        exec(compile(open(__file__).read(), __file__, 'exec'))
    File "/opt/odoo/custom/src/odoo/odoo.py", line 160, in <module>
        main()
    File "/opt/odoo/custom/src/odoo/odoo.py", line 157, in main
        openerp.cli.main()
    File "/opt/odoo/custom/src/odoo/openerp/cli/command.py", line 64, in main
        o.run(args)
    File "/opt/odoo/custom/src/odoo/openerp/cli/shell.py", line 65, in run
        self.shell(openerp.tools.config['db_name'])
    File "/opt/odoo/custom/src/odoo/openerp/cli/shell.py", line 52, in shell
        registry = openerp.modules.registry.RegistryManager.get(dbname)
    File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 355, in get
        update_module)
    File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 386, in new
        openerp.modules.load_modules(registry._db, force_demo, status, update_module)
    File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 335, in load_modules
        force, status, report, loaded_modules, update_module)
    File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 239, in load_marked_modules
        loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
    File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 136, in load_module_graph
        registry.setup_models(cr, partial=True)
    File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 186, in setup_models
        cr.execute('select model, transient from ir_model where state=%s', ('manual',))
    File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 154, in wrapper
        return f(self, *args, **kwargs)
    File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 233, in execute
        res = self._obj.execute(query, params)
    psycopg2.InternalError: current transaction is aborted, commands ignored until end of transaction block

Now you can safely migrate, be that parameter pre-created or not.

@Tecnativa