### PR TITLE
[IMP] auth_from_http_remote_user: check session in each request

### DIFF
--- a/auth_from_http_remote_user/controllers/main.py
+++ b/auth_from_http_remote_user/controllers/main.py
@@ -21,7 +21,7 @@ _logger = logging.getLogger(__name__)
 
 class Home(main.Home):
 
-    _REMOTE_USER_ATTRIBUTE = 'HTTP_REMOTE_USER'
+    _REMOTE_USER_ATTRIBUTE = utils.REMOTE_USER_HEADER
 
     @http.route('/web', type='http', auth="none")
     def web_client(self, s_action=None, **kw):

--- a/auth_from_http_remote_user/models/__init__.py
+++ b/auth_from_http_remote_user/models/__init__.py
@@ -4,3 +4,4 @@
 
 from . import res_users
 from . import auth_from_http_remote_user
+from . import ir_http

--- a/auth_from_http_remote_user/models/ir_http.py
+++ b/auth_from_http_remote_user/models/ir_http.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+import openerp
+from openerp import models
+from openerp import http
+
+from ..utils import REMOTE_USER_HEADER
+
+_logger = logging.getLogger(__name__)
+
+
+class IrHttp(models.Model):
+
+    _inherit = "ir.http"
+
+    def _authenticate(self, auth_method="user"):
+        """Check the HTTP remote user matches the session user.
+
+        This method is invoked for every HTTP request.
+        """
+        res = super(IrHttp, self)._authenticate(auth_method=auth_method)
+        headers = http.request.httprequest.headers.environ
+        remote_login = headers.get(REMOTE_USER_HEADER, None)
+        session = http.request.session
+        if (
+            remote_login
+            and session
+            and session.login
+            and remote_login != session.login
+        ):
+            _logger.warning(
+                "Remote user '%s' does not match session user '%s'. "
+                "Terminating session.",
+                remote_login,
+                session.login,
+            )
+            session.logout(keep_db=True)
+            raise openerp.exceptions.AccessDenied()
+        return res

--- a/auth_from_http_remote_user/utils.py
+++ b/auth_from_http_remote_user/utils.py
@@ -2,3 +2,4 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 KEY_LENGTH = 16
+REMOTE_USER_HEADER = 'HTTP_REMOTE_USER'


### PR DESCRIPTION
Previously the consistency between the session and the remote user
was checked in the /web route. Now it is checked at each request.
This is more robust in case, for instance, the user changes login in the
SSO then comes back to Odoo via deep links.