### PR TITLE
[8.0][fetchmail_attach_from_folder] Run server action after handle emails

### DIFF
--- a/fetchmail_attach_from_folder/model/fetchmail_server.py
+++ b/fetchmail_attach_from_folder/model/fetchmail_server.py
@@ -112,9 +112,9 @@ class fetchmail_server(models.Model):
                 'finished checking for emails in %s server %s',
                 folder.path, this.name)
 
-        _logger.info('running server actions for matched_object_ids %s',
-            matched_object_ids)
-        this.run_server_action(matched_object_ids, folder)
+            _logger.info('running server actions for matched_object_ids %s',
+                matched_object_ids)
+            this.run_server_action(matched_object_ids, folder)
 
         return matched_object_ids
 


### PR DESCRIPTION
Add last step on handle_folder that execute `ir.actions.server` configured on
parent `fetchmail.server`.

I had to fix the `attach_mail` method to return the ids of the records as does
the `handle_match` method of `openerp_standard`.