### PR TITLE
[10.0][IMP] Keychain : Add default validation logic

### DIFF
--- a/keychain/__manifest__.py
+++ b/keychain/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Keychain",
     "summary": "Store accounts and credentials",
-    "version": "10.0.2.0.0",
+    "version": "10.0.2.0.1",
     "category": "Uncategorized",
     "website": "https://akretion.com/",
     "author": "Akretion, Odoo Community Association (OCA)",

--- a/keychain/models/keychain.py
+++ b/keychain/models/keychain.py
@@ -116,11 +116,58 @@ class KeychainAccount(models.Model):
 
     @implemented_by_keychain
     def _validate_data(self, data):
+        """Ensure data is valid according to the namespace.
+
+        How to use:
+        - Create a method prefixed with your namespace
+        - Put your validation logic inside
+        - Return true if data is valid for your usage
+
+        This method will be called on write().
+        If false is returned an user error will be raised.
+
+        Example:
+        def _hereismynamspace_validate_data():
+            return len(data.get('some_param', '') > 6)
+
+        @params data dict
+        @returns boolean
+        """
         pass
+
+    def _default_validate_data(self, data):
+        """Default validation.
+
+        By default says data is always valid.
+        See _validata_data() for more information.
+        """
+        return True
 
     @implemented_by_keychain
     def _init_data(self):
+        """Initialize data field.
+
+        How to use:
+        - Create a method prefixed with your namespace
+        - Return a dict with the keys and may be default
+        values your expect.
+
+        This method will be called on write().
+
+        Example:
+        def _hereismynamspace_init_data():
+            return { 'some_param': 'default_value' }
+
+        @returns dict
+        """
         pass
+
+    def _default_init_data(self):
+        """Default initialization.
+
+        See _init_data() for more information.
+        """
+        return {}
 
     @staticmethod
     def _retrieve_env():

--- a/keychain/tests/test_keychain.py
+++ b/keychain/tests/test_keychain.py
@@ -79,14 +79,14 @@ class TestKeychain(TransactionCase):
         config['keychain_key'] = Fernet.generate_key()
         try:
             account._get_password()
-            self.assertTrue(False, 'It should not work with another key')
+            self.fail('It should not work with another key')
         except UserError as err:
             self.assertTrue(True, 'It should raise a UserError')
             self.assertTrue(
                 'has been encrypted with a diff' in str(err),
                 'It should display the right msg')
         else:
-            self.assertTrue(False, 'It should raise a UserError')
+            self.fail('It should raise a UserError')
 
     def test_no_key(self):
         """It should raise an exception when no key is set."""
@@ -96,7 +96,7 @@ class TestKeychain(TransactionCase):
         with self.assertRaises(UserError) as err:
             account.clear_password = 'aiuepr'
             account._inverse_set_password()
-            self.assertTrue(False, 'It should not work without key')
+            self.fail('It should not work without key')
         self.assertTrue(
             'Use a key similar to' in str(err.exception),
             'It should display the right msg')
@@ -109,7 +109,7 @@ class TestKeychain(TransactionCase):
         with self.assertRaises(UserError):
             account.clear_password = 'aiuepr'
             account._inverse_set_password()
-            self.assertTrue(False, 'It should not work missing formated key')
+            self.fail('It should not work missing formated key')
 
         self.assertTrue(True, 'It shoud raise a ValueError')
 
@@ -193,9 +193,7 @@ class TestKeychain(TransactionCase):
         for json in wrong_jsons:
             with self.assertRaises(ValidationError) as err:
                 account.write({"data": json})
-                self.assertTrue(
-                    False,
-                    'Should not validate baddly formatted json')
+                self.fail('Should not validate baddly formatted json')
             self.assertTrue(
                 'Data should be a valid JSON' in str(err.exception),
                 'It should raise a ValidationError')
@@ -220,7 +218,7 @@ class TestKeychain(TransactionCase):
                 account.write({"data": json})
                 self.assertTrue(True, 'Should validate json')
             except:
-                self.assertTrue(False, 'It should validate a good json')
+                self.fail('It should validate a good json')
 
     def test_default_init_and_valid(self):
         """."""
@@ -236,7 +234,7 @@ class TestKeychain(TransactionCase):
         try:
             account.write({"login": "test default"})
         except ValidationError:
-            self.assertTrue(False, 'It should validate any json in default')
+            self.fail('It should validate any json in default')
 
         self.assertEqual(
             account.data, account._serialize_data(

--- a/keychain/tests/test_keychain.py
+++ b/keychain/tests/test_keychain.py
@@ -221,3 +221,24 @@ class TestKeychain(TransactionCase):
                 self.assertTrue(True, 'Should validate json')
             except:
                 self.assertTrue(False, 'It should validate a good json')
+
+    def test_default_init_and_valid(self):
+        """."""
+        self.keychain._fields['namespace'].selection.append(
+            ('keychain_test_default', 'test')
+        )
+        account = self.keychain.create({
+            "name": "test",
+            "namespace": "keychain_test_default",
+            "login": "test",
+            "technical_name": "keychain.test"
+        })
+        try:
+            account.write({"login": "test default"})
+        except ValidationError:
+            self.assertTrue(False, 'It should validate any json in default')
+
+        self.assertEqual(
+            account.data, account._serialize_data(
+                account._default_init_data()),
+            'Data should be default value')


### PR DESCRIPTION
For each keychain implementation (namespace), you have to define what data you expect and validate it.

Before :
If you don't use any data in your namespace: you still have to define these methods (initalize and validate)

After:
If you don't use any data in your namespace, no initialize and no validate method to write (there is default methods)

More info : 
The goal was to force developers to write validation logic.
Now it's becoming useless with keychain.backend
And it adds boilerplate code.

In this commit, we set a permissive default validation logic.
It will reduce code in consumers module and still allow fine grained validation.