### PR TITLE
New module auth_ldap_multi_login

### DIFF
--- a/auth_ldap_multi_login/__init__.py
+++ b/auth_ldap_multi_login/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/auth_ldap_multi_login/__manifest__.py
+++ b/auth_ldap_multi_login/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Ldap multi login",
+
+    'summary': """
+        The module allows you to specify several fields in ldap to find the entered login""",
+
+    'description': """
+        The module allows you to specify several fields in ldap to find the entered login.
+        Also you can specify which ldap field to use as the login when creating the user Odoo.
+    """,
+    'author': "RYDLAB",
+    'category': 'Tools',
+    'version': '1.0',
+    'depends': ['base', 'auth_ldap'],
+    'data': [
+        'views/users_ldap_view.xml',
+    ],
+}

--- a/auth_ldap_multi_login/models/__init__.py
+++ b/auth_ldap_multi_login/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import res_company_ldap
+from . import res_users

--- a/auth_ldap_multi_login/models/res_company_ldap.py
+++ b/auth_ldap_multi_login/models/res_company_ldap.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import ldap
+import logging
+from re import findall
+from ldap.filter import filter_format
+
+from odoo import api, fields, models, tools
+
+_logger = logging.getLogger(__name__)
+
+
+class UsersLdapRoles(models.Model):
+    _inherit = 'res.company.ldap'
+
+    login_attribute = fields.Char(
+        'Login attribute', _defaults='uid',
+        help="LDAP attribute to use to retrieve login address.")
+
+    def authenticate(self, conf, login, password):
+        """
+        Authenticate a user against the specified LDAP server.
+        In order to prevent an unintended 'unauthenticated authentication',
+        which is an anonymous bind with a valid dn and a blank password,
+        check for empty passwords explicitely (:rfc:`4513#section-6.3.1`)
+        added the ability to search for a login on several fields ldap
+        :param dict conf: LDAP configuration
+        :param login: username
+        :param password: Password for the LDAP user
+        :return: LDAP entry of authenticated user or False
+        :rtype: dictionary of attributes
+        """
+        if not password:
+            return False
+        entry = False
+        user = self.env['res.users'].search([('active', '=', True), ('login', '=', login)])
+        _logger.debug(u'User with login %s found %s, last ldap login - %s' % (login, user.id, user.last_ldap_login))
+        if user and user.last_ldap_login:
+            login = user.last_ldap_login
+        try:
+            match_count = len(findall(r'[^%](%s)', conf['ldap_filter']))
+            filter = filter_format(conf['ldap_filter'], (login,) * match_count)
+        except TypeError:
+            _logger.warning('Could not format LDAP filter. Your filter should contain one \'%s\'.')
+            return False
+        try:
+            results = self.query(conf, tools.ustr(filter))
+            # Get rid of (None, attrs) for searchResultReference replies
+            results = [i for i in results if i[0]]
+            if len(results) == 1:
+                dn = results[0][0]
+                conn = self.connect(conf)
+                conn.simple_bind_s(dn, password.encode('utf-8'))
+                conn.unbind()
+                entry = results[0]
+        except ldap.INVALID_CREDENTIALS:
+            return False
+        except ldap.LDAPError, e:
+            _logger.error('An LDAP exception occurred: %s', e)
+        return entry
+
+    @api.model
+    def get_or_create_user(self, conf, ldap_login, ldap_entry):
+        immutable_ldap_login = ldap_login
+        if conf['login_attribute']:
+            user_login = ldap_entry[1][conf['login_attribute']][0]
+            if user_login:
+                ldap_login = user_login
+        user_id = super(UsersLdapRoles, self).get_or_create_user(conf, ldap_login, ldap_entry)
+        if user_id:
+            self.env['res.users'].browse(user_id).write({
+                'last_ldap_login': immutable_ldap_login,
+            })
+        return user_id

--- a/auth_ldap_multi_login/models/res_users.py
+++ b/auth_ldap_multi_login/models/res_users.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    last_ldap_login = fields.Char(string=u"Ldap login", readonly=True)

--- a/auth_ldap_multi_login/views/users_ldap_view.xml
+++ b/auth_ldap_multi_login/views/users_ldap_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record model="ir.ui.view" id="auth_ldap_multi_login_form">
+        <field name="name">Add login attributes to ldap view</field>
+        <field name="model">base.config.settings</field>
+        <field name="inherit_id" ref="auth_ldap.view_general_configuration_form_inherit_auth_ldap"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ldap_filter']" position="after">
+                <field name="login_attribute"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Sometimes while using LDAP there is a need to use complex filters to find user in LDAP. Also users can use several ids (login/email/phone) to login.
This module (`auth_ldap_multi_login`) allow create a custom LDAP filters with multiple user's logins like `(|(email=%s)(phone=%s))` and allows to choose which LDAP attribute odoo must use as login.