### PR TITLE
Switch AGPL to LGPL license

### DIFF
--- a/base_user_role/README.rst
+++ b/base_user_role/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
-   :alt: License: AGPL-3
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.png
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
 
 ==========
 User roles

--- a/base_user_role/__openerp__.py
+++ b/base_user_role/__openerp__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 {
     'name': 'User roles',
     'version': '8.0.1.2.0',
     'category': 'Tools',
     'author': 'ABF OSIELL, Odoo Community Association (OCA)',
-    'license': 'AGPL-3',
+    'license': 'LGPL-3',
     'maintainer': 'ABF OSIELL',
     'website': 'http://www.osiell.com',
     'depends': [

--- a/base_user_role/data/ir_cron.xml
+++ b/base_user_role/data/ir_cron.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <openerp>
     <data noupdate="1">
 

--- a/base_user_role/data/ir_module_category.xml
+++ b/base_user_role/data/ir_module_category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <openerp>
     <data>
 

--- a/base_user_role/hooks.py
+++ b/base_user_role/hooks.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from openerp import api, SUPERUSER_ID
 
 

--- a/base_user_role/migrations/8.0.1.1.0/post-migration.py
+++ b/base_user_role/migrations/8.0.1.1.0/post-migration.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from openerp import api, SUPERUSER_ID
 
 

--- a/base_user_role/migrations/8.0.1.2.0/post-migrate.py
+++ b/base_user_role/migrations/8.0.1.2.0/post-migrate.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from openerp import api, SUPERUSER_ID
 
 

--- a/base_user_role/models/res_groups.py
+++ b/base_user_role/models/res_groups.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # Copyright 2014 ABF OSIELL <http://osiell.com>
 # Copyright 2017 Opener B.V. <https://opener.amsterdam>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from lxml import etree
 
 from openerp import api, models

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import datetime
 import logging

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from openerp import api, fields, models
 

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import datetime
 

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2014 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <openerp>
     <data>
 

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2014 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <openerp>
     <data>
 


### PR DESCRIPTION
Following public and private conversations with the contributors, I propose this PR to switch the license between AGPL to LGPL.
The change is motivated by the fact that when using this kind of module in a project, any kind of module (private/open source) could be a dependency. With AGPL license, this would not be possible, hence the request to switch to LGPL.

@sebalix @tuxintheshell 

@pedrobaeza I am not sure I am doing it right starting from the oldest version v8.0. I might need guidance here.
