### PR TITLE
[10.0] [FIX] users_ldap_populate special characters

### DIFF
--- a/users_ldap_populate/i18n/am.po
+++ b/users_ldap_populate/i18n/am.po
@@ -81,8 +81,13 @@ msgstr ""
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/ar.po
+++ b/users_ldap_populate/i18n/ar.po
@@ -82,8 +82,13 @@ msgstr "الاسم"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/bg.po
+++ b/users_ldap_populate/i18n/bg.po
@@ -81,8 +81,13 @@ msgstr "Име"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/bs.po
+++ b/users_ldap_populate/i18n/bs.po
@@ -82,8 +82,13 @@ msgstr "Ime"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/ca.po
+++ b/users_ldap_populate/i18n/ca.po
@@ -81,8 +81,13 @@ msgstr "Nom"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/cs.po
+++ b/users_ldap_populate/i18n/cs.po
@@ -81,8 +81,13 @@ msgstr "Název"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/da.po
+++ b/users_ldap_populate/i18n/da.po
@@ -81,8 +81,13 @@ msgstr "Navn"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/de.po
+++ b/users_ldap_populate/i18n/de.po
@@ -81,11 +81,14 @@ msgstr "Name"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr "Kein Anmelde-Attribut gefunden: Konnte aus Filter %s kein Anmelde-Attribut extrahieren"
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
-"Kein Anmelde-Attribut gefunden: Konnte aus Filter %s kein Anmelde-Attribut "
-"extrahieren"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created

--- a/users_ldap_populate/i18n/el_GR.po
+++ b/users_ldap_populate/i18n/el_GR.po
@@ -82,8 +82,13 @@ msgstr "Ονομασία"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/en_GB.po
+++ b/users_ldap_populate/i18n/en_GB.po
@@ -82,8 +82,13 @@ msgstr "Name"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es.po
+++ b/users_ldap_populate/i18n/es.po
@@ -81,8 +81,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_AR.po
+++ b/users_ldap_populate/i18n/es_AR.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_CL.po
+++ b/users_ldap_populate/i18n/es_CL.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_CO.po
+++ b/users_ldap_populate/i18n/es_CO.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_CR.po
+++ b/users_ldap_populate/i18n/es_CR.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_DO.po
+++ b/users_ldap_populate/i18n/es_DO.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_EC.po
+++ b/users_ldap_populate/i18n/es_EC.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_ES.po
+++ b/users_ldap_populate/i18n/es_ES.po
@@ -82,8 +82,13 @@ msgstr ""
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_MX.po
+++ b/users_ldap_populate/i18n/es_MX.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_PE.po
+++ b/users_ldap_populate/i18n/es_PE.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_PY.po
+++ b/users_ldap_populate/i18n/es_PY.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/es_VE.po
+++ b/users_ldap_populate/i18n/es_VE.po
@@ -82,8 +82,13 @@ msgstr "Nombre"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/et.po
+++ b/users_ldap_populate/i18n/et.po
@@ -81,8 +81,13 @@ msgstr "Nimi"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/eu.po
+++ b/users_ldap_populate/i18n/eu.po
@@ -81,8 +81,13 @@ msgstr "Izena"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/fa.po
+++ b/users_ldap_populate/i18n/fa.po
@@ -81,8 +81,13 @@ msgstr "نام"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/fi.po
+++ b/users_ldap_populate/i18n/fi.po
@@ -81,8 +81,13 @@ msgstr "Nimi"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/fr.po
+++ b/users_ldap_populate/i18n/fr.po
@@ -47,7 +47,7 @@ msgstr "Nom affiché"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_id
 msgid "ID"
-msgstr "ID"
+msgstr "Identifiant"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_ldap_id
@@ -87,6 +87,7 @@ msgstr "Pas d'attribut login trouvé : impossible d'extraire l'attribut pour le 
 
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
 msgid "Unable to process user with login %s"
 msgstr "Impossible de synchroniser l'utilisateur ayant l'identifiant suivant : %s"
 

--- a/users_ldap_populate/i18n/fr.po
+++ b/users_ldap_populate/i18n/fr.po
@@ -9,15 +9,15 @@ msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-01 02:11+0000\n"
-"PO-Revision-Date: 2019-03-01 17:53+0000\n"
-"Last-Translator: Alexandre Fayolle <alexandre.fayolle@camptocamp.com>\n"
+"PO-Revision-Date: 2019-24-04 13:23+0000\n"
+"Last-Translator: Robin Hède <robin.hede@outlook.fr>\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.4\n"
+"X-Generator: Poedit 2.2.1\n"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.populate_wizard_view
@@ -62,12 +62,12 @@ msgstr "Dernière modification le"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_write_uid
 msgid "Last Updated by"
-msgstr "Mis à jour par"
+msgstr "Dernière mise à jour par"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_write_date
 msgid "Last Updated on"
-msgstr "Mis à jour le"
+msgstr "Dernière mise à jour le"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,help:users_ldap_populate.field_res_company_ldap_no_deactivate_user_ids
@@ -82,11 +82,13 @@ msgstr "Nom"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
-msgstr ""
-"Pas d'attribut login trouvé: impossible d'extraire l'attribut pour le login "
-"du filtre %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr "Pas d'attribut login trouvé : impossible d'extraire l'attribut pour le login du filtre %s"
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+msgid "Unable to process user with login %s"
+msgstr "Impossible de synchroniser l'utilisateur ayant l'identifiant suivant : %s"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created
@@ -106,17 +108,17 @@ msgstr "OK"
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.company_form_view
 msgid "Populate"
-msgstr "Remplir"
+msgstr "Synchroniser"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.company_form_view
 msgid "Populate user database"
-msgstr "Remplir la base d'utilisateurs"
+msgstr "Synchroniser les utilisateurs"
 
 #. module: users_ldap_populate
 #: model:ir.model,name:users_ldap_populate.model_res_company_ldap_populate_wizard
 msgid "Populate users from LDAP"
-msgstr "Remplir les utilisateurs depuis le LDAP"
+msgstr "Synchroniser les utilisateurs depuis le serveur LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_no_deactivate_user_ids

--- a/users_ldap_populate/i18n/fr_CA.po
+++ b/users_ldap_populate/i18n/fr_CA.po
@@ -37,7 +37,7 @@ msgstr "Créé le"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_deactivate_unknown_users
 msgid "Deactivate unknown users"
-msgstr ""
+msgstr "Désactiver les utilisateurs inconnus"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_display_name
@@ -52,12 +52,12 @@ msgstr "Identifiant"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_ldap_id
 msgid "LDAP Configuration"
-msgstr ""
+msgstr "Configuration LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard___last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Dernière modification le"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_write_uid
@@ -72,7 +72,7 @@ msgstr "Dernière mise à jour le"
 #. module: users_ldap_populate
 #: model:ir.model.fields,help:users_ldap_populate.field_res_company_ldap_no_deactivate_user_ids
 msgid "List users who never should be deactivated by the deactivation wizard"
-msgstr ""
+msgstr "Liste des utilisateurs à ne pas archiver même si absents du LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_name
@@ -82,46 +82,51 @@ msgstr "Nom"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
-msgstr ""
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr "Pas d'attribut login trouvé : impossible d'extraire l'attribut pour le login du filtre %s"
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
+msgstr "Impossible de synchroniser l'utilisateur ayant l'identifiant suivant : %s"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created
 msgid "Number of users created"
-msgstr ""
+msgstr "Nombre d'utilisateurs créés"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_deactivated
 msgid "Number of users deactivated"
-msgstr ""
+msgstr "Nombre d'utilisateurs archivés"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.populate_wizard_view
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.company_form_view
 msgid "Populate"
-msgstr ""
+msgstr "Synchroniser"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.company_form_view
 msgid "Populate user database"
-msgstr ""
+msgstr "Synchroniser les utilisateurs"
 
 #. module: users_ldap_populate
 #: model:ir.model,name:users_ldap_populate.model_res_company_ldap_populate_wizard
 msgid "Populate users from LDAP"
-msgstr ""
+msgstr "Synchroniser les utilisateurs depuis le serveur LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_no_deactivate_user_ids
 msgid "Users never to deactivate"
-msgstr ""
+msgstr "Utilisateurs à ne pas archiver"
 
 #. module: users_ldap_populate
 #: model:ir.model,name:users_ldap_populate.model_res_company_ldap
 msgid "res.company.ldap"
-msgstr ""
+msgstr "res.company.ldap"

--- a/users_ldap_populate/i18n/fr_CH.po
+++ b/users_ldap_populate/i18n/fr_CH.po
@@ -37,7 +37,7 @@ msgstr "Créé le"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_deactivate_unknown_users
 msgid "Deactivate unknown users"
-msgstr ""
+msgstr "Désactiver les utilisateurs inconnus"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_display_name
@@ -47,12 +47,12 @@ msgstr "Nom affiché"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_id
 msgid "ID"
-msgstr "ID"
+msgstr "Identifiant"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_ldap_id
 msgid "LDAP Configuration"
-msgstr ""
+msgstr "Configuration LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard___last_update
@@ -62,66 +62,71 @@ msgstr "Dernière modification le"
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_write_uid
 msgid "Last Updated by"
-msgstr "Modifié par"
+msgstr "Dernière mise à jour par"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_write_date
 msgid "Last Updated on"
-msgstr "Modifié le"
+msgstr "Dernière mise à jour le"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,help:users_ldap_populate.field_res_company_ldap_no_deactivate_user_ids
 msgid "List users who never should be deactivated by the deactivation wizard"
-msgstr ""
+msgstr "Liste des utilisateurs à ne pas archiver même si absents du LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_name
 msgid "Name"
-msgstr ""
+msgstr "Nom"
 
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
-msgstr ""
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr "Pas d'attribut login trouvé : impossible d'extraire l'attribut pour le login du filtre %s"
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
+msgstr "Impossible de synchroniser l'utilisateur ayant l'identifiant suivant : %s"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created
 msgid "Number of users created"
-msgstr ""
+msgstr "Nombre d'utilisateurs créés"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_deactivated
 msgid "Number of users deactivated"
-msgstr ""
+msgstr "Nombre d'utilisateurs archivés"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.populate_wizard_view
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.company_form_view
 msgid "Populate"
-msgstr ""
+msgstr "Synchroniser"
 
 #. module: users_ldap_populate
 #: model:ir.ui.view,arch_db:users_ldap_populate.company_form_view
 msgid "Populate user database"
-msgstr ""
+msgstr "Synchroniser les utilisateurs"
 
 #. module: users_ldap_populate
 #: model:ir.model,name:users_ldap_populate.model_res_company_ldap_populate_wizard
 msgid "Populate users from LDAP"
-msgstr ""
+msgstr "Synchroniser les utilisateurs depuis le serveur LDAP"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_no_deactivate_user_ids
 msgid "Users never to deactivate"
-msgstr ""
+msgstr "Utilisateurs à ne pas archiver"
 
 #. module: users_ldap_populate
 #: model:ir.model,name:users_ldap_populate.model_res_company_ldap
 msgid "res.company.ldap"
-msgstr ""
+msgstr "res.company.ldap"

--- a/users_ldap_populate/i18n/gl.po
+++ b/users_ldap_populate/i18n/gl.po
@@ -81,8 +81,13 @@ msgstr "Nome"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/gl_ES.po
+++ b/users_ldap_populate/i18n/gl_ES.po
@@ -82,8 +82,13 @@ msgstr ""
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/he.po
+++ b/users_ldap_populate/i18n/he.po
@@ -81,8 +81,13 @@ msgstr "שם"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/hr.po
+++ b/users_ldap_populate/i18n/hr.po
@@ -83,8 +83,13 @@ msgstr "Naziv"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/hr_HR.po
+++ b/users_ldap_populate/i18n/hr_HR.po
@@ -83,10 +83,14 @@ msgstr "Naziv"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr "Nije pronađen login atribut: Nije moguće izvući login atribut iz filtera %s"
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
-"Nije pronađen login atribut: Nije moguće izvući login atribut iz filtera %s"
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created

--- a/users_ldap_populate/i18n/hu.po
+++ b/users_ldap_populate/i18n/hu.po
@@ -81,8 +81,13 @@ msgstr "Név"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/id.po
+++ b/users_ldap_populate/i18n/id.po
@@ -81,8 +81,13 @@ msgstr "Nama"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/it.po
+++ b/users_ldap_populate/i18n/it.po
@@ -82,8 +82,13 @@ msgstr "Nome"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/ja.po
+++ b/users_ldap_populate/i18n/ja.po
@@ -81,8 +81,13 @@ msgstr "名称"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/ko.po
+++ b/users_ldap_populate/i18n/ko.po
@@ -81,8 +81,13 @@ msgstr "이름"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/lt.po
+++ b/users_ldap_populate/i18n/lt.po
@@ -82,8 +82,13 @@ msgstr "Pavadinimas"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/lt_LT.po
+++ b/users_ldap_populate/i18n/lt_LT.po
@@ -83,8 +83,13 @@ msgstr ""
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/lv.po
+++ b/users_ldap_populate/i18n/lv.po
@@ -82,8 +82,13 @@ msgstr "Nosaukums"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/mk.po
+++ b/users_ldap_populate/i18n/mk.po
@@ -81,8 +81,13 @@ msgstr "Име"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/mn.po
+++ b/users_ldap_populate/i18n/mn.po
@@ -81,8 +81,13 @@ msgstr "Нэр"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/nb.po
+++ b/users_ldap_populate/i18n/nb.po
@@ -82,8 +82,13 @@ msgstr "Navn"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/nb_NO.po
+++ b/users_ldap_populate/i18n/nb_NO.po
@@ -82,8 +82,13 @@ msgstr ""
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/nl.po
+++ b/users_ldap_populate/i18n/nl.po
@@ -81,8 +81,13 @@ msgstr "Naam"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/nl_BE.po
+++ b/users_ldap_populate/i18n/nl_BE.po
@@ -82,8 +82,13 @@ msgstr "Naam:"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/nl_NL.po
+++ b/users_ldap_populate/i18n/nl_NL.po
@@ -82,8 +82,13 @@ msgstr "Naam"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/pl.po
+++ b/users_ldap_populate/i18n/pl.po
@@ -83,10 +83,14 @@ msgstr "Nazwa"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
 msgstr ""
 
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
+msgstr ""
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created
 msgid "Number of users created"

--- a/users_ldap_populate/i18n/pt.po
+++ b/users_ldap_populate/i18n/pt.po
@@ -81,8 +81,13 @@ msgstr "Nome"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/pt_BR.po
+++ b/users_ldap_populate/i18n/pt_BR.po
@@ -82,8 +82,13 @@ msgstr "Nome"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/pt_PT.po
+++ b/users_ldap_populate/i18n/pt_PT.po
@@ -82,8 +82,13 @@ msgstr "Nome"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/ro.po
+++ b/users_ldap_populate/i18n/ro.po
@@ -82,8 +82,13 @@ msgstr "Nume"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/ru.po
+++ b/users_ldap_populate/i18n/ru.po
@@ -83,8 +83,13 @@ msgstr "Название"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/sk.po
+++ b/users_ldap_populate/i18n/sk.po
@@ -81,8 +81,13 @@ msgstr "Meno"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/sl.po
+++ b/users_ldap_populate/i18n/sl.po
@@ -82,11 +82,15 @@ msgstr "Naziv"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
-msgstr ""
-"Prijavni atribut ni najden: ni bilo mogoče izvleči prijavnega atributa iz "
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr "Prijavni atribut ni najden: ni bilo mogoče izvleči prijavnega atributa iz "
 "filtra %s"
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
+msgstr ""
 
 #. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created

--- a/users_ldap_populate/i18n/sr.po
+++ b/users_ldap_populate/i18n/sr.po
@@ -82,8 +82,13 @@ msgstr "Ime"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/sr@latin.po
+++ b/users_ldap_populate/i18n/sr@latin.po
@@ -83,8 +83,13 @@ msgstr "Ime:"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/sv.po
+++ b/users_ldap_populate/i18n/sv.po
@@ -81,8 +81,13 @@ msgstr "Namn"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/th.po
+++ b/users_ldap_populate/i18n/th.po
@@ -81,8 +81,13 @@ msgstr "ชื่อ"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/tr.po
+++ b/users_ldap_populate/i18n/tr.po
@@ -81,8 +81,13 @@ msgstr "Adı"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/tr_TR.po
+++ b/users_ldap_populate/i18n/tr_TR.po
@@ -82,8 +82,13 @@ msgstr "Ad"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/uk.po
+++ b/users_ldap_populate/i18n/uk.po
@@ -82,8 +82,13 @@ msgstr "Name"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/users_ldap_populate.pot
+++ b/users_ldap_populate/i18n/users_ldap_populate.pot
@@ -81,6 +81,7 @@ msgstr ""
 
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
 msgid "Unable to process user with login %s"
 msgstr ""
 

--- a/users_ldap_populate/i18n/users_ldap_populate.pot
+++ b/users_ldap_populate/i18n/users_ldap_populate.pot
@@ -80,6 +80,11 @@ msgid "No login attribute found: Could not extract login attribute from filter %
 msgstr ""
 
 #. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+msgid "Unable to process user with login %s"
+msgstr ""
+
+#. module: users_ldap_populate
 #: model:ir.model.fields,field_description:users_ldap_populate.field_res_company_ldap_populate_wizard_users_created
 msgid "Number of users created"
 msgstr ""
@@ -118,4 +123,3 @@ msgstr ""
 #: model:ir.model,name:users_ldap_populate.model_res_company_ldap
 msgid "res.company.ldap"
 msgstr ""
-

--- a/users_ldap_populate/i18n/vi.po
+++ b/users_ldap_populate/i18n/vi.po
@@ -81,8 +81,13 @@ msgstr "Tên"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/vi_VN.po
+++ b/users_ldap_populate/i18n/vi_VN.po
@@ -82,8 +82,13 @@ msgstr "Tên"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/zh_CN.po
+++ b/users_ldap_populate/i18n/zh_CN.po
@@ -82,8 +82,13 @@ msgstr "名称"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/i18n/zh_TW.po
+++ b/users_ldap_populate/i18n/zh_TW.po
@@ -82,8 +82,13 @@ msgstr "名稱"
 #. module: users_ldap_populate
 #: code:addons/users_ldap_populate/models/users_ldap.py:64
 #, python-format
-msgid ""
-"No login attribute found: Could not extract login attribute from filter %s"
+msgid "No login attribute found: Could not extract login attribute from filter %s"
+msgstr ""
+
+#. module: users_ldap_populate
+#: code:addons/users_ldap_populate/models/users_ldap.py:91
+#, python-format
+msgid "Unable to process user with login %s"
 msgstr ""
 
 #. module: users_ldap_populate

--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -125,10 +125,17 @@ class CompanyLDAP(models.Model):
         conn = self.connect(conf)
         ldap_password = conf['ldap_password'] or ''
         ldap_binddn = conf['ldap_binddn'] or ''
-        conn.simple_bind_s(ldap_binddn.encode('utf-8'), ldap_password.encode('utf-8'))
-        results = conn.search_st(conf['ldap_base'].encode('utf-8'), ldap.SCOPE_SUBTREE,
-                                 ldap_filter.encode('utf8'), None,
-                                 timeout=timeout)
+        conn.simple_bind_s(
+            ldap_binddn.encode('utf-8'),
+            ldap_password.encode('utf-8')
+        )
+        results = conn.search_st(
+            conf['ldap_base'].encode('utf-8'),
+            ldap.SCOPE_SUBTREE,
+            ldap_filter.encode('utf8'),
+            None,
+            timeout=timeout
+        )
         conn.unbind()
         return results
 

--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -123,9 +123,9 @@ class CompanyLDAP(models.Model):
         """
         ldap_filter = filter_format(conf['ldap_filter'] % user_name, ())
         conn = self.connect(conf)
-        conn.simple_bind_s(conf['ldap_binddn'] or '',
-                           conf['ldap_password'] or '')
-        results = conn.search_st(conf['ldap_base'], ldap.SCOPE_SUBTREE,
+        conn.simple_bind_s(conf['ldap_binddn'].encode('utf-8') or '',
+                           conf['ldap_password'].encode('utf-8') or '')
+        results = conn.search_st(conf['ldap_base'].encode('utf-8'), ldap.SCOPE_SUBTREE,
                                  ldap_filter.encode('utf8'), None,
                                  timeout=timeout)
         conn.unbind()

--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -123,8 +123,9 @@ class CompanyLDAP(models.Model):
         """
         ldap_filter = filter_format(conf['ldap_filter'] % user_name, ())
         conn = self.connect(conf)
-        conn.simple_bind_s(conf['ldap_binddn'].encode('utf-8') or '',
-                           conf['ldap_password'].encode('utf-8') or '')
+        ldap_password = conf['ldap_password'] or ''
+        ldap_binddn = conf['ldap_binddn'] or ''
+        conn.simple_bind_s(ldap_binddn.encode('utf-8'), ldap_password.encode('utf-8'))
         results = conn.search_st(conf['ldap_base'].encode('utf-8'), ldap.SCOPE_SUBTREE,
                                  ldap_filter.encode('utf8'), None,
                                  timeout=timeout)

--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -88,7 +88,7 @@ class CompanyLDAP(models.Model):
                         user_id = res[0]
                     else:
                         raise UserError(
-                            'Unable to process user with login %s' % login
+                            _("Unable to process user with login %s") % login
                         )
                 known_user_ids.append(user_id)
         users_created = users_model.search_count([]) - users_count_before

--- a/users_ldap_populate/tests/test_users_ldap_populate.py
+++ b/users_ldap_populate/tests/test_users_ldap_populate.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016-2018 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from openerp.tests.common import TransactionCase
 from contextlib import contextmanager
+from odoo.tests.common import TransactionCase
 
 
 class PatchLDAPConnection(object):


### PR DESCRIPTION
Hi,

Currently, you can not use special characters in the username, password, or LDAP base.

To fix that, you just have to modify the lines 126 to 130 of the file _users_ldap.py_ like this:
```
conn.simple_bind_s(conf['ldap_binddn'].encode('utf-8') or '',
                   conf['ldap_password'].encode('utf-8') or '')
results = conn.search_st(conf['ldap_base'].encode('utf-8'), ldap.SCOPE_SUBTREE,
                         ldap_filter.encode('utf8'), None,
                         timeout=60)
```

Best regards,

Robin Hède.