### PR TITLE
[9.0] [REF] Keychain: add index on keychain.account

### DIFF
--- a/keychain/models/keychain.py
+++ b/keychain/models/keychain.py
@@ -45,7 +45,8 @@ class KeychainAccount(models.Model):
     name = fields.Char(required=True, help="Humain readable label")
     technical_name = fields.Char(
         required=True,
-        help="Technical name. Must be unique")
+        help="Technical name. Must be unique",
+        index=True)
     namespace = fields.Selection([], help="Type of account", required=True)
     environment = fields.Char(
         required=False,


### PR DESCRIPTION
On my database, the following query took ~11ms before this change and ~0.3ms now.

``` sql
SELECT "keychain_account".id FROM "keychain_account" WHERE ((("keychain_account"."namespace" = ?) AND ("keychain_account"."technical_name" = ?)) AND (("keychain_account"."environment" in (?)) OR "keychain_account"."environment" IS NULL)) ORDER BY "keychain_account"."id";
```

Forward port to 10.0 : https://github.com/OCA/server-tools/pull/1748
Forward port to 11.0 : https://github.com/OCA/server-auth/pull/153
