### PR TITLE
[FIX][database_cleanup] don't destroy values when there are empty default properties

### DIFF
--- a/database_cleanup/models/purge_properties.py
+++ b/database_cleanup/models/purge_properties.py
@@ -4,6 +4,7 @@
 from odoo import api, models, fields
 REASON_DUPLICATE = 1
 REASON_DEFAULT = 2
+REASON_DEFAULT_FALSE = 3
 
 
 class CleanupPurgeLineProperty(models.TransientModel):
@@ -17,6 +18,7 @@ class CleanupPurgeLineProperty(models.TransientModel):
     reason = fields.Selection([
         (REASON_DUPLICATE, 'Duplicated property'),
         (REASON_DEFAULT, 'Same value as default'),
+        (REASON_DEFAULT_FALSE, 'Empty default property'),
     ])
 
     @api.multi
@@ -42,6 +44,15 @@ class CleanupPurgeWizardProperty(models.TransientModel):
         ])
         handled_field_ids = []
         for prop in default_properties:
+            if not prop.get_by_record():
+                result.append({
+                    'name': '%s@%s: %s' % (
+                        prop.name, prop.res_id, prop.get_by_record()
+                    ),
+                    'property_id': prop.id,
+                    'reason': REASON_DEFAULT_FALSE,
+                })
+                continue
             if prop.fields_id.id in handled_field_ids:
                 continue
             domain = [

--- a/database_cleanup/models/purge_properties.py
+++ b/database_cleanup/models/purge_properties.py
@@ -87,7 +87,8 @@ class CleanupPurgeWizardProperty(models.TransientModel):
             for redundant_property in self.env['ir.property'].search(domain):
                 result.append({
                     'name': '%s@%s: %s' % (
-                        prop.name, prop.res_id, prop.get_by_record()
+                        prop.name, redundant_property.res_id,
+                        prop.get_by_record()
                     ),
                     'property_id': redundant_property.id,
                     'reason': REASON_DEFAULT,

--- a/database_cleanup/views/create_indexes.xml
+++ b/database_cleanup/views/create_indexes.xml
@@ -39,7 +39,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_create_indexes_line" />
-        <field name="code">env.get('cleanup.create_indexes.line').purge()</field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="cleanup_create_indexes_line_action_value" model="ir.values">

--- a/database_cleanup/views/purge_columns.xml
+++ b/database_cleanup/views/purge_columns.xml
@@ -37,9 +37,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_column" />
-        <field name="code">
-            env.get('cleanup.purge.line.column').purge()
-        </field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_column_line_value" model="ir.values">

--- a/database_cleanup/views/purge_data.xml
+++ b/database_cleanup/views/purge_data.xml
@@ -37,9 +37,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_data" />
-        <field name="code">
-            env.get('cleanup.purge.line.data').purge()
-        </field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_data_line_value" model="ir.values">

--- a/database_cleanup/views/purge_menus.xml
+++ b/database_cleanup/views/purge_menus.xml
@@ -33,9 +33,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_menu" />
-        <field name="code">
-            env.get('cleanup.purge.line.menu').purge()
-        </field>
+            <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_menu_line_value" model="ir.values">

--- a/database_cleanup/views/purge_models.xml
+++ b/database_cleanup/views/purge_models.xml
@@ -33,9 +33,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_model" />
-        <field name="code">
-            env.get('cleanup.purge.line.model').purge()
-        </field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_model_line_value" model="ir.values">

--- a/database_cleanup/views/purge_modules.xml
+++ b/database_cleanup/views/purge_modules.xml
@@ -33,9 +33,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_module" />
-        <field name="code">
-            env.get('cleanup.purge.line.module').purge()
-        </field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_module_line_value" model="ir.values">

--- a/database_cleanup/views/purge_properties.xml
+++ b/database_cleanup/views/purge_properties.xml
@@ -33,7 +33,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_property" />
-        <field name="code">env.get('cleanup.purge.line.property').purge()</field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_property_line_value" model="ir.values">

--- a/database_cleanup/views/purge_tables.xml
+++ b/database_cleanup/views/purge_tables.xml
@@ -33,9 +33,7 @@
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
         <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_table" />
-        <field name="code">
-            env.get('cleanup.purge.line.table').purge()
-        </field>
+        <field name="code">records.purge()</field>
     </record>
 
     <record id="action_purge_table_line_value" model="ir.values">


### PR DESCRIPTION
when you have a default property with a falsy value, the cleanup will go very wrong because it will delete all your properties.

The right thing to do in such a case is to remove the empty default value.

This one we should cherry pick back and forth through the versions.

I also slipped in a cosmetic fix for display of redundant properties, this was always showing `False`. Last thing I fixed while being at this PR is that the action to purge just a selection of lines was migrated wrongly to 10 (and the following)