### PR TITLE
[10.0][IMP] users_ldap_populate. Log failing filter if populate error...

### DIFF
--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2012 Therp BV (<http://therp.nl>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/gpl.html).
+# Copyright 2012 Therp BV (<https://therp.nl>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/gpl.html).
 
 import re
 
@@ -125,9 +125,14 @@ class CompanyLDAP(models.Model):
         conn = self.connect(conf)
         conn.simple_bind_s(conf['ldap_binddn'] or '',
                            conf['ldap_password'] or '')
-        results = conn.search_st(conf['ldap_base'], ldap.SCOPE_SUBTREE,
-                                 ldap_filter.encode('utf8'), None,
-                                 timeout=timeout)
+        try:
+            results = conn.search_st(
+                conf['ldap_base'], ldap.SCOPE_SUBTREE,
+                ldap_filter.encode('utf8'), None, timeout=timeout)
+        except Exception:
+            _logger.error(_(
+                'Error searching with filter %s'), ldap_filter, exc_info=True)
+            raise
         conn.unbind()
         return results
 

--- a/users_ldap_populate/tests/test_users_ldap_populate.py
+++ b/users_ldap_populate/tests/test_users_ldap_populate.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 Therp BV <https://therp.nl>.
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from openerp.tests.common import TransactionCase
+# Copyright 2016-2019 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+# pylint: disable=missing-docstring
 from contextlib import contextmanager
+from odoo.tests.common import TransactionCase
 
 
 class PatchLDAPConnection(object):
+    # pylint: disable=no-self-use,unused-argument,too-many-arguments
     def __init__(self, results):
         self.results = results
 
@@ -15,21 +17,20 @@ class PatchLDAPConnection(object):
     def search_st(self, base, scope, ldap_filter, attributes, timeout=None):
         if ldap_filter == '(uid=*)':
             return self.results
-        else:
-            return []
+        raise Exception("Invalid filter %s" % ldap_filter)
 
     def unbind(self):
         return True
 
 
 @contextmanager
-def patch_ldap(self, results):
+def patch_ldap(results):
     """ defuse ldap functions to return fake entries instead of talking to a
     server. Use this in your own ldap related tests """
     import ldap
     original_initialize = ldap.initialize
 
-    def initialize(uri):
+    def initialize(uri):  # pylint: disable=unused-argument
         return PatchLDAPConnection(results)
     ldap.initialize = initialize
     yield
@@ -55,17 +56,27 @@ def get_fake_ldap(self):
     )
 
 
+EXPECTED_RESULTS = [
+    ('DN=fake', {
+        'cn': ['fake'],
+        'uid': ['fake'],
+        'mail': ['fake@fakery.com']})]
+
+
 class TestUsersLdapPopulate(TransactionCase):
 
-    def test_users_ldap_populate(self):
-        with patch_ldap(self, [('DN=fake', {
-            'cn': ['fake'],
-            'uid': ['fake'],
-            'mail': ['fake@fakery.com'],
-        })]):
+    def test_populate(self):
+        with patch_ldap(EXPECTED_RESULTS):
             get_fake_ldap(self).populate_wizard()
             self.assertFalse(self.env.ref('base.user_demo').active)
             self.assertTrue(self.env.ref('base.user_root').active)
             self.assertTrue(self.env['res.users'].search([
                 ('login', '=', 'fake')
             ]))
+
+    def test_populate_exception(self):
+        with patch_ldap(EXPECTED_RESULTS):
+            fake_ldap = get_fake_ldap(self)
+            fake_ldap.ldap_filter = '(not_a_uid=%s)'
+            with self.assertRaises(Exception):
+                fake_ldap.populate_wizard()


### PR DESCRIPTION
It can be difficult to see what the failing filter (if any) is if any error occurs during ldap population. 

This PR adds the failing filter to the server log, then reraises the original exception.