### PR TITLE
[IMP] add possibility to use static files (css, js) depending on the environment

### DIFF
--- a/server_environment/__init__.py
+++ b/server_environment/__init__.py
@@ -19,6 +19,7 @@
 #
 ##############################################################################
 import logging
+from . import controllers
 
 _logger = logging.getLogger(__name__)
 

--- a/server_environment/__openerp__.py
+++ b/server_environment/__openerp__.py
@@ -23,7 +23,7 @@
     "name": "server configuration environment files",
     "version": "8.0.1.1.0",
     "depends": ["base"],
-    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "author": "Camptocamp,GRAP,Odoo Community Association (OCA)",
     "description": """\
 Environment file pattern for OpenERP
 ====================================
@@ -75,6 +75,35 @@ Example usage
        print (key, value)
 
     serv_config.get('external_service.ftp', 'tls')
+
+This module provides also the possibility to load static files depending
+on the environment.
+
+Example usage
+-------------
+
+Create a file view/templates.xml, and insert a css file
+
+::
+
+    <openerp><data>
+        <template id="login_layout_no_db" name="Login Layout"
+                inherit_id="web.login_layout" >
+            <xpath expr="." position="inside">
+                <link rel="stylesheet"
+                href="/server_environment_files/static/RUNNING_ENV/css.css"/>
+            </xpath>
+        </template>
+    </data></openerp>
+
+Then, create css files for each environment you have. exemple:
+::
+
+    /server_environment_files/static/dev/css.css
+    /server_environment_files/static/prod/css.css
+    ...
+
+
     """,
     "website": "http://www.camptocamp.com",
     "license": "GPL-3 or any later version",

--- a/server_environment/controllers/__init__.py
+++ b/server_environment/controllers/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+from . import main

--- a/server_environment/controllers/main.py
+++ b/server_environment/controllers/main.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import openerp.http as http
+from openerp.tools.config import config
+
+
+class ServerEnvironmentController(http.Controller):
+
+    @http.route(
+        '/server_environment_<module_extension>'
+        '/static/RUNNING_ENV/<local_path>',
+        type='http', auth='public')
+    def environment_redirect(self, module_extension, local_path, **kw):
+        # Note: module_extension is present to make working
+        # the module in normal configuration, with the folder
+        # server_environment_files and in demo configuration, withe the
+        # module  server_environment_files_sample
+        running_env = config.get('running_env', "RUNNING_ENV")
+        return http.local_redirect(
+            'server_environment_%s/static/%s/%s' % (
+                module_extension, running_env, local_path))

--- a/server_environment/controllers/main.py
+++ b/server_environment/controllers/main.py
@@ -18,7 +18,7 @@ class ServerEnvironmentController(http.Controller):
         # the module in normal configuration, with the folder
         # server_environment_files and in demo configuration, withe the
         # module  server_environment_files_sample
-        running_env = config.get('running_env', "RUNNING_ENV")
+        running_env = config.get('running_env', "default")
         return http.local_redirect(
             '/server_environment_%s/static/%s/%s' % (
                 module_extension, running_env, local_path))

--- a/server_environment/controllers/main.py
+++ b/server_environment/controllers/main.py
@@ -20,5 +20,5 @@ class ServerEnvironmentController(http.Controller):
         # module  server_environment_files_sample
         running_env = config.get('running_env', "RUNNING_ENV")
         return http.local_redirect(
-            'server_environment_%s/static/%s/%s' % (
+            '/server_environment_%s/static/%s/%s' % (
                 module_extension, running_env, local_path))

--- a/server_environment/controllers/main.py
+++ b/server_environment/controllers/main.py
@@ -3,11 +3,15 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import openerp.http as http
+from werkzeug.utils import redirect
+from urlparse import urljoin
+
 from openerp.tools.config import config
+from openerp import http
+from openerp.http import request, Controller
 
 
-class ServerEnvironmentController(http.Controller):
+class ServerEnvironmentController(Controller):
 
     @http.route(
         '/server_environment_<module_extension>'
@@ -16,9 +20,12 @@ class ServerEnvironmentController(http.Controller):
     def environment_redirect(self, module_extension, local_path, **kw):
         # Note: module_extension is present to make working
         # the module in normal configuration, with the folder
-        # server_environment_files and in demo configuration, withe the
+        # server_environment_files and in demo configuration, with the
         # module  server_environment_files_sample
         running_env = config.get('running_env', "default")
-        return http.local_redirect(
-            '/server_environment_%s/static/%s/%s' % (
-                module_extension, running_env, local_path))
+        IrConfigParameter = request.env['ir.config_parameter']
+        base_url = IrConfigParameter.get_param('web.base.url', '')
+        new_path = "/server_environment_%s/static/%s/%s" % (
+            module_extension, running_env, local_path)
+        url = urljoin(base_url, new_path)
+        return redirect(url, 303)

--- a/server_environment_files_sample/__openerp__.py
+++ b/server_environment_files_sample/__openerp__.py
@@ -22,8 +22,8 @@
 {
     "name": "Example server configuration environment files repository module",
     "version": "8.0.1.0.0",
-    "depends": ["base"],
-    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "depends": ["server_environment", "web"],
+    "author": "Camptocamp,GRAP,Odoo Community Association (OCA)",
     "description": """\
 File store for environment file sample module
 =============================================
@@ -43,7 +43,9 @@ variable of the OpenERP configuration file.
     "website": "http://www.camptocamp.com",
     "license": "GPL-3 or any later version",
     "category": "Tools",
-    "data": [],
+    "data": [
+        'views/templates.xml',
+    ],
     "installable": True,
     "active": False,
 }

--- a/server_environment_files_sample/static/default/web_login.css
+++ b/server_environment_files_sample/static/default/web_login.css
@@ -1,0 +1,4 @@
+.oe_single_form{
+    background-color:#AAFFAA !important;
+    background-image: none !important;
+}

--- a/server_environment_files_sample/static/dev/web_login.css
+++ b/server_environment_files_sample/static/dev/web_login.css
@@ -1,0 +1,4 @@
+.oe_single_form{
+    background-color:#AAFFFF !important;
+    background-image: none !important;
+}

--- a/server_environment_files_sample/static/preprod/web_login.css
+++ b/server_environment_files_sample/static/preprod/web_login.css
@@ -1,0 +1,4 @@
+.oe_single_form{
+    background-color:#AAFFAA !important;
+    background-image: none !important;
+}

--- a/server_environment_files_sample/static/prod/web_login.css
+++ b/server_environment_files_sample/static/prod/web_login.css
@@ -1,0 +1,4 @@
+.oe_single_form{
+    background-color:#CCCCCC !important;
+    background-image: none !important;
+}

--- a/server_environment_files_sample/views/templates.xml
+++ b/server_environment_files_sample/views/templates.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2019-Today GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+
+<openerp><data>
+
+    <template id="login_layout_no_db" name="Login Layout" inherit_id="web.login_layout" >
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" href="/server_environment_files_sample/static/RUNNING_ENV/web_login.css"/>
+        </xpath>
+    </template>
+
+</data></openerp>


### PR DESCRIPTION
This PR improves the module ``server_environment`` to have the possibility to use custom static files, depending on the environment.


# Usage

* Create a file view/templates.xml, and insert a css file, for exemple

```
    <openerp><data>
        <template id="login_layout_no_db" name="Login Layout"
                inherit_id="web.login_layout" >
            <xpath expr="." position="inside">
                <link rel="stylesheet"
                href="/server_environment_files/static/RUNNING_ENV/css.css"/>
            </xpath>
        </template>
    </data></openerp>
```

Then create your custom css files in the according folders, in your ``server_environment_files`` folders

```
    /server_environment_files/static/dev/css.css
    /server_environment_files/static/prod/css.css
    ....
```

# Technical information

this module adds basically a new http controller, that catch dynamically the call of the URLs that match the pattern ``server_environment_files/static/RUNNING_ENV/<path>`` and make a redirection. So your log will belong two lines.

```
INFO [...] "GET /server_environment_files_sample/static/RUNNING_ENV/web_login.css HTTP/1.1" 303 -
INFO [...] "GET /server_environment_files_sample/static/prod/web_login.css HTTP/1.1" 200 -
```


# Sample

![image](https://user-images.githubusercontent.com/3407482/52347863-3d2b9880-2a23-11e9-98dd-67e4a73a44a0.png)
