### PR TITLE
[12.0][base_exception] Fix union between recordset and parent recordset in base_exception

### DIFF
--- a/base_exception/__manifest__.py
+++ b/base_exception/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Exception Rule',
-    'version': '12.0.2.0.2',
+    'version': '12.0.2.0.3',
     'category': 'Generic Modules',
     'summary': """
     This module provide an abstract model to manage customizable

--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -62,6 +62,16 @@ class BaseExceptionMethod(models.AbstractModel):
     _description = 'Exception Rule Methods'
 
     @api.multi
+    def _get_main_records(self):
+        """
+            Used in case we check exceptions on a record but write these
+            exceptions on a parent record. Typical example is with
+            sale.order.line. We check exceptions on some sale order lines but
+            write these exceptions on the sale order, so they are visible.
+        """
+        return self
+
+    @api.multi
     def _reverse_field(self):
         raise NotImplementedError()
 
@@ -85,7 +95,8 @@ class BaseExceptionMethod(models.AbstractModel):
             records_with_exception = self._detect_exceptions(rule)
             reverse_field = self._reverse_field()
             if self:
-                commons = self & rule[reverse_field]
+                main_records = self._get_main_records()
+                commons = main_records & rule[reverse_field]
                 to_remove = commons - records_with_exception
                 to_add = records_with_exception - commons
                 to_remove_list = [(3, x.id, _) for x in to_remove]


### PR DESCRIPTION
Same as https://github.com/OCA/server-tools/pull/1601

There is still a bug due to last big refactore on the module.
A test has been added on sale_exception to detect it.

In the code, tested with sale_exception, we try to get the intersection between sale.order.line and sale.order, which obviously fail.

In this PR, we implement a way to manage this properly in submodules.

@hparfr @bealdav @mourad-ehm @sebastienbeau