### PR TITLE
[9.0][IMP] auth_totp: Secret key visible in wizard

### DIFF
--- a/auth_totp/__openerp__.py
+++ b/auth_totp/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'MFA Support',
     'summary': 'Allows users to enable MFA and add optional trusted devices',
-    'version': '9.0.1.0.1',
+    'version': '9.0.1.1.0',
     'category': 'Extra Tools',
     'website': 'https://laslabs.com/',
     'author': 'LasLabs, Odoo Community Association (OCA)',

--- a/auth_totp/wizards/res_users_authenticator_create.py
+++ b/auth_totp/wizards/res_users_authenticator_create.py
@@ -29,6 +29,7 @@ class ResUsersAuthenticatorCreate(models.TransientModel):
         index=True,
     )
     secret_key = fields.Char(
+        string='Secret Code',
         default=lambda s: pyotp.random_base32(),
         required=True,
     )

--- a/auth_totp/wizards/res_users_authenticator_create.xml
+++ b/auth_totp/wizards/res_users_authenticator_create.xml
@@ -20,9 +20,9 @@
                     <group name="data">
                         <field name="name"/>
                         <field name="user_id"/>
+                        <field name="secret_key" readonly="1"/>
                         <field name="qr_code_tag"/>
                         <field name="confirmation_code"/>
-                        <field name="secret_key" invisible="1"/>
                     </group>
                 </sheet>
                 <footer>

--- a/auth_totp/wizards/res_users_authenticator_create.xml
+++ b/auth_totp/wizards/res_users_authenticator_create.xml
@@ -15,7 +15,7 @@
                 <sheet>
                     <div>
                         <span>Please provide a name for your app/device. </span>
-                        <span>Then scan the QR code below to add this account to your authenticator app and enter in the six digit code produced by the app.</span>
+                        <span>Then scan the QR code or enter the secret code below to add this account to your authenticator app and enter in the six digit code produced by the app.</span>
                     </div>
                     <group name="data">
                         <field name="name"/>


### PR DESCRIPTION
Hello everyone,

this change should allow the usage of the module for more categories of devices to generate the confirmation codes. I'm currently working with an USB stick to generate the confirmation codes and therefore I have to enter the secret key in the configuration. This change shouldn't decrease the security because the secret key is already visible in the QR code.