### PR TITLE
[DUMMY] Revert "scheduler_error_mailer: fix version in manifest"

### DIFF
--- a/scheduler_error_mailer/__manifest__.py
+++ b/scheduler_error_mailer/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Scheduler Error Mailer',
-    'version': '11.0.1.0.0',
+    'version': '10.0.1.0.0',
     'category': 'Extra Tools',
     'license': 'AGPL-3',
     'author': "Akretion,Sodexis,Odoo Community Association (OCA)",


### PR DESCRIPTION
This reverts commit e944699093ba29a08880617e3f468d02a9934a99.

This is to test if the lintmanifest-version-format  is triggered after
the fix  https://github.com/OCA/pylint-odoo/commit/6b1f1e1bfaf