### PR TITLE
auditlog: Fix fast-logging exception on create with multiple records

### DIFF
--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -119,3 +119,22 @@ class TestAuditlogFast(TransactionCase, AuditlogCommon):
     def tearDown(self):
         self.groups_rule.unlink()
         super(TestAuditlogFast, self).tearDown()
+
+    def test_LogCreateMulti(self):
+        """Test creation of multiple objects at once."""
+
+        auditlog_log = self.env['auditlog.log']
+        self.groups_rule.subscribe()
+
+        vals = [
+            {'name': 'Test Group 01'},
+            {'name': 'Test Group 02'},
+        ]
+        groups = self.env['res.groups'].create(vals)
+        self.assertTrue(len(groups) == 2)
+        for grp in groups:
+            self.assertTrue(auditlog_log.search([
+                ('model_id', '=', self.groups_model_id),
+                ('method', '=', 'create'),
+                ('res_id', '=', grp.id),
+            ]).ensure_one())


### PR DESCRIPTION
When fast-logging create calls the code assumed the old-style
calling convention where only one dictionary value is passed
into the create() function. When it received a list of
dictionaries instead it blew up trying to manipulate a
single dict object instead of a list.

o Fix the code to degrade gracefully to full logging, instead.
o Add a unit test to catch this case in the future
o Fixes #1619