### PR TITLE
[10.0][FIX] base_techical_features: Don't load all users if not needed

### DIFF
--- a/base_technical_features/__manifest__.py
+++ b/base_technical_features/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Technical features group",
     "summary": "Access to technical features without activating debug mode",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Usability",
     "website": "https://github.com/oca/server-tools",
     "author": "Opener B.V., Odoo Community Association (OCA)",

--- a/base_technical_features/models/res_users.py
+++ b/base_technical_features/models/res_users.py
@@ -23,18 +23,16 @@ class ResUsers(models.Model):
     def get_show_technical_features(self):
         """ Only display the technical features checkbox in the user
         preferences if the user has access to them """
-        users = self.env.ref('base.group_no_one').users
         for user in self:
-            user.show_technical_features = user in users
+            user.show_technical_features = user.has_group('base.group_no_one')
 
     @api.multi
     @api.depends('groups_id')
     def get_technical_features(self):
         """ Map user membership to boolean field value """
-        users = self.env.ref(
-            'base_technical_features.group_technical_features').users
         for user in self:
-            user.technical_features = user in users
+            user.technical_features = user.has_group(
+                'base_technical_features.group_technical_features')
 
     @api.multi
     def set_technical_features(self):


### PR DESCRIPTION
Odoo ORM will load all users contained in loaded group in cache.
That has huge performances impact if there is a lot of users
in that group (especially in computed fields).