### PR TITLE
[IMP] base_exception: Only write if a change is necessary

### DIFF
--- a/base_exception/__manifest__.py
+++ b/base_exception/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Exception Rule',
-    'version': '11.0.1.1.0',
+    'version': '11.0.1.1.1',
     'category': 'Generic Modules',
     'summary': """
     This module provide an abstract model to manage customizable

--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -185,7 +185,10 @@ class BaseException(models.AbstractModel):
                 continue
             exception_ids = obj._detect_exceptions(
                 model_exceptions, sub_exceptions)
-            obj.exception_ids = [(6, 0, exception_ids)]
+            if set(obj.exception_ids.ids).symmetric_difference(
+                set(exception_ids)
+            ):
+                obj.exception_ids = [(6, 0, exception_ids)]
             all_exception_ids += exception_ids
         return all_exception_ids
 


### PR DESCRIPTION
Without this change, the base_exception was unable to integrate with server-ux/base_tier_validation without an integration module for each affected model. Also, no writes will be launched if no differences are found.