### PR TITLE
[FIX] actually use filter_format

### DIFF
--- a/users_ldap_populate/models/users_ldap.py
+++ b/users_ldap_populate/models/users_ldap.py
@@ -178,7 +178,9 @@ class CompanyLDAP(orm.Model):
 
         Don't call self.query because it supresses possible exceptions
         """
-        ldap_filter = filter_format(conf['ldap_filter'] % user_name, ())
+        ldap_filter = filter_format(
+            conf['ldap_filter'], (user_name,)
+        ) if user_name != '*' else conf['ldap_filter'] % user_name
         conn = self.connect(conf)
         conn.simple_bind_s(conf['ldap_binddn'] or '',
                            conf['ldap_password'] or '')


### PR DESCRIPTION
the code as it was never actually used `filter_format`, as it didn't pass any parameters to be formatted