### PR TITLE
[8.0][shell] force rollback on exit

### DIFF
--- a/shell/cli/shell.py
+++ b/shell/cli/shell.py
@@ -83,6 +83,7 @@ class Shell(Command):
                     local_vars['env'] = env
                     local_vars['self'] = env.user
                     self.console(local_vars)
+                    cr.rollback()
             else:
                 self.console(local_vars)
 


### PR DESCRIPTION
depending on the REPL and the exist method, exiting the shell performs a commit.
We need to force a rollback to avoid commiting unwanted changes...

It was fixed in Odoo in v10 : https://github.com/odoo/odoo/commit/ea2faefe0d6a

@dreispt @pedrobaeza 