### PR TITLE
[10.0] base_exception: fix concurrency issue

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -112,7 +112,12 @@ class BaseExceptionMethod(models.AbstractModel):
             to_add = records_with_exception - commons
             to_remove_list = [(3, x.id, _) for x in to_remove]
             to_add_list = [(4, x.id, _) for x in to_add]
-            rule.write({reverse_field: to_remove_list + to_add_list})
+            if to_remove_list or to_add_list:
+                self.env.cr.execute(
+                    'SELECT id FROM exception_rule '
+                    'WHERE id = %s FOR UPDATE', (rule.id,)
+                )  # no deadlock because the order is enforced by sequence
+                rule.write({reverse_field: to_remove_list + to_add_list})
             if records_with_exception:
                 all_exception_ids.append(rule.id)
         return all_exception_ids


### PR DESCRIPTION
When several connections are creating sale orders, the exceptions are checked parallel transactions. 

Without this fix:

* the write() can be  a noop but this will nevertheless trigger a UPDATE of the write_uid and write_date automatic fields, which in turn will cause a Rollback of the transaction because of concurrent access. When using the web client, there is a retry, but this causes a slow down. When scripting the creation of sale orders from an external system (e.g. Magento) this causes failed queue.jobs
* if the write() actually writes something, then we need to serialize the database updates / insertions, otherwise we run into the same problem as above. We do this by locking the rows of the transactions in SQL with SELECT ... FOR UPDATE. 