### PR TITLE
Switch AGPL to LGPL license

### DIFF
--- a/base_user_role/README.rst
+++ b/base_user_role/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
-   :alt: License: AGPL-3
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
 
 ==========
 User roles

--- a/base_user_role/__manifest__.py
+++ b/base_user_role/__manifest__.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 
 {
     'name': 'User roles',
     'version': '10.0.1.0.2',
     'category': 'Tools',
     'author': 'ABF OSIELL, Odoo Community Association (OCA)',
-    'license': 'AGPL-3',
+    'license': 'LGPL-3',
     'maintainer': 'ABF OSIELL',
     'website': 'http://www.osiell.com',
     'depends': [

--- a/base_user_role/data/ir_cron.xml
+++ b/base_user_role/data/ir_cron.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+ -->
 <odoo noupdate="1">
 
 <record model="ir.cron" id="cron_update_users">

--- a/base_user_role/data/ir_module_category.xml
+++ b/base_user_role/data/ir_module_category.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2016 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+ -->
 <odoo>
 
 <record model="ir.module.category" id="ir_module_category_role">

--- a/base_user_role/models/role.py
+++ b/base_user_role/models/role.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 
 import datetime
 import logging

--- a/base_user_role/models/user.py
+++ b/base_user_role/models/user.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 
 from odoo import api, fields, models
 

--- a/base_user_role/tests/test_user_role.py
+++ b/base_user_role/tests/test_user_role.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 ABF OSIELL <http://osiell.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 
 import datetime
 

--- a/base_user_role/views/role.xml
+++ b/base_user_role/views/role.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2014 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+ -->
 <odoo>
 
 <record id="view_res_users_role_form" model="ir.ui.view">

--- a/base_user_role/views/user.xml
+++ b/base_user_role/views/user.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2014 ABF OSIELL <http://osiell.com>
-     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+ -->
 <odoo>
 
 <record id="view_res_users_form_inherit" model="ir.ui.view">


### PR DESCRIPTION
Following public and private conversations with the contributors, I propose this PR to switch the license between AGPL to LGPL.
The change is motivated by the fact that when using this kind of module in a project, any kind of module (private/open source) could be a dependency. With AGPL license, this would not be possible, hence the request to switch to LGPL.

@sebalix @tuxintheshell

@pedrobaeza / @hbrunn following up on #1469 (comment)