### PR TITLE
module_auto_update: remove maintainer

### DIFF
--- a/module_auto_update/__manifest__.py
+++ b/module_auto_update/__manifest__.py
@@ -19,5 +19,4 @@
         'base',
     ],
     'development_status': 'Production/Stable',
-    'maintainers': ['sbidoul'],
 }


### PR DESCRIPTION
Hi,

I'm removing myself from maintainers of this module.

The reason is that we found circumstances where the module did not work reliably.
I'm continuing the maintenance of the auto update algorithm in [click-odoo-update](https://github.com/acsone/click-odoo-contrib/blob/master/README.rst#click-odoo-update-beta), where it works in a manner very similar to the regular Odoo `-u`.