### PR TITLE
Fix avoid_quick_create with multiprocess

### DIFF
--- a/base_optional_quick_create/models/ir_model.py
+++ b/base_optional_quick_create/models/ir_model.py
@@ -51,4 +51,6 @@ class IrModel(models.Model):
     def write(self, vals):
         res = super(IrModel, self).write(vals)
         self._patch_quick_create()
+        if 'avoid_quick_create' in vals:
+            self.pool.signal_registry_change()
         return res


### PR DESCRIPTION
When starting Odoo in multiprocess, a change to the field
IrModel.avoid_quick_create would be active only on the current worker.
Otherwise, it would be active after a restart.

The proposed change is to signal a registry change, forcing the other
workers to reload a registry and then be aware of the change.