### PR TITLE
[ADD] mass_editing: multiple changes

### DIFF
--- a/mass_editing/models/ir_model_fields.py
+++ b/mass_editing/models/ir_model_fields.py
@@ -12,12 +12,13 @@ class IrModelFields(models.Model):
     def search(self, args, offset=0, limit=0, order=None, count=False):
         model_domain = []
         for domain in args:
-            if (len(domain) > 2 and domain[0] == 'model_id' and
-                    isinstance(domain[2], basestring)):
-                model_domain += [('model_id', 'in',
-                                  map(int, domain[2][1:-1].split(',')))]
-            else:
-                model_domain.append(domain)
+            if len(domain) > 2 and domain[0] == 'mass_editing_model_id':
+                if isinstance(domain[2], basestring):
+                    domain = ('model_id', 'in',
+                              map(int, domain[2][1:-1].split(',')))
+                else:
+                    domain = ('model_id', 'in', domain[2])
+            model_domain.append(domain)
         return super(IrModelFields, self).search(model_domain, offset=offset,
                                                  limit=limit, order=order,
                                                  count=count)

--- a/mass_editing/models/mass_object.py
+++ b/mass_editing/models/mass_object.py
@@ -10,10 +10,11 @@ class MassObject(models.Model):
     _description = "Mass Editing Object"
 
     name = fields.Char('Name', required=True, select=1)
-    model_id = fields.Many2one('ir.model', 'Model', required=True,
-                               help="Model is used for Selecting Fields. "
-                                    "This is editable until Sidebar menu "
-                                    "is not created.")
+    mass_editing_model_id = fields.Many2one(
+        'ir.model', 'Model', required=True,
+        help="Model is used for Selecting Fields. "
+        "This is editable until Sidebar menu "
+        "is not created.", oldname="model_id")
     field_ids = fields.Many2many('ir.model.fields', 'mass_field_rel',
                                  'mass_id', 'field_id', 'Fields')
     ref_ir_act_window_id = fields.Many2one('ir.actions.act_window',
@@ -33,14 +34,14 @@ class MassObject(models.Model):
         ('name_uniq', 'unique (name)', _('Name must be unique!')),
     ]
 
-    @api.onchange('model_id')
-    def _onchange_model_id(self):
+    @api.onchange('mass_editing_model_id')
+    def _onchange_mass_editing_model_id_domain(self):
         self.field_ids = [(6, 0, [])]
         model_list = []
-        if self.model_id:
+        if self.mass_editing_model_id:
             model_obj = self.env['ir.model']
-            model_list = [self.model_id.id]
-            active_model_obj = self.env[self.model_id.model]
+            model_list = [self.mass_editing_model_id.id]
+            active_model_obj = self.env[self.mass_editing_model_id.model]
             if active_model_obj._inherits:
                 keys = active_model_obj._inherits.keys()
                 inherits_model_list = model_obj.search([('model', 'in', keys)])
@@ -53,7 +54,7 @@ class MassObject(models.Model):
         self.ensure_one()
         vals = {}
         action_obj = self.env['ir.actions.act_window']
-        src_obj = self.model_id.model
+        src_obj = self.mass_editing_model_id.model
         button_name = _('Mass Editing (%s)') % self.name
         vals['ref_ir_act_window_id'] = action_obj.create({
             'name': button_name,

--- a/mass_editing/views/mass_editing_view.xml
+++ b/mass_editing/views/mass_editing_view.xml
@@ -14,7 +14,7 @@
                         </h1>
                         <group>
                             <group>
-                                <field name="model_id" required="1" attrs="{'readonly':[('ref_ir_act_window_id','!=',False)]}"/>
+                                <field name="mass_editing_model_id" required="1" attrs="{'readonly':[('ref_ir_act_window_id','!=',False)]}"/>
                             </group>
                             <group>
                                 <field name="model_list" invisible="1"/>
@@ -41,7 +41,7 @@
                     <notebook colspan="4">
                         <page string="Fields">
                             <field name="field_ids" colspan="4" nolabel="1"
-                            domain="[('ttype', 'not in', ['refenrence', 'function']), ('model_id', 'in', model_list)]"/>
+                            domain="[('ttype', 'not in', ['refenrence', 'function']), ('mass_editing_model_id', 'in', model_list)]" context="{'default_model_id': mass_editing_model_id}"/>
                         </page>
                         <page string="Advanced" attrs="{'invisible':[('ref_ir_act_window_id','=',False)]}">
                             <group colspan="2" col="2">
@@ -61,7 +61,7 @@
         <field name="arch" type="xml">
             <tree string="Object">
                 <field name="name"/>
-                <field name="model_id"/>
+                <field name="mass_editing_model_id"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
[FIX] error when trying to create a new personalize field by changing the
mass_editing model_field name to mass_editing_model_id.

[IMP] add mass editing current model to context in order to have by default
this model when creating a new field from there.