### PR TITLE
[FIX] auth_admin_passkey : AccessError sending mail

### DIFF
--- a/auth_admin_passkey/__manifest__.py
+++ b/auth_admin_passkey/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Authentification - Admin Passkey',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'base',
     'author': "GRAP,Odoo Community Association (OCA)",
     'website': 'http://www.grap.coop',

--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -19,7 +19,7 @@ class ResUsers(models.Model):
         mail_obj = self.env['mail.mail'].sudo()
         icp_obj = self.env['ir.config_parameter']
 
-        admin_user = self.browse(SUPERUSER_ID)
+        admin_user = self.sudo().browse(SUPERUSER_ID)
         login_user = self.browse(user_id)
 
         send_to_admin = safe_eval(


### PR DESCRIPTION
Hi all, 
during the process of sending the email, the admin user is browsed by the current user. This can raise undesired AccessError if the admin user is not accessible by the current user at line 33. (try to access to  admin_user.email).

this trivial patch fixes this problem.

Thanks for your review.

regards.

CC : @sebalix, @Fenkiou