### PR TITLE
[IMP] auto_backup: Count files instead of looking at dates

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -219,6 +219,7 @@ class DbBackup(models.Model):
         except:
             _logger.exception("Database backup failed: %s", self.name)
             escaped_tb = tools.html_escape(traceback.format_exc())
+            # pylint: disable=translation-required
             self.message_post(
                 "<p>%s</p><pre>%s</pre>" % (
                     _("Database backup failed."),
@@ -261,6 +262,7 @@ class DbBackup(models.Model):
         except:
             _logger.exception("Cleanup of old database backups failed: %s")
             escaped_tb = tools.html_escape(traceback.format_exc())
+            # pylint: disable=translation-required
             self.message_post(
                 "<p>%s</p><pre>%s</pre>" % (
                     _("Cleanup of old database backups failed."),

--- a/auto_backup/tests/test_auto_backup.py
+++ b/auto_backup/tests/test_auto_backup.py
@@ -3,7 +3,7 @@
 # © 2015 Alessio Gerace <alesiso.gerace@agilebg.com>
 # © 2016 Grupo ESOC Ingeniería de Servicios, S.L.U. - Jairo Llopis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
+import mock
 import os
 from datetime import datetime
 from openerp.tests import common
@@ -16,6 +16,7 @@ class TestsAutoBackup(common.TransactionCase):
         self.abk = self.env["db.backup"].create(
             {
                 'name': u'Têst backup',
+                'days_to_keep': 2,
             }
         )
 
@@ -26,3 +27,26 @@ class TestsAutoBackup(common.TransactionCase):
         generated_backup = [f for f in os.listdir(self.abk.folder)
                             if f >= filename]
         self.assertEqual(len(generated_backup), 1)
+        self.abk.action_backup()
+        # here the cleanup must kick in and delete the first backup
+        self.abk.action_backup()
+        generated_backup = [f for f in os.listdir(self.abk.folder)
+                            if f >= filename]
+        self.assertEqual(len(generated_backup), 2)
+
+    def test_remote(self):
+        with mock.patch(
+            'openerp.addons.auto_backup.models.db_backup.pysftp.Connection'
+        ) as mock_connection:
+            mock_contextmanager = mock.MagicMock()
+            mock_connection.return_value = mock.MagicMock()
+            mock_connection.return_value.__enter__.return_value =\
+                mock_contextmanager
+            mock_contextmanager.listdir.return_value = [
+                '1.dump.zip', '2.dump.zip', '3.dump.zip',
+            ]
+            with mock_connection() as test:
+                self.assertEqual(test, mock_contextmanager)
+            self.abk.method = 'sftp'
+            self.abk.action_backup()
+            mock_contextmanager.unlink.assert_called_once()


### PR DESCRIPTION
this solves two problems: If the oldest file to delete is some seconds older/newer than now, we'll either delete it when it shouldn't be deleted or the other way around.

Also, by making this not time dependent any more, there's no danger to delete all backups if some backups in between failed, it will always keep the last N backups.