### PR TITLE
[9.0] [REF] Mail Environment: remove dependency on server_environment_files

### DIFF
--- a/mail_environment/__openerp__.py
+++ b/mail_environment/__openerp__.py
@@ -26,7 +26,6 @@
     'website': 'http://odoo-community.org',
     'depends': ['fetchmail',
                 'server_environment',
-                'server_environment_files',
                 ],
     'data': ['mail_view.xml'],
     'installable': True,


### PR DESCRIPTION
In the same logic as https://github.com/OCA/server-env/issues/10

Already done in 10.0 (and 11.0) in 1c0e6a67a8d4cca07890c3f1b1ce6f4fa79bfca1

8.0 PR : https://github.com/OCA/server-tools/pull/1281