### PR TITLE
[FIX] users_ldap_populate: Wrong attribute usage

### DIFF
--- a/users_ldap_populate/README.rst
+++ b/users_ldap_populate/README.rst
@@ -55,6 +55,7 @@ Contributors
 * Holger Brunn <hbrunn@therp.nl>
 * Daniel Reis <dgreis@sapo.pt>
 * Stefan Rijnhart <stefan@opener.am>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -160,7 +160,7 @@ class CompanyLDAP(orm.Model):
                 bool(
                     self.get_ldap_entry_dicts(
                         conf,
-                        user_name=unknown_user.login,
+                        user_name=unknown_user['login'],
                     ))
                 for conf in self.get_ldap_dicts(cr, ids)
             )


### PR DESCRIPTION
The variable is a dict, and the desired value must be accessed via key, not attribute.

This fixes a bug introduced in https://github.com/OCA/server-tools/pull/1519.

@Tecnativa