### PR TITLE
[9.0][sql_export] Fix uses of params in sql query

### DIFF
--- a/sql_export/demo/sql_export.xml
+++ b/sql_export/demo/sql_export.xml
@@ -44,8 +44,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
     <record id="sql_export_partner_with_variables" model="sql.export">
         <field name="name">Export Partners With Variables (Demo Data)</field>
-	<field name="query">SELECT p.id FROM res_partner p LEFT JOIN res_partner_res_partner_category_rel rel ON rel.partner_id = p.id WHERE create_date &lt; %(x_date)s AND id = %(x_id)s AND rel.category_id in %(x_partner_categ_ids)s</field>
-	<field eval="[(6, 0, [ref('date_field_variable_sql'), ref('integer_field_variable_sql'), ref('m2m_field_variable_sql')])]" name="field_ids"/>
+        <field name="query">SELECT p.id FROM res_partner p LEFT JOIN res_partner_res_partner_category_rel rel ON rel.partner_id = p.id WHERE create_date &lt; %(x_date)s AND id = %(x_id)s AND rel.category_id in %(x_partner_categ_ids)s</field>
+        <field eval="[(6, 0, [ref('date_field_variable_sql'), ref('integer_field_variable_sql'), ref('m2m_field_variable_sql')])]" name="field_ids"/>
     </record>
 
     <function model="sql.export" name="button_validate_sql_expression" eval="([ref('sql_export.sql_export_partner_with_variables')])"/>

--- a/sql_export/demo/sql_export.xml
+++ b/sql_export/demo/sql_export.xml
@@ -7,11 +7,47 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 <openerp><data>
 
+    <record id="date_field_variable_sql" model="ir.model.fields">
+        <field name="name">x_date</field>
+        <field name="field_description">Date</field>
+        <field name="ttype">date</field>
+        <field name="model_id" ref="sql_export.model_sql_file_wizard"/>
+        <field name="model">sql.file.wizard</field>
+        <field name="state">manual</field>
+    </record>
+
+    <record id="integer_field_variable_sql" model="ir.model.fields">
+        <field name="name">x_id</field>
+        <field name="field_description">ID</field>
+        <field name="ttype">integer</field>
+        <field name="model_id" ref="sql_export.model_sql_file_wizard"/>
+        <field name="model">sql.file.wizard</field>
+        <field name="state">manual</field>
+    </record>
+
+    <record id="m2m_field_variable_sql" model="ir.model.fields">
+        <field name="name">x_partner_categ_ids</field>
+        <field name="field_description">Partner Categories</field>
+        <field name="ttype">many2many</field>
+        <field name="model_id" ref="sql_export.model_sql_file_wizard"/>
+        <field name="model">sql.file.wizard</field>
+        <field name="state">manual</field>
+        <field name="relation">res.partner.category</field>
+    </record>
+
     <record id="sql_export_partner" model="sql.export">
         <field name="name">Export Partners (Demo Data)</field>
         <field name="query">SELECT name, street FROM res_partner;</field>
     </record>
 
     <function model="sql.export" name="button_validate_sql_expression" eval="([ref('sql_export.sql_export_partner')])"/>
+
+    <record id="sql_export_partner_with_variables" model="sql.export">
+        <field name="name">Export Partners With Variables (Demo Data)</field>
+	<field name="query">SELECT p.id FROM res_partner p LEFT JOIN res_partner_res_partner_category_rel rel ON rel.partner_id = p.id WHERE create_date &lt; %(x_date)s AND id = %(x_id)s AND rel.category_id in %(x_partner_categ_ids)s</field>
+	<field eval="[(6, 0, [ref('date_field_variable_sql'), ref('integer_field_variable_sql'), ref('m2m_field_variable_sql')])]" name="field_ids"/>
+    </record>
+
+    <function model="sql.export" name="button_validate_sql_expression" eval="([ref('sql_export.sql_export_partner_with_variables')])"/>
 
 </data></openerp>

--- a/sql_export/tests/test_sql_query.py
+++ b/sql_export/tests/test_sql_query.py
@@ -6,6 +6,7 @@
 import base64
 from openerp.tests.common import TransactionCase
 from openerp.exceptions import Warning as UserError
+from openerp import fields
 
 
 class TestExportSqlQuery(TransactionCase):
@@ -56,3 +57,16 @@ class TestExportSqlQuery(TransactionCase):
             self.assertEqual(
                 sql_export.state, 'sql_valid',
                 "%s is a valid request" % (query))
+
+    def test_sql_query_with_params(self):
+        query = self.env.ref('sql_export.sql_export_partner_with_variables')
+        categ_id = self.env.ref('base.res_partner_category_0').id
+        wizard = self.wizard_obj.create({
+            'sql_export_id': query.id,
+            'x_date': fields.Date.today(),
+            'x_id': 1,
+            'x_partner_categ_ids': [(6, 0, [categ_id])]
+        })
+        wizard.export_sql()
+        export = base64.b64decode(wizard.binary_file)
+        self.assertTrue(export)

--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -30,7 +30,7 @@
                 <group name="request" string="SQL Request" groups="sql_request_abstract.group_sql_request_user">
                     <field name="query" nolabel="1" placeholder="select * from res_partner"/>
                 </group>
-                <group string="Parameters" groups="sql_request_abstract.group_sql_request_user">
+                <group name="parameters" string="Parameters" groups="sql_request_abstract.group_sql_request_user">
                     <field name="field_ids" nolabel="1"/>
                 </group>
                 <group groups="sql_request_abstract.group_sql_request_manager">
@@ -76,8 +76,17 @@
     <record id="sql_parameter_view_form" model="ir.ui.view">
         <field name="name">Sql_parameter_form_view</field>
         <field name="model">ir.model.fields</field>
+	<field name="priority">150</field>
         <field name="arch" type="xml">
             <form string="SQL export">
+		<group>
+                    <field name="name"/>
+                    <field name="field_description"/>
+                    <field name="ttype"/>
+		    <field name="relation" attrs="{'invisible': [('ttype', 'not in', ('many2one', 'many2many', 'one2many'))], 'required': [('ttype', 'in', ('many2one', 'many2many', 'one2many'))]}"/>
+                    <field name="model_id" readonly="1"/>
+                    <field name="model" invisible="1"/>
+	        </group>
             </form>
         </field>
     </record>
@@ -85,23 +94,41 @@
     <record id="sql_parameter_view_tree" model="ir.ui.view">
         <field name="name">Sql_parameter_tree_view</field>
         <field name="model">ir.model.fields</field>
+	<field name="priority">150</field>
         <field name="arch" type="xml">
             <tree string="SQL Parameter">
                 <field name="name"/>
+                <field name="field_description"/>
+                <field name="ttype"/>
+                <field name="required"/>
             </tree>
         </field>
     </record>
 
-    <record id="sql_parameter_tree_action" model="ir.actions.act_window">
+    <record id="sql_parameter_action" model="ir.actions.act_window">
         <field name="name">SQL Parameter</field>
         <field name="res_model">ir.model.fields</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
-        <field name="context" eval="{'default_model_id': ref('sql_export.model_sql_file_wizard'), 'default_size': 64, 'search_default_state': 'manual'}"/>
+        <field name="context" eval="{'default_model_id': ref('sql_export.model_sql_file_wizard'), 'default_size': 64, 'search_default_state': 'manual', 'default_model': 'sql.file.wizard'}"/>
         <field name="domain">[('model','=','sql.file.wizard')]</field>
     </record>
 
-    <menuitem id="sql_parameter_menu_view" name="Sql Export Variables" parent="sql_export_menu" action="sql_parameter_tree_action" sequence="5" groups="sql_request_abstract.group_sql_request_manager"/>
+        <record id="sql_parameter_action_view_tree" model="ir.actions.act_window.view">
+            <field name="sequence" eval="1"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="sql_parameter_view_tree"/>
+            <field name="act_window_id" ref="sql_parameter_action"/>
+        </record>
+
+        <record id="sql_parameter_action_view_form" model="ir.actions.act_window.view">
+            <field name="sequence" eval="2"/>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="sql_parameter_view_form"/>
+            <field name="act_window_id" ref="sql_parameter_action"/>
+        </record>
+
+    <menuitem id="sql_parameter_menu_view" name="Sql Export Variables" parent="sql_export_menu" action="sql_parameter_action" sequence="5" groups="sql_request_abstract.group_sql_request_manager"/>
 
 
 </data>

--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -76,17 +76,17 @@
     <record id="sql_parameter_view_form" model="ir.ui.view">
         <field name="name">Sql_parameter_form_view</field>
         <field name="model">ir.model.fields</field>
-	<field name="priority">150</field>
+        <field name="priority">150</field>
         <field name="arch" type="xml">
             <form string="SQL export">
-		<group>
+                <group>
                     <field name="name"/>
                     <field name="field_description"/>
                     <field name="ttype"/>
-		    <field name="relation" attrs="{'invisible': [('ttype', 'not in', ('many2one', 'many2many', 'one2many'))], 'required': [('ttype', 'in', ('many2one', 'many2many', 'one2many'))]}"/>
+                    <field name="relation" attrs="{'invisible': [('ttype', 'not in', ('many2one', 'many2many', 'one2many'))], 'required': [('ttype', 'in', ('many2one', 'many2many', 'one2many'))]}"/>
                     <field name="model_id" readonly="1"/>
                     <field name="model" invisible="1"/>
-	        </group>
+                </group>
             </form>
         </field>
     </record>
@@ -94,7 +94,7 @@
     <record id="sql_parameter_view_tree" model="ir.ui.view">
         <field name="name">Sql_parameter_tree_view</field>
         <field name="model">ir.model.fields</field>
-	<field name="priority">150</field>
+        <field name="priority">150</field>
         <field name="arch" type="xml">
             <tree string="SQL Parameter">
                 <field name="name"/>

--- a/sql_export/wizard/wizard_file.py
+++ b/sql_export/wizard/wizard_file.py
@@ -79,7 +79,12 @@ class SqlFileWizard(models.TransientModel):
         date = today_tz.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
         if sql_export.field_ids:
             for field in sql_export.field_ids:
-                variable_dict[field.name] = self[field.name]
+                if field.ttype == 'many2one':
+                    variable_dict[field.name] = self[field.name].id
+                elif field.ttype == 'many2many':
+                    variable_dict[field.name] = tuple(self[field.name].ids)
+                else:
+                    variable_dict[field.name] = self[field.name]
         if "%(company_id)s" in sql_export.query:
             variable_dict['company_id'] = self.env.user.company_id.id
         if "%(user_id)s" in sql_export.query:

--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -146,6 +146,7 @@ class SQLRequestMixin(models.AbstractModel):
 
         query = self.env.cr.mogrify(self.query, params).decode('utf-8')
 
+        # pylint: disable=sql-injection
         if mode in ('fetchone', 'fetchall'):
             pass
         elif mode == 'stdout':
@@ -181,6 +182,7 @@ class SQLRequestMixin(models.AbstractModel):
     # Private Section
     @api.model
     def _create_savepoint(self):
+        # pylint: disable=sql-injection
         rollback_name = '%s_%s' % (
             self._name.replace('.', '_'), uuid.uuid1().hex)
         req = "SAVEPOINT %s" % (rollback_name)
@@ -189,6 +191,7 @@ class SQLRequestMixin(models.AbstractModel):
 
     @api.model
     def _rollback_savepoint(self, rollback_name):
+        # pylint: disable=sql-injection
         req = "ROLLBACK TO SAVEPOINT %s" % (rollback_name)
         self.env.cr.execute(req)
 

--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -144,10 +144,7 @@ class SQLRequestMixin(models.AbstractModel):
         if mode in ('view', 'materialized_view'):
             rollback = False
 
-        params = params or {}
-        # pylint: disable=sql-injection
-        query = self.query % params
-        query = query.decode('utf-8')
+        query = self.env.cr.mogrify(self.query, params).decode('utf-8')
 
         if mode in ('fetchone', 'fetchall'):
             pass


### PR DESCRIPTION
Hello,

The use of variable in this module is broken since https://github.com/OCA/server-tools/pull/1301 I think.
Indeed, variable of type date, char don't work...
Variable of type integer or boolean work, but not the rest...

I don't understand what that was changed, also because in the present way, sql injection is possible.
So I have reverted the change in sql_request_abstract.
Also, I fixed the variable view for sql_export and I have added test to cover the bug (testing a sql_query with variables : integer/date/many2many.

@mreficent @bguillot @bealdav @legalsylvain 