### PR TITLE
[IMP][12.0][base_exception] Improvements on base_exception

### DIFF
--- a/base_exception/README.rst
+++ b/base_exception/README.rst
@@ -75,7 +75,7 @@ Contributors
 * SodexisTeam <dev@sodexis.com>
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
-* Iván Todorovich <ivan.todorovich@gmail.com>
+* Iván Todorovich <ivan.todorovich@druidoo.io>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_exception/__manifest__.py
+++ b/base_exception/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Exception Rule',
-    'version': '12.0.2.0.3',
+    'version': '12.0.3.0.0',
     'category': 'Generic Modules',
     'summary': """
     This module provide an abstract model to manage customizable

--- a/base_exception/readme/CONTRIBUTORS.rst
+++ b/base_exception/readme/CONTRIBUTORS.rst
@@ -6,4 +6,4 @@
 * SodexisTeam <dev@sodexis.com>
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
-* Iván Todorovich <ivan.todorovich@gmail.com>
+* Iván Todorovich <ivan.todorovich@druidoo.io>


### PR DESCRIPTION
This is what makes this possible in `sale_exception` (https://github.com/OCA/sale-workflow/pull/878):

![image](https://user-images.githubusercontent.com/1914185/59679214-890afd00-91ce-11e9-97e2-fa6f3fd7866a.png)

If modules like `sale_exception` implement this approach for displaying errors, main_exception_id field wouldn't be necessary anymore.

---

Also added `copy=False` to `exception_ids` because they should be reevaluated, not copied.
