### PR TITLE
[FIX] module_auto_update: Ignore `__pycache__` in hash test

### DIFF
--- a/module_auto_update/__manifest__.py
+++ b/module_auto_update/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Module Auto Update',
     'summary': 'Automatically update Odoo modules',
-    'version': '11.0.2.0.2',
+    'version': '11.0.2.0.3',
     'category': 'Extra Tools',
     'website': 'https://github.com/OCA/server-tools',
     'author': 'LasLabs, '

--- a/module_auto_update/tests/test_addon_hash.py
+++ b/module_auto_update/tests/test_addon_hash.py
@@ -21,7 +21,7 @@ class TestAddonHash(unittest.TestCase):
     def test_basic(self):
         files = list(addon_hash._walk(
             self.sample_dir,
-            exclude_patterns=[],
+            exclude_patterns=["*/__pycache__/*"],
             keep_langs=[],
         ))
         self.assertEqual(files, [


### PR DESCRIPTION
Python >= 3.2 implements [PEP 3147](https://www.python.org/dev/peps/pep-3147/), so in a precompiled environment, the patched test could fail with this or similar:

    FAIL: test_basic (odoo.addons.module_auto_update.tests.test_addon_hash.TestAddonHash)
    Traceback (most recent call last):
    `   File "/opt/odoo/auto/addons/module_auto_update/tests/test_addon_hash.py", line 42, in test_basic
    `     'static/src/some.js',
    ` AssertionError: Lists differ: ['REA[237 chars]o', 'models/__pycache__/stuff.cpython-35.opt-1[23 chars].js'] != ['REA[237 chars]o', 'static/src/some.js']
    `
    ` First differing element 14:
    ` 'models/__pycache__/stuff.cpython-35.opt-1.pyc'
    ` 'static/src/some.js'
    `
    ` First list contains 1 additional elements.
    ` First extra element 15:
    ` 'static/src/some.js'
    `
    `   ['README.rst',
    `    'data/f1.xml',
    `    'data/f2.xml',
    `    'i18n/en.po',
    `    'i18n/en_US.po',
    `    'i18n/fr.po',
    `    'i18n/fr_BE.po',
    `    'i18n/test.pot',
    `    'i18n_extra/en.po',
    `    'i18n_extra/fr.po',
    `    'i18n_extra/nl_NL.po',
    `    'models/stuff.py',
    `    'models/stuff.pyc',
    `    'models/stuff.pyo',
    ` -  'models/__pycache__/stuff.cpython-35.opt-1.pyc',
    `    'static/src/some.js']

With this patch, we fix all those failing tests in integration environments.

@Tecnativa