### PR TITLE
[FIX] field_rrule: respect rrule timezone when serializing

### DIFF
--- a/field_rrule/field_rrule.py
+++ b/field_rrule/field_rrule.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
 import pytz
 from dateutil.rrule import rrule, rruleset
 from dateutil.tz import gettz
-from openerp import fields, models
-from openerp.exceptions import ValidationError
+from openerp import _, fields, models
+
+
+_logger = logging.getLogger(__name__)
 
 _RRULE_DATETIME_FIELDS = ['_until', '_dtstart']
 _RRULE_SCALAR_FIELDS = [
@@ -36,6 +39,11 @@ class SerializableRRuleSet(list):
         def _as_utc(_date):
             if _date and _date.tzinfo:
                 return _date.astimezone(pytz.utc)
+            elif _date:
+                _logger.warning(
+                    _('Warning: naive datetime %s interpreted as UTC'),
+                    str(_date))
+                return _date
             else:
                 return _date
 

--- a/field_rrule/field_rrule.py
+++ b/field_rrule/field_rrule.py
@@ -12,6 +12,18 @@ _RRULE_SCALAR_FIELDS = [
 _RRULE_ZERO_IS_NOT_NONE = ['_freq']
 
 
+def get_tz_from_rrule(_rrule):
+    """ Get timezone from dtstart if it's filled """
+    if _rrule._dtstart:
+        tz = _rrule._dtstart.tzinfo
+        if tz:
+            try:
+                return tz._filename
+            except AttributeError:
+                return tz.zone
+    return None
+
+
 class LocalRRuleSet(rruleset):
     """An rruleset that yields the naive utc representation of a date if the
     original date was timezone aware"""
@@ -30,7 +42,10 @@ class SerializableRRuleSet(list):
     stuff in __iter__"""
     def __init__(self, *args):
         self._rrule = list(args)
-        self.tz = None
+        if self._rrule:
+            self.tz = get_tz_from_rrule(self._rrule[0])
+        else:
+            self.tz = None
         super(SerializableRRuleSet, self).__init__(self)
 
     def __iter__(self):


### PR DESCRIPTION
Ran into some issues where serialized and subsequently deserialized rrules suddenly have shifted 1 or 2 hours forward. This normally does not lead to problems, unless eg. your weekly rrule starts on `Monday February 4 2019 00:00 AM` and now suddenly starts at `Monday February 4 2019 02:00 AM`, thereby now missing its first occurrence on `Monday February 4 2019 00:00 AM` and skipping directly to February 11.
