### PR TITLE
[10.0][FIX] users_ldap_populate. Wrong field name in test.

### DIFF
--- a/users_ldap_mail/README.rst
+++ b/users_ldap_mail/README.rst
@@ -23,6 +23,10 @@ To use this module, you need to:
    These items will correspond with a new user that is created, when a user
    logs in via LDAP in Odoo.
 
+The default attribute used for the name is "cn".
+For Active Directory, you might prefer to use "displayName" instead.
+AD also supports the "mail" attribute, so it can be mapped into Odoo.
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/repo/149

--- a/users_ldap_mail/__manifest__.py
+++ b/users_ldap_mail/__manifest__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # © Daniel Reis (https://launchpad.com/~dreis-pt)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/gpl.html).
-
 {
     'name': "LDAP mapping for user name and e-mail",
     'version': "10.0.1.0.0",
@@ -9,14 +8,6 @@
     'author': "Daniel Reis (https://launchpad.com/~dreis-pt),"
               "Odoo Community Association (OCA)",
     'license': 'AGPL-3',
-    'description': """\
-Allows to define the LDAP attributes to use to retrieve user name and e-mail
-address.
-
-The default attribute used for the name is "cn".
-For Active Directory, you might prefer to use "displayName" instead.
-AD also supports the "mail" attribute, so it can be mapped into OpenERP.
-""",
     'category': "Tools",
     'data': [
         'views/users_ldap_view.xml',

--- a/users_ldap_populate/__manifest__.py
+++ b/users_ldap_populate/__manifest__.py
@@ -1,30 +1,12 @@
 # -*- coding: utf-8 -*-
-# © 2012 Therp BV (<http://therp.nl>)
+# Copyright 2012-2018 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/gpl.html).
-
 {
     "name": "LDAP Populate",
-    "version": "10.0.1.0.1",
-    "author": (
-        "Therp BV",
-        "Odoo Community Association (OCA)",
-    ),
+    "version": "10.0.1.0.2",
+    "author": "Therp BV, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": 'Tools',
-    "description": """
-This module allows to prepopulate the user database with all entries in the
-LDAP database.
-
-In order to schedule the population of the user database on a regular basis,
-create a new scheduled action with the following properties:
-
-- Object: res.company.ldap
-- Function: action_populate
-- Arguments: [res.company.ldap.id]
-
-Substitute res.company.ldap.id with the actual id of the res.company.ldap
-object you want to query.
-""",
     "depends": [
         'auth_ldap',
     ],

--- a/users_ldap_populate/tests/test_users_ldap_populate.py
+++ b/users_ldap_populate/tests/test_users_ldap_populate.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# © 2016 Therp BV <http://therp.nl>
+# Copyright 2016-2018 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp.tests.common import TransactionCase
 from contextlib import contextmanager
 
 
-class patch_ldap_connection(object):
+class PatchLDAPConnection(object):
     def __init__(self, results):
         self.results = results
 
@@ -30,7 +30,7 @@ def patch_ldap(self, results):
     original_initialize = ldap.initialize
 
     def initialize(uri):
-        return patch_ldap_connection(results)
+        return PatchLDAPConnection(results)
     ldap.initialize = initialize
     yield
     ldap.initialize = original_initialize
@@ -41,7 +41,7 @@ def get_fake_ldap(self):
     company.write({
         'ldaps': [(0, 0, {
             'ldap_server': 'fake',
-            'ldap_port': 'fake',
+            'ldap_server_port': 389,
             'ldap_filter': '(uid=%s)',
             'ldap_base': 'fake',
             'deactivate_unknown_users': True,


### PR DESCRIPTION
Also various changes to satisfy pylint/flake/travis.

Prevent this error in test:

2018-04-20 10:40:34 | WARNING | server | odoo.models:3836 create                                     res.company.ldap.create() includes unknown fields: ldap_port


