### PR TITLE
[IMP] purge uninstalled unavailable modules in bulk

### DIFF
--- a/database_cleanup/models/purge_modules.py
+++ b/database_cleanup/models/purge_modules.py
@@ -63,15 +63,18 @@ class CleanupPurgeWizardModule(models.TransientModel):
     @api.model
     def find(self):
         res = []
+        purge_lines = self.env['cleanup.purge.line.module']
         for module in self.env['ir.module.module'].search([]):
             if get_module_path(module.name):
                 continue
             if module.state == 'uninstalled':
-                self.env['cleanup.purge.line.module'].create({
+                purge_lines += self.env['cleanup.purge.line.module'].create({
                     'name': module.name,
-                }).purge()
+                })
                 continue
             res.append((0, 0, {'name': module.name}))
+
+        purge_lines.purge()
 
         if not res:
             raise UserError(_('No modules found to purge'))


### PR DESCRIPTION
without this, you'll have to wait unnecessarily long for the wizard to start in case there are a lot of uninstallable modules to purge, because purging causes a full registry reload, which costs a lot of time. Doing it in bulk will cause only one registry reload for all modules.