### PR TITLE
[IMP][10.0] Make secret key visible auth_totp

### DIFF
--- a/auth_totp/__manifest__.py
+++ b/auth_totp/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'MFA Support',
     'summary': 'Allows users to enable MFA and add optional trusted devices',
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.1.0',
     'category': 'Extra Tools',
     'website': 'https://github.com/OCA/server-tools',
     'author': 'LasLabs, Odoo Community Association (OCA)',

--- a/auth_totp/wizards/res_users_authenticator_create.py
+++ b/auth_totp/wizards/res_users_authenticator_create.py
@@ -29,6 +29,7 @@ class ResUsersAuthenticatorCreate(models.TransientModel):
         index=True,
     )
     secret_key = fields.Char(
+        string='Secret Code',
         default=lambda s: pyotp.random_base32(),
         required=True,
     )

--- a/auth_totp/wizards/res_users_authenticator_create.xml
+++ b/auth_totp/wizards/res_users_authenticator_create.xml
@@ -15,14 +15,14 @@
                 <sheet>
                     <div>
                         <span>Please provide a name for your app/device. </span>
-                        <span>Then scan the QR code below to add this account to your authenticator app and enter in the six digit code produced by the app.</span>
+                        <span>Then scan the QR code or enter the secret code below to add this account to your authenticator app and enter in the six digit code produced by the app.</span>
                     </div>
                     <group name="data">
                         <field name="name"/>
                         <field name="user_id"/>
+                        <field name="secret_key" readonly="1"/>
                         <field name="qr_code_tag"/>
                         <field name="confirmation_code"/>
-                        <field name="secret_key" invisible="1"/>
                     </group>
                 </sheet>
                 <footer>


### PR DESCRIPTION
Hello everyone,

this change should allow the usage of the module for more categories of devices to generate the confirmation codes. This change shouldn't decrease the security because the secret key is already visible in the QR code.

This is a cherry pick of [#1409](https://github.com/OCA/server-tools/pull/1409)