### PR TITLE
[FIX] base_exception: send the active_model in the conxtext when call…

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -128,7 +128,8 @@ class BaseException(models.AbstractModel):
         action_data.update({
             'context': {
                 'active_id': self.ids[0],
-                'active_ids': self.ids
+                'active_ids': self.ids,
+                'active_model': self._name,
             }
         })
         return action_data


### PR DESCRIPTION
… the _popup_exceptions method

This it's becase if you go to Sale order from  CRM opportunities an confirm sale, occurs an error with  the active model in this case is "crm.lead" instead "sale.order".