### PR TITLE
[FIX] 11.0 auto_backup: .dump files not being cleaned

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -232,18 +232,21 @@ class DbBackup(models.Model):
         now = datetime.now()
         for rec in self.filtered("days_to_keep"):
             with rec.cleanup_log():
-                oldest = self.filename(now - timedelta(days=rec.days_to_keep))
+                bu_format = rec.backup_format
+                file_extension = bu_format == 'zip' and 'dump.zip' or bu_format
+                oldest = self.filename(now - timedelta(days=rec.days_to_keep),
+                                       bu_format)
 
                 if rec.method == "local":
                     for name in iglob(os.path.join(rec.folder,
-                                                   "*.dump.zip")):
+                                                   '*.%s' % file_extension)):
                         if os.path.basename(name) < oldest:
                             os.unlink(name)
 
                 elif rec.method == "sftp":
                     with rec.sftp_connection() as remote:
                         for name in remote.listdir(rec.folder):
-                            if (name.endswith(".dump.zip") and
+                            if (name.endswith('.%s' % file_extension) and
                                     os.path.basename(name) < oldest):
                                 remote.unlink('%s/%s' % (rec.folder, name))
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

cleanup method only looking for .dump.zip files, so .dump files are not
being deleted as intended

Current behavior:

No cleanup for .dump files

Desired behavior after PR is merged:

.dump files get deleted