### PR TITLE
[10.0][FIX] base_exception: add active_model in returned action

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -97,6 +97,7 @@ class BaseException(models.AbstractModel):
         action = action.read()[0]
         action.update({
             'context': {
+                'active_model': self._name,
                 'active_id': self.ids[0],
                 'active_ids': self.ids
             }


### PR DESCRIPTION
The active modle is not propagated at the same time than active_id and active_ids.
In some particular cases it causes some troubles.