### PR TITLE
[12.0] IMP dbfilter_from_header allowing to use hostname (%h) or the first subdomain (%d)…

### DIFF
--- a/dbfilter_from_header/override.py
+++ b/dbfilter_from_header/override.py
@@ -15,6 +15,15 @@ def db_filter(dbs, httprequest=None):
     dbs = db_filter_org(dbs, httprequest)
     httprequest = httprequest or http.request.httprequest
     db_filter_hdr = httprequest.environ.get('HTTP_X_ODOO_DBFILTER')
+
+    # copied from original db_filter function, to support '%h' and '%d'
+    h = httprequest.environ.get('HTTP_HOST', '').split(':')[0]
+    d, _, r = h.partition('.')
+    if d == "www" and r:
+        d = r.partition('.')[0]
+    d, h = re.escape(d), re.escape(h)
+    db_filter_hdr = db_filter_hdr.replace('%h', h).replace('%d', d)
+
     if db_filter_hdr:
         dbs = [db for db in dbs if re.match(db_filter_hdr, db)]
     return dbs

--- a/dbfilter_from_header/readme/CONFIGURE.rst
+++ b/dbfilter_from_header/readme/CONFIGURE.rst
@@ -16,3 +16,5 @@ applied before looking at the regular expression in the header.
 And make sure that proxy mode is enabled in Odoo's configuration file:
 
 ``proxy_mode = True``
+
+Your filter regex can contain dynamically injected hostname (%h) or the first subdomain (%d) through which the system is being accessed

--- a/dbfilter_from_header/readme/CONTRIBUTORS.rst
+++ b/dbfilter_from_header/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Fabio Vilchez <fabio.vilchez@clearcorp.co.cr>
 * Jos De Graeve <Jos.DeGraeve@apertoso.be>
 * Lai Tim Siu (Quaritle Limited) <info@quartile.co>
+* Lorenzo Battistini <https://github.com/eLBati>


### PR DESCRIPTION
… through which the system is being accessed, same feature  as odoo itself.

This can be useful when you have a virtualhost with "server_name *.domain.com"

See https://www.odoo.com/documentation/12.0/setup/deploy.html#dbfilter