### PR TITLE
[10.0][IMP] base_view_inheritance_extension : Add new feature 'target_position'

### DIFF
--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -33,10 +33,18 @@ Move an element in the view
 
 .. code-block:: xml
 
-    <xpath expr="$xpath" position="move" target="$targetxpath" />
+    <xpath expr="$xpath" position="move" target="$targetxpath" target_position="$target_position"/>
 
-This can also be used to wrap some element into another, create the target
-element first, then move the node youwant to wrap there.
+Availables values for target_position attribute:
+
+* inside (default if omitted)
+* after
+* before
+
+
+This can also be used to wrap some element into another, create the new target
+element first, then move the element you want inside (or before/after) the new
+element.
 
 Add to values in a list (states for example)
 --------------------------------------------
@@ -60,7 +68,6 @@ Known issues / Roadmap
 ======================
 
 * add ``<attribute operation="json_dict" key="$key">$value</attribute>``
-* support ``<xpath expr="$xpath" position="move" target="xpath" target_position="position" />``
 * support an ``eval`` attribute for our new node types
 
 Bug Tracker

--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Extended view inheritance",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "category": "Hidden/Dependency",

--- a/base_view_inheritance_extension/demo/ir_ui_view.xml
+++ b/base_view_inheritance_extension/demo/ir_ui_view.xml
@@ -18,10 +18,15 @@
                 <form position="inside">
                     <notebook>
                         <page string="Phone numbers" name="phone_book" />
+                        <page string="Other information" name="other_info">
+                            <separator name="info_separator"/>
+                        </page>
                     </notebook>
                 </form>
                 <xpath expr="//field[@name='phone']" position="move" target="//page[@name='phone_book']" />
                 <xpath expr="//field[@name='mobile']" position="move" target="//page[@name='phone_book']" />
+                <xpath expr="//field[@name='function']" position="move" target="//page[@name='other_info']/separator[@name='info_separator']" target_position="before"/>
+                <xpath expr="//field[@name='email']" position="move" target="//page[@name='other_info']/separator[@name='info_separator']" target_position="after" />
             </field>
         </record>
 </odoo>

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -2,7 +2,7 @@
 # © 2016 Therp BV <http://therp.nl>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from lxml import etree
-from odoo import api, models, tools
+from odoo import api, models, tools, _
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -125,7 +125,20 @@ class IrUiView(models.Model):
         target_node = self.locate_node(
             source, etree.Element(specs.tag, expr=specs.get('target'))
         )
-        target_node.append(node)
+
+        target_position = specs.get('target_position', 'inside')
+
+        if target_position == 'after':
+            target_node.addnext(node)
+        elif target_position == 'before':
+            target_node.addprevious(node)
+        elif target_position == 'inside':
+            target_node.append(node)
+        else:
+            self.raise_view_error(
+                _("Invalid target_position attribute: '%s'") % target_position,
+                inherit_id
+            )
         return source
 
     @api.model

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -30,6 +30,23 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             view.xpath('//page[@name="phone_book"]')[0]
         )
 
+    def test_target_position(self):
+        view_id = self.env.ref('base.view_partner_simple_form').id
+        fields_view_get = self.env['res.partner'].fields_view_get(
+            view_id=view_id
+        )
+        view = etree.fromstring(fields_view_get['arch'])
+        # verify we moved the phone field (before)
+        self.assertEqual(
+            view.xpath('//field[@name="function"]')[0].getnext(),
+            view.xpath('//separator[@name="info_separator"]')[0]
+        )
+        # verify we moved the mobile field (after)
+        self.assertEqual(
+            view.xpath('//field[@name="email"]')[0].getprevious(),
+            view.xpath('//separator[@name="info_separator"]')[0]
+        )
+
     def test_list_add(self):
         view_model = self.env['ir.ui.view']
         inherit_id = self.env.ref('base.view_partner_form').id


### PR DESCRIPTION
By default, inheritance with spec **position="move"** append the node inside the target.
The spec **target_position** let you choose what you want to do :

- **inside**: append the node inside the target
- **before**: append the node before target
- **after**: append the node after target

By default, if no value is provide we use the standard behavior **inside**.