### PR TITLE
[FIX] Prevent NameErrors from uninstalled modules

### DIFF
--- a/external_file_location/tasks/filestore.py
+++ b/external_file_location/tasks/filestore.py
@@ -7,11 +7,13 @@ _logger = logging.getLogger(__name__)
 
 try:
     from fs import osfs
+    superclass = osfs.OSFS
 except ImportError:
     _logger.debug('Cannot `import fs`.')
+    superclass = object
 
 
-class FileStoreTask(osfs.OSFS):
+class FileStoreTask(superclass):
 
     _key = 'filestore'
     _name = 'File Store'

--- a/external_file_location/tasks/ftp.py
+++ b/external_file_location/tasks/ftp.py
@@ -7,12 +7,13 @@ _logger = logging.getLogger(__name__)
 
 try:
     from fs import ftpfs
+    superclass = ftpfs.FTPFS
 except ImportError:
     _logger.debug('Cannot `import fs`.')
+    superclass = object
 
 
-class FtpTask(ftpfs.FTPFS):
-
+class FtpTask(superclass):
     _key = 'sftp'
     _name = 'SFTP'
     _synchronize_type = None

--- a/external_file_location/tasks/sftp.py
+++ b/external_file_location/tasks/sftp.py
@@ -7,11 +7,13 @@ _logger = logging.getLogger(__name__)
 
 try:
     from fs import sftpfs
+    superclass = sftpfs.SFTPFS
 except ImportError:
     _logger.debug('Cannot `import fs`.')
+    superclass = object
 
 
-class SftpTask(sftpfs.SFTPFS):
+class SftpTask(superclass):
 
     _key = 'sftp'
     _name = 'SFTP'

--- a/oauth_provider/oauth2/validator.py
+++ b/oauth_provider/oauth2/validator.py
@@ -12,11 +12,13 @@ _logger = logging.getLogger(__name__)
 
 try:
     from oauthlib.oauth2 import RequestValidator
+    superclass = RequestValidator
 except ImportError:
     _logger.debug('Cannot `import oauthlib`.')
+    superclass = object
 
 
-class OdooValidator(RequestValidator):
+class OdooValidator(superclass):
     """ OAuth2 validator to be used in Odoo
 
     This is an implementation of oauthlib's RequestValidator interface

--- a/oauth_provider_jwt/models/oauth_provider_client.py
+++ b/oauth_provider_jwt/models/oauth_provider_client.py
@@ -34,11 +34,14 @@ except ImportError:
 class OAuthProviderClient(models.Model):
     _inherit = 'oauth.provider.client'
 
-    CRYPTOSYSTEMS = {
-        'ES': EllipticCurvePrivateKey,
-        'RS': RSAPrivateKey,
-        'PS': RSAPrivateKey,
-    }
+    try:
+        CRYPTOSYSTEMS = {
+            'ES': EllipticCurvePrivateKey,
+            'RS': RSAPrivateKey,
+            'PS': RSAPrivateKey,
+        }
+    except NameError:
+        pass
 
     token_type = fields.Selection(selection_add=[('jwt', 'JSON Web Token')])
     jwt_scope_id = fields.Many2one(


### PR DESCRIPTION
```2019-12-13 21:51:10,338 27482 ERROR ? werkzeug: Error on request:
Traceback (most recent call last):
  File "/odoo/9.0/eggs/Werkzeug-0.11.11-py2.7.egg/werkzeug/serving.py", line 193, in run_wsgi
    execute(self.server.app)
  File "/odoo/9.0/eggs/Werkzeug-0.11.11-py2.7.egg/werkzeug/serving.py", line 181, in execute
    application_iter = app(environ, start_response)
  File "/odoo/9.0/parts/odoo/openerp/service/wsgi_server.py", line 184, in application
    return application_unproxied(environ, start_response)
  File "/odoo/9.0/parts/odoo/openerp/service/wsgi_server.py", line 170, in application_unproxied
    result = handler(environ, start_response)
  File "/odoo/9.0/parts/odoo/openerp/http.py", line 1514, in __call__
    self.load_addons()
  File "/odoo/9.0/parts/odoo/openerp/http.py", line 1535, in load_addons
    m = __import__('openerp.addons.' + module)
  File "/odoo/9.0/parts/odoo/openerp/modules/module.py", line 61, in load_module
    mod = imp.load_module('openerp.addons.' + module_part, f, path, descr)
  File "/odoo/9.0/parts/server-tools/oauth_provider/__init__.py", line 6, in <module>
    from . import models
  File "/odoo/9.0/parts/server-tools/oauth_provider/models/__init__.py", line 9, in <module>
    from . import oauth_provider_client
  File "/odoo/9.0/parts/server-tools/oauth_provider/models/oauth_provider_client.py", line 9, in <module>
    from ..oauth2.validator import OdooValidator
  File "/odoo/9.0/parts/server-tools/oauth_provider/oauth2/validator.py", line 19, in <module>
    class OdooValidator(RequestValidator):
NameError: name 'RequestValidator' is not defined```