### PR TITLE
[8.0][FIX] users_ldap_push: Don't fail when having attribute values that are not ASCII

### DIFF
--- a/users_ldap_push/models/res_users.py
+++ b/users_ldap_push/models/res_users.py
@@ -67,7 +67,7 @@ class ResUsers(models.Model):
             field_name = mapping.field_id.name
             if field_name not in values or not values[field_name]:
                 continue
-            result[str(mapping.attribute)] = [str(values[field_name])]
+            result[mapping.attribute] = [values[field_name].encode('utf-8')]
         if result:
             result['objectClass'] = conf.create_ldap_entry_objectclass\
                 .encode('utf-8').split(',')


### PR DESCRIPTION
Having an LDAP value with values out of the ASCII range fails because of
str(). This fixes it by changing to a utf8 encoded string that works
with international characters when used in attribute values.