### PR TITLE
[FIX] add perm_read in ir.model.access for base.group_user to avoid b…

### DIFF
--- a/base_user_role/security/ir.model.access.csv
+++ b/base_user_role/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_res_users_role,access_res_users_role,model_res_users_role,"base.group_erp_manager",1,1,1,1
 access_res_users_role_line,access_res_users_role_line,model_res_users_role_line,"base.group_erp_manager",1,1,1,1
+access_res_users_role_user,access_res_users_role_user,model_res_users_role,"base.group_user",1,0,0,0
+access_res_users_role_line_user,access_res_users_role_line_user,model_res_users_role_line,"base.group_user",1,0,0,0


### PR DESCRIPTION
add perm_read in ir.model.access for base.group_user to avoid bug when reading an user info.
Give the same right to object role  as group object  in base module.
@sebastienbeau , @bealdav, @StefanRijnhart, @sebalix 

