### PR TITLE
[10.0] [FIX] auth_session_timeout: use `_authenticate` from `ir.http`

### DIFF
--- a/auth_session_timeout/models/__init__.py
+++ b/auth_session_timeout/models/__init__.py
@@ -4,3 +4,4 @@
 
 from . import res_users
 from . import ir_config_parameter
+from . import ir_http

--- a/auth_session_timeout/models/ir_http.py
+++ b/auth_session_timeout/models/ir_http.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# (c) 2019 Anass Ahmed, Katherine Zaoral
+
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import models
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _authenticate(cls, auth_method='user'):
+        res = super(IrHttp, cls)._authenticate(auth_method=auth_method)
+        # use session.uid instead of env.user because first requests don't have
+        # that and basically bypass our check (if you close the browser in an
+        # acitve session, then you open it again after the timeout passed)
+        if request and request.session and request.session.uid:
+            request.env.user._auth_timeout_check()
+        return res

--- a/auth_session_timeout/models/res_users.py
+++ b/auth_session_timeout/models/res_users.py
@@ -9,7 +9,7 @@ from os.path import getmtime
 from time import time
 from os import utime
 
-from odoo import api, http, models, tools
+from odoo import api, http, models
 
 _logger = logging.getLogger(__name__)
 
@@ -101,10 +101,3 @@ class ResUsers(models.Model):
                 _logger.exception(
                     'Exception updating session file access/modified times.',
                 )
-
-    @tools.ormcache('sid')
-    def _compute_session_token(self, sid):
-        res = super(ResUsers, self)._compute_session_token(sid)
-        if http.request:
-            http.request.env.user._auth_timeout_check()
-        return res

--- a/auth_session_timeout/tests/__init__.py
+++ b/auth_session_timeout/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_ir_config_parameter
 from . import test_res_users
+from . import test_ir_http

--- a/auth_session_timeout/tests/test_ir_http.py
+++ b/auth_session_timeout/tests/test_ir_http.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Anass Ahmed.
+
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import mock
+
+from contextlib import contextmanager
+
+from odoo.tests.common import TransactionCase
+
+
+class TestIrHttp(TransactionCase):
+
+    post_install = True
+    at_install = False
+
+    def setUp(self):
+        super(TestIrHttp, self).setUp()
+        self.TestUser = self.env['res.users'].create({
+            'login': 'test_user',
+            'name': 'test_user',
+        })
+
+    @contextmanager
+    def _mock_assets(self, assets=None):
+        """ Multi patch names in `odoo.addons.auth_session_timeout.models.
+        ir_http` for mocking them.
+
+        :param assets: The symbols in ir_http that will be patched with
+        MagicMock objects.
+        """
+        if assets is None:
+            assets = ['request']
+        patches = {name: mock.DEFAULT for name in assets}
+        with mock.patch.multiple(
+            'odoo.addons.auth_session_timeout.models.ir_http', **patches
+        ) as mocks:
+            yield mocks
+
+    def test_authenticate_check_timeout(self):
+        """Make sure each time _authenticate is called, the timeout is
+           checked."""
+        with self._mock_assets() as assets:
+            user = mock.MagicMock()
+            assets['request'].env.user = user
+            assets['request'].session.uid = 10
+            assets['request'].session.dbname = self.env.cr.dbname
+            assets['request'].session.sid = '123'
+            with mock.patch('odoo.addons.base.ir.ir_http.IrHttp'
+                            '._authenticate') as mock_super_athenticate:
+                self.env['ir.http']._authenticate()
+                self.assertTrue(mock_super_athenticate.called)
+            self.assertTrue(user._auth_timeout_check.called)
+
+    def test_initial_check_no_user(self):
+        """Make sure _auth_timeout_check is not called when no user is stored
+           in the session."""
+        with self._mock_assets() as assets:
+            user = mock.MagicMock()
+            assets['request'].env.user = None
+            assets['request'].session.uid = None
+            assets['request'].session.dbname = self.env.cr.dbname
+            assets['request'].session.sid = '123'
+            with mock.patch('odoo.addons.base.ir.ir_http.IrHttp'
+                            '._authenticate') as mock_super_athenticate:
+                self.env['ir.http']._authenticate()
+                self.assertTrue(mock_super_athenticate.called)
+            self.assertFalse(user._auth_timeout_check.called)


### PR DESCRIPTION
This commit kinda uses the logic in `11.0` module counterpart.

I've done some initial tests and looks like it works, but I will do more extensive tests in the following days to ensure it works just fine.

I've modified the tests, but I'm unsatisfied with the current format (in `11.0` there's no test for `ir.http` at all). also, `patch.multiple` is unfamiliar to me, so I did my own `patch` for now.

If you have any suggestions, please comment and leave your review.