### PR TITLE
[10.0][FIX] onchange_helper: Values recieved as input must be preserved.

### DIFF
--- a/onchange_helper/models/models.py
+++ b/onchange_helper/models/models.py
@@ -128,6 +128,7 @@ class Base(models.AbstractModel):
         This method reimplement the onchange method to be able to work on the
         current recordset if provided.
         """
+        updated_values = values.copy()
         env = self.env
         if self:
             self.ensure_one()
@@ -196,6 +197,14 @@ class Base(models.AbstractModel):
                 dirties = self._compute_onchange_dirty(origin, record, name)
                 dirty |= set(dirties)
                 todo.extend(dirties)
+
+                # preserve values to update since these are the one selected
+                # by the user.
+                for f in dirties:
+                    field = self._fields[f]
+                    if (f in updated_values and
+                            field.type not in ("one2many", "many2many")):
+                        record[f] = values[f]
 
         # prepare the result to return a dictionary with the new values for
         # the dirty fields


### PR DESCRIPTION
The goal of this lib is to play the onchange methods to get values for the fields not yet filled into the received list of values used to createor update a record. Therefore, the values from the user must be preserved. If we don't process on this way and you play the onchange methods on a sale.order for a new line with 'product_id' and 'product_uom_qty', the product_uom_qty will be reset to 1 when the onchange for product_id will be played and we'll lost the initial value for product_uom_qty