### PR TITLE
scheduler_error_mailer: fix version in manifest

### DIFF
--- a/scheduler_error_mailer/__manifest__.py
+++ b/scheduler_error_mailer/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Scheduler Error Mailer',
-    'version': '10.0.1.0.0',
+    'version': '11.0.1.0.0',
     'category': 'Extra Tools',
     'license': 'AGPL-3',
     'author': "Akretion,Sodexis,Odoo Community Association (OCA)",


### PR DESCRIPTION
I thought we had a lint check for that.