### PR TITLE
[FIX] fix security issue due to wrong cache invalidation

### DIFF
--- a/base_suspend_security/models/ir_model_access.py
+++ b/base_suspend_security/models/ir_model_access.py
@@ -33,3 +33,8 @@ class IrModelAccess(models.Model):
         return super(IrModelAccess, self).check(
             cr, uid, model, mode=mode, raise_exception=raise_exception,
             context=context)
+
+    def call_cache_clearing_methods(self, cr):
+        # we need to clear manually the original cache
+        super(IrModelAccess, self).check.clear_cache(self)
+        return super(IrModelAccess, self).call_cache_clearing_methods(cr)


### PR DESCRIPTION
When we do an inherit with ormcache the cache is not clear correctly.
So if you try to remove the access right on a user, it will not remove until a restart of Odoo!
Here is a patch and a test that show the bug and fix it with a hack.

@StefanRijnhart @sbidoul @guewen @gurneyalex 

you can reproduce the bug by just removing the code of the method call_cache_clearing_methods