### PR TITLE
[FIX] Sentry: str.split can't parse options dsn value when its unicode

### DIFF
--- a/sentry/const.py
+++ b/sentry/const.py
@@ -2,6 +2,7 @@
 # Copyright 2016-2017 Versada <https://versada.eu/>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import string
 import collections
 import logging
 
@@ -70,7 +71,7 @@ def select_transport(name=DEFAULT_TRANSPORT):
 
 def get_sentry_options():
     return [
-        SentryOption('dsn', '', str.strip),
+        SentryOption('dsn', '', string.strip),
         SentryOption('install_sys_hook', False, None),
         SentryOption('transport', DEFAULT_TRANSPORT, select_transport),
         SentryOption('include_paths', '', split_multiple),


### PR DESCRIPTION
when i use sentry module and run a cron job, i got an error:
```
  File ".../sentry/__init__.py", line 78, in <module>
    sentry_client = initialize_raven(odoo_config)
  File ".../sentry/__init__.py", line 50, in initialize_raven
    value = option.converter(value)
TypeError: descriptor 'strip' requires a 'str' object but received a 'unicode'
```
this because in python2, str.split can't use for 'unicode' and i change to string.split to fix it