### PR TITLE
[FIX][10.0] add safe_eval context

### DIFF
--- a/base_exception/__manifest__.py
+++ b/base_exception/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {'name': 'Exception Rule',
- 'version': '10.0.3.0.1',
+ 'version': '10.0.3.0.2',
  'category': 'Generic Modules',
  'summary': """This module provide an abstract model to manage customizable
   exceptions to be applied on different models (sale order, invoice, ...)""",

--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -63,11 +63,23 @@ class ExceptionRule(models.Model):
                       "domain is missing to match the exception type.")
                 )
 
+    def _get_eval_context(self):
+        """ Prepare the context used when evaluating python code
+            :returns: dict -- evaluation context given to safe_eval
+        """
+        return {
+            'uid': self.env.uid,
+            'user': self.env.user,
+            'env': self.env,
+            'self': self,
+        }
+
     @api.multi
     def _get_domain(self):
         """ override me to customize domains according exceptions cases """
         self.ensure_one()
-        return safe_eval(self.domain)
+        eval_context = self._get_eval_context()
+        return safe_eval(self.domain, eval_context)
 
 
 class BaseExceptionMethod(models.AbstractModel):

--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -68,10 +68,7 @@ class ExceptionRule(models.Model):
             :returns: dict -- evaluation context given to safe_eval
         """
         return {
-            'uid': self.env.uid,
-            'user': self.env.user,
-            'env': self.env,
-            'self': self,
+            'ref': self.env.ref,
         }
 
     @api.multi


### PR DESCRIPTION
Add safe_eval context to allow evaluating domain with python params ex(use ref method to get object by xml_id).
