### PR TITLE
[12.0][FIX] module_auto_update, sentry: tag unittest.TestCase subclasses

### DIFF
--- a/module_auto_update/tests/test_addon_hash.py
+++ b/module_auto_update/tests/test_addon_hash.py
@@ -4,10 +4,13 @@
 import os
 import unittest
 
+from odoo.tests.common import tagged
+
 from .. import addon_hash
 from ..models.module import DEFAULT_EXCLUDE_PATTERNS
 
 
+@tagged('standard', 'at_install')
 class TestAddonHash(unittest.TestCase):
 
     def setUp(self):

--- a/sentry/tests/test_client.py
+++ b/sentry/tests/test_client.py
@@ -8,6 +8,7 @@ import unittest
 import raven
 
 from odoo import exceptions
+from odoo.tests.common import tagged
 
 from .. import initialize_raven
 from ..logutils import OdooSentryHandler
@@ -58,6 +59,7 @@ class InMemoryClient(raven.Client):
         return False
 
 
+@tagged('standard', 'at_install')
 class TestClientSetup(unittest.TestCase):
 
     def setUp(self):

--- a/sentry/tests/test_logutils.py
+++ b/sentry/tests/test_logutils.py
@@ -4,10 +4,12 @@
 import unittest
 
 import mock
+from odoo.tests.common import tagged
 
 from ..logutils import SanitizeOdooCookiesProcessor
 
 
+@tagged('standard', 'at_install')
 class TestOdooCookieSanitizer(unittest.TestCase):
 
     def test_cookie_as_string(self):


### PR DESCRIPTION
Since [v12.0](https://github.com/odoo/odoo/commit/b356b190338e3ee032b9e3a7f670f76468965006), direct subclasses of `unittest.TestCase` which do not have :class:`odoo.tests.common.MetaCase` as a meta-class must be explicitly tagged with :method:`odoo.tests.common.tagged`, otherwise they will not be picked up by the test runner. E.g.:

```python
@tagged('standard', 'at_install')
```
