### PR TITLE
[12.0][FIX] base_kanban_stage: avoid same-label warning

### DIFF
--- a/base_kanban_stage/models/base_kanban_abstract.py
+++ b/base_kanban_stage/models/base_kanban_abstract.py
@@ -58,7 +58,7 @@ class BaseKanbanAbstract(models.AbstractModel):
         help='User that the record is currently assigned to',
     )
     kanban_color = fields.Integer(
-        string='Color Index',
+        string='Kanban Color Index',
         help='Color index to be used for the record\'s Kanban card',
     )
     kanban_legend_priority = fields.Text(


### PR DESCRIPTION
In case `project.project` becomes a kanban, then a warning is shown: `Two fields (kanban_color, color) of project.project() have the same label: Color Index`.

Please, fast track.