### PR TITLE
[FIX] don't remove computed fields with inverse method of the onchange values

### DIFF
--- a/onchange_helper/models/models.py
+++ b/onchange_helper/models/models.py
@@ -47,5 +47,5 @@ class Base(models.AbstractModel):
 
         return {
             f: v for f, v in all_values.iteritems()
-            if not self._fields[f].compute
+            if not (self._fields[f].compute and not self._fields[f].inverse)
             and (f in values or f in new_values)}


### PR DESCRIPTION
Hi,

This PR fixes an issue in onchange_helper module.

Current behavior :
If you want to write a computed field with inverse method and call the method play_onchanges, it will be removed of the returned dict.

Expected behavior :
Computed fields are removed from the values dictionnary unless the field has a inverse method
