### PR TITLE
[RFR] [FIX] 12.0 deepcopy on api.Environment class fails

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -14,7 +14,9 @@ FIELDS_BLACKLIST = [
 EMPTY_DICT = {}
 
 
-def model__deepcopy__(self, memo={}):
+def model__deepcopy__(self, memo=None):
+    if memo is None:
+        memo = {}
     return self.browse(self.ids)
 
 

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -14,6 +14,13 @@ FIELDS_BLACKLIST = [
 EMPTY_DICT = {}
 
 
+def model__deepcopy__(self, memo={}):
+    return self.browse(self.ids)
+
+
+models.Model.__deepcopy__ = model__deepcopy__
+
+
 class DictDiffer(object):
     """Calculate the difference between two dictionaries as:
     (1) items added

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -92,12 +92,14 @@ class AuditlogCommon(object):
         groups_vals = [
             {'name': 'testgroup1'},
             {'name': 'testgroup3'},
-            {'name': 'testgroup2'},
+            {'name': 'testgroup2', 'users': self.env['res.users']},
+            {'name': 'testgroup4', 'users': self.env.user},
         ]
         groups = self.env['res.groups'].create(groups_vals)
         # Ensure that the recordset returns is in the same order
         # than list of vals
-        expected_names = ['testgroup1', 'testgroup3', 'testgroup2']
+        expected_names = [
+            'testgroup1', 'testgroup3', 'testgroup2', 'testgroup4']
         self.assertEqual(groups.mapped('name'), expected_names)
 
         logs = auditlog_log.search([


### PR DESCRIPTION
An empty environment object will trigger an error during deepcopy.
From what I could gather, an empty Environment object is a possible value to create new records from.
Python's deepcopy fails to create a new object from this value.

Not saying my solution is the right one, but @sebalix I was interested in your feedback on this since you created the original fix (https://github.com/OCA/server-tools/pull/1688) 

The actual error is that for each key-value pair in the dictionary sent to deepcopy, python attempts to instantiate object. In the case of an api.Environment class object, a new `api.Environment` object  is created which in turn calls to `__new__()`. Unfortunately, that method requires `cr`, `uid`, and `context` as parameters and ultimately fails to create the new object.
