### PR TITLE
[FIX] add and remove modules to/from graph one by one to avoid race conditions

### DIFF
--- a/base_manifest_extension/hooks.py
+++ b/base_manifest_extension/hooks.py
@@ -91,4 +91,4 @@ def post_load_hook():
             to_reload.append(node.name)
     for module_name in to_reload:
         del graph[module_name]
-    graph.add_modules(cr, to_reload)
+        graph.add_module(cr, module_name)


### PR DESCRIPTION
if we remove a big amount of modules, chances are they won't be added to the graph because we already removed some dependency of it. Removing modules and adding them one by one solves this issue