### PR TITLE
[10.0][FIX] base_exception: browse records were not updated

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -115,10 +115,12 @@ class BaseExceptionMethod(models.AbstractModel):
             # we expect to always work on the same model type
             rules_to_remove.setdefault(
                 rule.id, main_records.browse()
-            ).update(to_remove)
+            )
+            rules_to_remove[rule.id] |= to_remove
             rules_to_add.setdefault(
                 rule.id, main_records.browse()
-            ).update(to_add)
+            )
+            rules_to_add[rule.id] |= to_add
             if records_with_exception:
                 all_exception_ids.append(rule.id)
         # Cumulate all the records to attach to the rule


### PR DESCRIPTION
As recordset are immutables, update() does not work on dict
that contain such recordsets.