### PR TITLE
Exclude database_cleanup from tests - fixes #1202

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,11 @@ env:
   matrix:
   - LINT_CHECK="1"
   - TRANSIFEX="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo"
-  - TESTS="1" ODOO_REPO="OCA/OCB"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="database_cleanup"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="database_cleanup
+  - TESTS="1" ODOO_REPO="odoo/odoo" INCLUDE="database_cleanup"
+  - TESTS="1" ODOO_REPO="OCA/OCB" INCLUDE="database_cleanup"
+  
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
Isolate database_cleanup to avoid double module install. The same way it is done in 9.0 - and as suggested by @sylvain-garancher in #1202 and to avoid the errors in #1201