### PR TITLE
[12.0][FIX]base_jsonify: Preserve initial order on ir.export.line

### DIFF
--- a/base_jsonify/models/ir_exports_line.py
+++ b/base_jsonify/models/ir_exports_line.py
@@ -7,7 +7,6 @@ from odoo import api, fields, models, _
 
 class IrExportsLine(models.Model):
     _inherit = 'ir.exports.line'
-    _order = 'name'
 
     alias = fields.Char(
         'Alias',

--- a/base_jsonify/tests/test_get_parser.py
+++ b/base_jsonify/tests/test_get_parser.py
@@ -8,30 +8,33 @@ class TestParser(TransactionCase):
 
     def test_getting_parser(self):
         expected_parser = [
+
+            'name',
             'active',
-            ('category_id', ['name']),
-            ('child_ids', [(
-                'child_ids', ['name']),
-                ('country_id', ['code', 'name']),
-                'email', 'id',
-                'name'
-            ]),
-            'color',
-            'comment',
-            ('country_id', ['code', 'name']),
             'credit_limit',
+            'color',
+            ('category_id', ['name']),
+            ('country_id', ['name', 'code']),
+            ('child_ids', [
+                'name',
+                'id',
+                'email',
+                ('country_id', ['name', 'code']),
+                ('child_ids', ['name']),
+            ]),
             'lang',
-            'name']
+            'comment'
+        ]
 
         exporter = self.env.ref('base_jsonify.ir_exp_partner')
         parser = exporter.get_json_parser()
-        self.assertEqual(parser, expected_parser)
+        self.assertListEqual(parser, expected_parser)
 
         # modify an ir.exports_line to put an alias for a field
         self.env.ref('base_jsonify.category_id_name').write({
             'alias': 'category_id:category/name'
         })
-        expected_parser[1] = ('category_id:category', ['name'])
+        expected_parser[4] = ('category_id:category', ['name'])
         parser = exporter.get_json_parser()
         self.assertEqual(parser, expected_parser)
 


### PR DESCRIPTION
We can't change the order on ir.export.line since it's used to preserve the order speicifed by the user when creating a export filter into the UI

forward port of #1661