### PR TITLE
[FIX] auth_brute_force: Avoid storing false login attempts

### DIFF
--- a/auth_brute_force/__openerp__.py
+++ b/auth_brute_force/__openerp__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Authentification - Brute-Force Filter',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'category': 'Tools',
     'summary': "Track Authentication Attempts and Prevent Brute-force Attacks",
     'author': "GRAP, "

--- a/auth_brute_force/models/res_authentication_attempt.py
+++ b/auth_brute_force/models/res_authentication_attempt.py
@@ -30,7 +30,6 @@ class ResAuthenticationAttempt(models.Model):
     remote_metadata = fields.Text(
         string="Remote IP metadata",
         compute='_compute_metadata',
-        store=True,
         help="Metadata publicly available for remote IP",
     )
     whitelisted = fields.Boolean(

--- a/auth_brute_force/models/res_users.py
+++ b/auth_brute_force/models/res_users.py
@@ -120,10 +120,6 @@ class ResUsers(models.Model):
                 db, login, password, user_agent_env),
         )
 
-    def check(self, db, uid, passwd):
-        with self._auth_attempt(uid):
-            return super(ResUsers, self).check(db, uid, passwd)
-
     @api.model
     def check_credentials(self, password):
         """This is the most important and specific auth check method.

--- a/auth_brute_force/views/action.xml
+++ b/auth_brute_force/views/action.xml
@@ -7,7 +7,7 @@
             <field name="name">Authentication Attempts</field>
             <field name="res_model">res.authentication.attempt</field>
             <field name="view_type">form</field>
-            <field name="view_mode">tree,graph</field>
+            <field name="view_mode">tree,form,graph</field>
             <field name="context">{"search_default_filter_no_success":1}</field>
         </record>
 


### PR DESCRIPTION
In Odoo v9, every request calls `res.users.check()`, which stores one authentication attempt per request, which is false.

Besides, it easily leads to hitting ip-api.com rate limits, so now that API is only asked when seeing in form view (simply by setting the computed field as not stored).

Also, form view was hidden, so it's now visible.

@Tecnativa