### PR TITLE
[10.0] module auto update: add post condition check

### DIFF
--- a/module_auto_update/__manifest__.py
+++ b/module_auto_update/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Module Auto Update',
     'summary': 'Automatically update Odoo modules',
-    'version': '10.0.2.0.1',
+    'version': '10.0.2.0.2',
     'category': 'Extra Tools',
     'website': 'https://github.com/OCA/server-tools',
     'author': 'LasLabs, '


### PR DESCRIPTION
In rare situations [1], button_upgrade would fail without exception, this would lead to corruption because no upgrade would be performed and save_installed_checksums would update cheksums for modules that have not been upgraded.

So I add a post condition check to be sure (ie state = 'to upgrade').

[1] Seen this when trying to run module_auto_upgrade on a database with a module trying to add a field on res_partner, which led to an error obtaining the context for the user.