### PR TITLE
[10.0][ADD]  Exception type as warning

### DIFF
--- a/base_exception/views/base_exception_view.xml
+++ b/base_exception/views/base_exception_view.xml
@@ -7,8 +7,10 @@
             <field name="arch" type="xml">
                 <tree string="Exception Rule">
                     <field name="active"/>
+                    <field name="warning_only"/>
                     <field name="name"/>
                     <field name="description"/>
+                    <field name="warning_text"/>
                     <field name="model"/>
                     <field name="sequence"/>
                 </tree>
@@ -36,6 +38,10 @@
                         <field name="code"
                                attrs="{'invisible': [('exception_type','!=','by_py_code')], 'required': [('exception_type','=','by_py_code')]}"/>
                         <field name="active"/>
+                    </group>
+                    <group colspan="4" col="2" groups="base.group_system">
+                      <field name="warning_only"/>
+                      <field name="warning_text"/>
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
Allow to tag an exception as a warning. Contrary to a regular exception
a warning will be raised but not be blocking.