### PR TITLE
[FIX] doesn't try to replace params if they are no args

### DIFF
--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -144,9 +144,11 @@ class SQLRequestMixin(models.AbstractModel):
         if mode in ('view', 'materialized_view'):
             rollback = False
 
-        params = params or {}
         # pylint: disable=sql-injection
-        query = self.query % params
+        if params:
+            query = self.query % params
+        else:
+            query = self.query
         query = query.decode('utf-8')
 
         if mode in ('fetchone', 'fetchall'):


### PR DESCRIPTION
In some cases, the query contains the char ```%```. (with ilike request for exemple).
this will fail, when trying to replace with params.
This trivial patch fixes this bug if they are no params. (if not, query should be escaped).

Sample

```
SELECT
    name as x_name,
    case
        when author ilike '%OpenERP SA%' THEN 'Odoo SA'
        when author ilike '%Odoo Community Association (OCA)%' THEN 'OCA'
       else 'Undefined Author' END as x_author_type
FROM ir_module_module
```