### PR TITLE
[10.0][FIX] issue 1227. auth_admin_passkey. Error on editing general settings.

### DIFF
--- a/auth_admin_passkey/models/res_config.py
+++ b/auth_admin_passkey/models/res_config.py
@@ -4,55 +4,50 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import api, fields, models
-from odoo.tools.safe_eval import safe_eval
 
 
 class BaseConfigSettings(models.TransientModel):
     _inherit = 'base.config.settings'
 
+    # Getter / Setter Section
     @api.model
     def get_default_auth_admin_passkey_send_to_admin(self, fields):
-        icp = self.env['ir.config_parameter']
         return {
-            'auth_admin_passkey_send_to_admin': safe_eval(icp.get_param(
-                'auth_admin_passkey.send_to_admin', 'True')),
+            'auth_admin_passkey_send_to_admin':
+            self.env["ir.config_parameter"].get_param(
+                "auth_admin_passkey.send_to_admin")
         }
-
-    @api.model
-    def get_default_auth_admin_passkey_send_to_user(self, fields):
-        icp = self.env['ir.config_parameter']
-        return {
-            'auth_admin_passkey_send_to_user': safe_eval(icp.get_param(
-                'auth_admin_passkey.send_to_user', 'True')),
-        }
-
-    auth_admin_passkey_send_to_admin = fields.Boolean(
-        'Send email to admin user.',
-        help=('When the administrator use his password to login in '
-              'with a different account, Odoo will send an email '
-              'to the admin user.'),
-    )
-    auth_admin_passkey_send_to_user = fields.Boolean(
-        string='Send email to user.',
-        help=('When the administrator use his password to login in '
-              'with a different account, Odoo will send an email '
-              'to the account user.'),
-    )
 
     @api.multi
     def set_auth_admin_passkey_send_to_admin(self):
-        self.ensure_one()
+        for config in self:
+            self.env['ir.config_parameter'].set_param(
+                "auth_admin_passkey.send_to_admin",
+                config.auth_admin_passkey_send_to_admin or '')
 
-        icp = self.env['ir.config_parameter']
-        icp.set_param(
-            'auth_admin_passkey.send_to_admin',
-            repr(self.auth_admin_passkey_send_to_admin))
+    @api.model
+    def get_default_auth_admin_passkey_send_to_user(self, fields):
+        return {
+            'auth_admin_passkey_send_to_user':
+            self.env["ir.config_parameter"].get_param(
+                "auth_admin_passkey.send_to_user")
+        }
 
     @api.multi
     def set_auth_admin_passkey_send_to_user(self):
-        self.ensure_one()
+        for config in self:
+            self.env['ir.config_parameter'].set_param(
+                "auth_admin_passkey.send_to_user",
+                config.auth_admin_passkey_send_to_user or '')
 
-        icp = self.env['ir.config_parameter']
-        icp.set_param(
-            'auth_admin_passkey.send_to_user',
-            repr(self.auth_admin_passkey_send_to_user))
+    auth_admin_passkey_send_to_admin = fields.Boolean(
+        string='Send email to admin user.',
+        help='When the administrator use his password to login in '
+             'with a different account, Odoo will send an email '
+             'to the admin user.')
+
+    auth_admin_passkey_send_to_user = fields.Boolean(
+        string='Send email to user.',
+        help='When the administrator use his password to login in '
+             'with a different account, Odoo will send an email '
+             'to the account user.')

--- a/auth_admin_passkey/tests/__init__.py
+++ b/auth_admin_passkey/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2013-2014 GRAP (http://www.grap.coop)
 # @author Sylvain LE GAL (https://twitter.com/legalsylvain)
-# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
 
 from . import test_auth_admin_passkey
 from . import test_ui
+from . import test_config

--- a/auth_admin_passkey/tests/test_config.py
+++ b/auth_admin_passkey/tests/test_config.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Therp BV (https://therp.nl)
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+from odoo.tests import common
+
+
+@common.post_install(True)
+class TestConfig(common.TransactionCase):
+    def test_set_get_config(self):
+        """Test configuration methods."""
+        config_model = self.env["base.config.settings"]
+        config = config_model.create(
+            {
+                "auth_admin_passkey_send_to_admin": False,
+                "auth_admin_passkey_send_to_user": False,
+            }
+        )
+        # Set email admin and user to False (and back again).
+        config.set_auth_admin_passkey_send_to_admin()
+        config.set_auth_admin_passkey_send_to_user()
+        self.assertEqual(
+            False,
+            config_model.get_default_auth_admin_passkey_send_to_admin([])[
+                "auth_admin_passkey_send_to_admin"
+            ],
+        )
+        self.assertEqual(
+            False,
+            config_model.get_default_auth_admin_passkey_send_to_user([])[
+                "auth_admin_passkey_send_to_user"
+            ],
+        )
+        config.write(
+            {
+                "auth_admin_passkey_send_to_admin": True,
+                "auth_admin_passkey_send_to_user": True,
+            }
+        )
+        config.set_auth_admin_passkey_send_to_admin()
+        config.set_auth_admin_passkey_send_to_user()
+        self.assertEqual(
+            u'True',
+            config_model.get_default_auth_admin_passkey_send_to_admin([])[
+                "auth_admin_passkey_send_to_admin"
+            ],
+        )
+        self.assertEqual(
+            u'True',
+            config_model.get_default_auth_admin_passkey_send_to_user([])[
+                "auth_admin_passkey_send_to_user"
+            ],
+        )


### PR DESCRIPTION
This is an alternative for the stale PR: https://github.com/OCA/server-tools/pull/1228