### PR TITLE
[9.0][FIX] sql_request_abstract: mogrify doesn't allow dicts

### DIFF
--- a/sql_request_abstract/__openerp__.py
+++ b/sql_request_abstract/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'SQL Request Abstract',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'author': 'GRAP,Akretion,Odoo Community Association (OCA)',
     'website': 'https://www.odoo-community.org',
     'license': 'AGPL-3',

--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -144,8 +144,10 @@ class SQLRequestMixin(models.AbstractModel):
         if mode in ('view', 'materialized_view'):
             rollback = False
 
-        params = params and params or {}
-        query = self.env.cr.mogrify(self.query, params).decode('utf-8')
+        params = params or {}
+        # pylint: disable=sql-injection
+        query = self.query % params
+        query = query.decode('utf-8')
 
         if mode in ('fetchone', 'fetchall'):
             pass


### PR DESCRIPTION
A fix cheery-picked from https://github.com/OCA/server-tools/pull/1047/commits/733364656d4b1f74db2cdce15bcc37aa43e6432a (https://github.com/OCA/server-tools/pull/1047). `Mogrify` allows a _list_ as parameter but not a _dict_, and a list is not useful here. Thus, `mogrify` is substituted by something more suited.