### PR TITLE
[8.0] [REF] Mail Environment: remove dependency on server_environment_files

### DIFF
--- a/mail_environment/__openerp__.py
+++ b/mail_environment/__openerp__.py
@@ -62,7 +62,6 @@ password = openerp
     'depends': ['mail',
                 'fetchmail',
                 'server_environment',
-                'server_environment_files',
                 ],
     'data': ['mail_view.xml'],
     'demo': [],


### PR DESCRIPTION
In the same logic as https://github.com/OCA/server-env/issues/10

Already done in 10.0 (and 11.0) in 1c0e6a67a8d4cca07890c3f1b1ce6f4fa79bfca1

9.0 PR : https://github.com/OCA/server-tools/pull/1282