### PR TITLE
[Fix] dot in report name is not mandatory

### DIFF
--- a/base_report_auto_create_qweb/models/report_xml.py
+++ b/base_report_auto_create_qweb/models/report_xml.py
@@ -59,11 +59,11 @@ class IrActionsReport(models.Model):
     def create(self, values):
         values['report_name'] = self._format_template_name(
             values.get('report_name', ''))
-        if (values.get('report_type') in ['qweb-pdf', 'qweb-html'] and
-                values.get('report_name') and
-                values['report_name'].find('.') == -1):
-            raise exceptions.Warning(
-                _("Template Name must contain at least a dot in it's name"))
+#         if (values.get('report_type') in ['qweb-pdf', 'qweb-html'] and
+#                 values.get('report_name') and
+#                 values['report_name'].find('.') == -1):
+#             raise exceptions.Warning(
+#                 _("Template Name must contain at least a dot in it's name"))
         if not self.env.context.get('enable_duplication', False):
             return super(IrActionsReport, self).create(values)
         report_xml = super(IrActionsReport, self).create(values)


### PR DESCRIPTION
Create requires that report name has at least one dot in it, however in core Odoo there are reports that do not have any and thus fail migration eg. mrp_bom_cost in mrp module.