### PR TITLE
[9.0] [REF] Server Environment: secret keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # Installer logs
 pip-log.txt

--- a/server_environment/README.rst
+++ b/server_environment/README.rst
@@ -15,7 +15,8 @@ module.
 
 All the settings will be read only and visible under the Configuration
 menu.  If you are not in the 'dev' environment you will not be able to
-see the values contained in keys named '*passw*'.
+see the values contained in the defined secret keys
+(by default : '*passw*', '*key*', '*secret*' and '*token*').
 
 Installation
 ============

--- a/server_environment/__openerp__.py
+++ b/server_environment/__openerp__.py
@@ -29,6 +29,7 @@
     "license": "GPL-3 or any later version",
     "category": "Tools",
     "data": [
+        'security/res_groups.xml',
         'serv_config.xml',
     ],
     'installable': True,

--- a/server_environment/security/res_groups.xml
+++ b/server_environment/security/res_groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<odoo>
+
+    <record model="res.groups" id="has_server_configuration_access">
+        <field name="name">View Server Environment Configuration</field>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    </record>
+
+</odoo>

--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -25,7 +25,7 @@ import ConfigParser
 from lxml import etree
 from itertools import chain
 
-from openerp import models, fields
+from openerp import api, models, fields
 from openerp.tools.config import config as system_base_config
 
 from .system_info import get_server_environment
@@ -246,6 +246,16 @@ class ServerConfiguration(models.TransientModel):
             res['fields'] = xfields
         return res
 
+    @api.model
+    def _is_secret(self, key):
+        """
+        This method is intended to be inherited to defined which keywords
+        should be secret.
+        :return: list of secret keywords
+        """
+        secret_keys = ['passw', 'key', 'secret', 'token']
+        return any(secret_key in key for secret_key in secret_keys)
+
     def default_get(self, cr, uid, fields_list, context=None):
         res = {}
         current_user = self.pool['res.users'].browse(
@@ -254,7 +264,8 @@ class ServerConfiguration(models.TransientModel):
                 'server_environment.has_server_configuration_access'):
             return res
         for key in self._conf_defaults:
-            if 'passw' in key and not self.show_passwords:
+            if not self.show_passwords and self._is_secret(
+                    cr, uid, context=context, key=key):
                 res[key] = '**********'
             else:
                 res[key] = self._conf_defaults[key]()

--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -248,6 +248,11 @@ class ServerConfiguration(models.TransientModel):
 
     def default_get(self, cr, uid, fields_list, context=None):
         res = {}
+        current_user = self.pool['res.users'].browse(
+            cr, uid, uid, context=context)
+        if not current_user.has_group(
+                'server_environment.has_server_configuration_access'):
+            return res
         for key in self._conf_defaults:
             if 'passw' in key and not self.show_passwords:
                 res[key] = '**********'


### PR DESCRIPTION
This PR:
 - restricts access to server configuration to a new security group (Admin is part of it by default)
 - allows to define which keys of the server configuration must be hidden in other environments than DEV