### PR TITLE
[FIX] password_security: Create user as admin in tests

### DIFF
--- a/password_security/__manifest__.py
+++ b/password_security/__manifest__.py
@@ -5,7 +5,7 @@
 
     'name': 'Password Security',
     "summary": "Allow admin to set password security requirements.",
-    'version': '10.0.1.1.3',
+    'version': '10.0.1.1.4',
     'author': "LasLabs, Odoo Community Association (OCA)",
     'category': 'Base',
     'depends': [

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -4,48 +4,49 @@
 
 import time
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import at_install, post_install, SavepointCase
 
 from ..exceptions import PassError
 
 
-class TestResUsers(TransactionCase):
+@at_install(False)
+@post_install(True)
+class TestResUsers(SavepointCase):
 
-    def setUp(self):
-        super(TestResUsers, self).setUp()
-        self.main_comp = self.env.ref('base.main_company')
+    def setUp(cls):
+        super(TestResUsers, cls).setUp()
+        cls.main_comp = cls.env.ref('base.main_company')
         # Modify users as privileged, but non-root user
-        privileged_user = self.env['res.users'].create({
+        cls.privileged_user = cls.env['res.users'].create({
             'name': 'Privileged User',
             'login': 'privileged_user@example.com',
-            'company_id': self.main_comp.id,
+            'company_id': cls.main_comp.id,
             'groups_id': [
-                (4, self.env.ref('base.group_erp_manager').id),
-                (4, self.env.ref('base.group_partner_manager').id),
-                (4, self.env.ref('base.group_user').id),
+                (4, cls.env.ref('base.group_erp_manager').id),
+                (4, cls.env.ref('base.group_partner_manager').id),
+                (4, cls.env.ref('base.group_user').id),
             ],
         })
-        privileged_user.email = privileged_user.login
-        self.env = self.env(user=privileged_user)
-        self.login = 'foslabs@example.com'
-        self.partner_vals = {
+        cls.privileged_user.email = cls.privileged_user.login
+        cls.login = 'foslabs@example.com'
+        cls.partner_vals = {
             'name': 'Partner',
             'is_company': False,
-            'email': self.login,
+            'email': cls.login,
         }
-        self.password = 'asdQWE123$%^'
-        self.vals = {
+        cls.password = 'asdQWE123$%^'
+        cls.vals = {
             'name': 'User',
-            'login': self.login,
-            'password': self.password,
-            'company_id': self.main_comp.id
+            'login': cls.login,
+            'password': cls.password,
+            'company_id': cls.main_comp.id
         }
-        self.model_obj = self.env['res.users']
+        cls.model_obj = cls.env['res.users']
 
     def _new_record(self):
         partner_id = self.env['res.partner'].create(self.partner_vals)
         self.vals['partner_id'] = partner_id.id
-        return self.model_obj.create(self.vals)
+        return self.model_obj.create(self.vals).sudo(self.privileged_user)
 
     def test_password_write_date_is_saved_on_create(self):
         rec_id = self._new_record()


### PR DESCRIPTION
If you test this addon after installing `partner_event`, you get this error in all tests:

    ERROR: test_validate_pass_reset_error (odoo.addons.password_security.tests.test_res_users.TestResUsers)
    ` It should throw PassError on reset inside min threshold
    Traceback (most recent call last):
    `   File "/opt/odoo/auto/addons/password_security/tests/test_res_users.py", line 143, in test_validate_pass_reset_error
    `     rec_id = self._new_record()
    `   File "/opt/odoo/auto/addons/password_security/tests/test_res_users.py", line 46, in _new_record
    `     partner_id = self.env['res.partner'].create(self.partner_vals)
    `   File "/opt/odoo/auto/addons/mail_tracking_mailgun/models/res_partner.py", line 154, in create
    `     return super(ResPartner, self).create(vals)
    `   File "/opt/odoo/auto/addons/partner_firstname/models/res_partner.py", line 54, in create
    `     return super(ResPartner, self.with_context(context)).create(vals)
    `   File "/opt/odoo/custom/src/odoo/odoo/addons/base/res/res_partner.py", line 532, in create
    `     partner = super(Partner, self).create(vals)
    `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 228, in create
    `     thread = super(MailThread, self).create(values)
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3847, in create
    `     record = self.browse(self._create(old_vals))
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4006, in _create
    `     self.recompute()
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5336, in recompute
    `     vals = rec._convert_to_write({n: rec[n] for n in ns})
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5336, in <dictcomp>
    `     vals = rec._convert_to_write({n: rec[n] for n in ns})
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5232, in __getitem__
    `     return self._fields[key].__get__(self, type(self))
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 918, in __get__
    `     value = record._cache[self]
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5584, in __getitem__
    `     return value.get() if isinstance(value, SpecialValue) else value
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 48, in get
    `     raise self.exception
    ` AccessError: (u'Sorry, you are not allowed to access this document. Only users with the following access level are currently allowed to do that:\n- Events/User\n\n(Document model: event.registration)', None)

Since creating users or partners in tests has a very high probability to collide with other addons, this test is being moved to post mode.

Also, to avoid the above permissions issue, the partner is actually created through the admin user, which actually has permissions to read everything. Then, it is `.sudo()`ed later, to perform the module tests correctly. The tests do not get affected because what is being tested was not [intended to be] the partner creation itself, but the password policy enforcement.

@Tecnativa