### PR TITLE
[FIX] base_remote: Do not raise Error on login failure

### DIFF
--- a/base_remote/__manifest__.py
+++ b/base_remote/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': "Remote Base",
-    'version': '11.0.1.0.3',
+    'version': '11.0.1.0.4',
     'category': 'Generic Modules/Base',
     'author': "Creu Blanca, Odoo Community Association (OCA)",
     'website': 'http://github.com/OCA/server-tools',

--- a/base_remote/models/base.py
+++ b/base_remote/models/base.py
@@ -13,5 +13,7 @@ class Base(models.AbstractModel):
         try:
             remote_addr = current_thread().environ["REMOTE_ADDR"]
         except KeyError:
-            remote_addr = False
+            return self.env['res.remote']
+        except AttributeError:
+            return self.env['res.remote']
         return self.env['res.remote']._get_remote(remote_addr)

--- a/base_remote/models/res_users.py
+++ b/base_remote/models/res_users.py
@@ -3,7 +3,6 @@
 
 from threading import current_thread
 from odoo import api, models, SUPERUSER_ID
-from odoo.exceptions import AccessDenied
 from odoo.service import wsgi_server
 
 
@@ -30,12 +29,9 @@ class ResUsers(models.Model):
         with cls.pool.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
             remote = env["res.users"].remote
-            remote.ensure_one()
-        result = method()
-        if not result:
-            # Force exception to record auth failure
-            raise AccessDenied()
-        return result
+            if remote:
+                remote.ensure_one()
+        return method()
 
     # Override all auth-related core methods
     @classmethod

--- a/base_remote/tests/test_remote.py
+++ b/base_remote/tests/test_remote.py
@@ -1,8 +1,6 @@
 # Copyright 2018 Creu Blanca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from xmlrpc.client import Fault
-
 from mock import patch
 from werkzeug.utils import redirect
 
@@ -56,9 +54,8 @@ class TestRemote(HttpCase):
         """Test Login Failure"""
         data1 = self.data_demo
         data1['password'] = 'Failure!'
-        with self.assertRaises(Fault):
-            self.assertFalse(self.xmlrpc_common.authenticate(
-                self.env.cr.dbname, data1["login"], data1["password"], {}))
+        self.assertFalse(self.xmlrpc_common.authenticate(
+            self.env.cr.dbname, data1["login"], data1["password"], {}))
         with self.cursor() as cr:
             env = self.env(cr)
             self.assertTrue(


### PR DESCRIPTION
When you failed the login, it was raising an error due to 
https://github.com/OCA/server-tools/blob/11.0/base_remote/models/base.py#L14

With this fix, it should not happen anymore.