### PR TITLE
[11.0][IMP] scheduler_error_mailer: Show the trace error in the mail …

### DIFF
--- a/scheduler_error_mailer/data/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/data/ir_cron_email_tpl.xml
@@ -18,15 +18,24 @@
 <p>Odoo tried to run the scheduler <em>${object.name or ''}</em> in the database <em>${ctx.get('dbname')}</em> but it failed. Here is the error message :</p>
 
 <strong>
-${ctx.get('job_exception') and ctx.get('job_exception').value or 'Failed to get the error message from the context.'}
+${ctx.get('job_exception') and (ctx.get('job_exception').value or ctx.get('job_exception').name) or 'Failed to get the error message from the context.'}
 </strong>
+
+<p>
+<strong>
+% for trace_line in ctx.get('trace_exception'):
+<span>${trace_line}</span>
+<br/>
+% endfor
+</strong>
+</p
 
 <p>You may check the logs of the Odoo server to get more information about this failure.</p>
 
 <p>Properties of the scheduler <em>${object.name or ''}</em> :</p>
 <ul>
-<li>Model : ${object.model or ''}</li>
-<li>Method : ${object.function or ''}</li>
+<li>Model : ${object.model_id.name or ''}</li>
+<li>Method : ${object.code or ''}</li>
 <li>Arguments : ${object.args or ''}</li>
 <li>Interval : ${object.interval_number or '0'} ${object.interval_type or ''}</li>
 <li>Number of calls : ${object.numbercall or '0'}</li>

--- a/scheduler_error_mailer/models/ir_cron.py
+++ b/scheduler_error_mailer/models/ir_cron.py
@@ -6,6 +6,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 import logging
+import traceback
 
 
 _logger = logging.getLogger(__name__)
@@ -31,11 +32,15 @@ class IrCron(models.Model):
         my_cron = self.browse(job_id)
 
         if my_cron.email_template_id:
+            # catching the trace error
+            trace = traceback.format_exc()
+
             # we put the job_exception in context to be able to print it inside
             # the email template
             context = {
                 'job_exception': job_exception,
                 'dbname': self._cr.dbname,
+                'trace_exception': trace.split("\n") if trace else "",
             }
 
             _logger.debug(


### PR DESCRIPTION
This improve has two points:
- Allow us to show in the body mail message the error trace. Also I have modified the template to loop the trace and show it more clarely.
- I have changed model and code fields from template.