### PR TITLE
[FIX] auth_brute_force: Fix addon requirement computation

### DIFF
--- a/auth_brute_force/__manifest__.py
+++ b/auth_brute_force/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Authentification - Brute-Force Filter',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.1.1',
     'category': 'Tools',
     'summary': "Track Authentication Attempts and Prevent Brute-force Attacks",
     'author': "GRAP, "

--- a/auth_brute_force/tests/test_brute_force.py
+++ b/auth_brute_force/tests/test_brute_force.py
@@ -5,6 +5,7 @@
 from threading import current_thread
 from urllib import urlencode
 
+from decorator import decorator
 from mock import patch
 from werkzeug.utils import redirect
 
@@ -33,6 +34,7 @@ def skip_unless_addons_installed(*addons):
         Explain why you must skip this test.
     """
 
+    @decorator
     def _wrapper(method, self, *args, **kwargs):
         installed = self.addons_installed(*addons)
         if not installed:


### PR DESCRIPTION
Include HACK for https://github.com/odoo/odoo/pull/24833, which explains the false positive problem we were having here: an addon being importable doesn't mean it is installed.

@Tecnativa