### PR TITLE
[IMP][8.0] base_import_odoo: show inactive records also

### DIFF
--- a/base_import_odoo/views/import_odoo_database.xml
+++ b/base_import_odoo/views/import_odoo_database.xml
@@ -58,6 +58,7 @@
                         return openerp.webclient.action_manager.do_action({
                             'name': model_name,
                             'type': 'ir.actions.act_window',
+                            'context': {'active_test': false},
                             'views': [[false, 'list'], [false, 'form']],
                             'res_model': model,
                             'domain': [['id', 'in', _.map(data, function(x) {return x.res_id})]]


### PR DESCRIPTION
Records could be imported as inactive, but it is confusing not to show them in this view