### PR TITLE
[ADD] copy flag in context to have other code do the right thing (tm)

### DIFF
--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -69,7 +69,7 @@ class CompanyLDAP(models.Model):
                     conf['ldap_filter'])
             results = self.get_ldap_entry_dicts(conf)
             for result in results:
-                user_id = self.get_or_create_user(
+                user_id = self.with_context(copy=True).get_or_create_user(
                     conf, result[1][login_attr][0], result)
                 # this happens if something goes wrong while creating the user
                 # or fetching information from ldap


### PR DESCRIPTION
When creating users from ldap with a template user, we basically clone the template user with our default values.

In cases where partner_firstname is involved, this goes wrong because this module will overwrite the name from the template user's first, lastname again. Given this is a copy operation in principle anyways, I think it's safe to pass the flag partner_firstname reacts to here: https://github.com/OCA/partner-contact/blob/10.0/partner_firstname/models/res_partner.py#L45 (which it does because the copy context is set in cases some record is copied)