### PR TITLE
[FIX] auth_brute_force: Small typos

### DIFF
--- a/auth_brute_force/__manifest__.py
+++ b/auth_brute_force/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Authentification - Brute-Force Filter',
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.1.0',
     'category': 'Tools',
     'summary': "Track Authentication Attempts and Prevent Brute-force Attacks",
     'author': "GRAP, "

--- a/auth_brute_force/views/view.xml
+++ b/auth_brute_force/views/view.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <tree
                 decoration-warning="result == 'failed'"
-                decoration-error="result == 'banned'"
+                decoration-danger="result == 'banned'"
             >
                 <field name="create_date"/>
                 <field name="remote"/>
@@ -44,6 +44,7 @@
                         <field name="login"/>
                         <field name="remote"/>
                         <field name="remote_metadata"/>
+                        <field name="whitelisted" invisible="1"/>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
- The `whitelisted` field needs to exist in view to be usable.
- The correct class is `decoration-danger` for tree views.

@Tecnativa