### PR TITLE
[FIX] password_security: Avoid creating duplicate res.users.log entries

### DIFF
--- a/password_security/controllers/main.py
+++ b/password_security/controllers/main.py
@@ -39,11 +39,7 @@ class PasswordSecurityHome(AuthSignupHome):
         login_success = request.params.get('login_success', False)
         if not request.httprequest.method == 'POST' or not login_success:
             return response
-        uid = request.session.authenticate(
-            request.session.db,
-            request.params['login'],
-            request.params['password']
-        )
+        uid = request.uid
         if not uid:
             return response
         users_obj = request.env['res.users'].sudo()


### PR DESCRIPTION
The reason for this change is that the `super` will already call the `authenticate` method and then store the result in the `request.uid` variable. There is no reason to call `authenticate` here again.