### PR TITLE
[12.0][FIX] base_exception writes on empty record set

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -101,12 +101,12 @@ class BaseExceptionMethod(models.AbstractModel):
             to_remove = commons - records_with_exception
             to_add = records_with_exception - commons
             # we expect to always work on the same model type
-            rules_to_remove.setdefault(
-                rule.id, main_records.browse()
-            ).update(to_remove)
-            rules_to_add.setdefault(
-                rule.id, main_records.browse()
-            ).update(to_add)
+            if rule.id not in rules_to_remove:
+                rules_to_remove[rule.id] = main_records.browse()
+            rules_to_remove[rule.id] |= to_remove
+            if rule.id not in rules_to_add:
+                rules_to_add[rule.id] = main_records.browse()
+            rules_to_add[rule.id] |= to_add
             if records_with_exception:
                 all_exception_ids.append(rule.id)
         # Cumulate all the records to attach to the rule

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -68,6 +68,8 @@ class TestBaseException(common.SavepointCase):
         # Block because of exception during validation
         with self.assertRaises(ValidationError):
             potest1.button_confirm()
+        # Test that we have linked exceptions
+        self.assertTrue(potest1.exception_ids)
         # Test ignore exeception make possible for the po to validate
         potest1.ignore_exception = True
         potest1.button_confirm()


### PR DESCRIPTION
After doing some updates including updates to `base_exception` (from **server-tools**) and `sale_exception` (from **sale-workflow**), I was suddenly hit by empty exception popups and no linked `exception_ids` on the record.

After inserting logging statements, it became apparent that the writes on line 126 and 128 were always called on empty record sets.  While the removed code is very clever and does in fact work with normal sets in a plain python REPL, it does not work with Odoo recordsets.

There is already a relevant test in `sale_exception` that was disabled.

I have added a similar test in `base_exception` that failed prior to changes. (in my environment anyway, and given that I can now uncomment and run the tests in `sale_exception`, presumably the CI/CD environment you use as well)