### PR TITLE
[IMP][12.0][auto_backup] Support pysftp==0.2.9 - Auto-add host to known_hosts, if it's the first time we connect

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -1,6 +1,7 @@
 # Copyright 2004-2009 Tiny SPRL (<http://tiny.be>).
 # Copyright 2015 Agile Business Group <http://www.agilebg.com>
 # Copyright 2016 Grupo ESOC Ingenieria de Servicios, S.L.U. - Jairo Llopis
+# Copyright 2020 Druidoo (<https://www.druidoo.io>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import logging
@@ -18,7 +19,7 @@ _logger = logging.getLogger(__name__)
 try:
     import pysftp
 except ImportError:  # pragma: no cover
-    _logger.debug('Cannot import pysftp')
+    _logger.error('Cannot import pysftp')
 
 
 class DbBackup(models.Model):
@@ -301,4 +302,30 @@ class DbBackup(models.Model):
         else:
             params["password"] = self.sftp_password
 
-        return pysftp.Connection(**params)
+        # CnOpts added in pysftp==0.2.9
+        hostkeys = None
+        if hasattr(pysftp, 'CnOpts'):
+            cnopts = pysftp.CnOpts()
+            params['cnopts'] = cnopts
+            # If it's the first time we connect to this host
+            # disable hostkey validation, and add to known_hosts
+            if cnopts.hostkeys.lookup(self.sftp_host) is None:
+                hostkeys = cnopts.hostkeys
+                cnopts.hostkeys = None
+
+        sftp = pysftp.Connection(**params)
+        if sftp and hostkeys is not None:
+            hostkeys.add(
+                self.sftp_host,
+                sftp.remote_server_key.get_name(),
+                sftp.remote_server_key)
+            known_hosts = pysftp.helpers.known_hosts()
+            if not os.path.exists(os.path.dirname(known_hosts)):
+                os.makedirs(os.path.dirname(known_hosts))
+            hostkeys.save(known_hosts)
+            _logger.info(
+                'Permanently added "%s" (%s) to the list of '
+                'known hosts' % (
+                    self.sftp_host,
+                    sftp.remote_server_key.get_name()))
+        return sftp

--- a/auto_backup/readme/CONTRIBUTORS.rst
+++ b/auto_backup/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Dave Lasley <dave@laslabs.com>
 * Andrea Stirpe <a.stirpe@onestein.nl>
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/auto_backup/readme/INSTALL.rst
+++ b/auto_backup/readme/INSTALL.rst
@@ -1,4 +1,4 @@
 Before installing this module, you need to execute::
 
-    pip3 install pysftp==0.2.8
+    pip3 install pysftp==0.2.9
 

--- a/auto_backup/tests/test_db_backup.py
+++ b/auto_backup/tests/test_db_backup.py
@@ -196,12 +196,16 @@ class TestDbBackup(common.TransactionCase):
         """ It should initiate SFTP connection w/ proper args and pass """
         rec_id = self.new_record()
         rec_id.sftp_connection()
-        pysftp.Connection.assert_called_once_with(
+        params = dict(
             host=rec_id.sftp_host,
             username=rec_id.sftp_user,
             port=rec_id.sftp_port,
             password=rec_id.sftp_password,
         )
+        # CnOpts added in pysftp==0.2.9
+        if hasattr(pysftp, 'CnOpts'):
+            params['cnopts'] = pysftp.CnOpts()
+        pysftp.Connection.assert_called_once_with(**params)
 
     @mock.patch('%s.pysftp' % model)
     def test_sftp_connection_init_key(self, pysftp):
@@ -212,13 +216,17 @@ class TestDbBackup(common.TransactionCase):
             'sftp_password': 'pkeypass',
         })
         rec_id.sftp_connection()
-        pysftp.Connection.assert_called_once_with(
+        params = dict(
             host=rec_id.sftp_host,
             username=rec_id.sftp_user,
             port=rec_id.sftp_port,
             private_key=rec_id.sftp_private_key,
             private_key_pass=rec_id.sftp_password,
         )
+        # CnOpts added in pysftp==0.2.9
+        if hasattr(pysftp, 'CnOpts'):
+            params['cnopts'] = pysftp.CnOpts()
+        pysftp.Connection.assert_called_once_with(**params)
 
     @mock.patch('%s.pysftp' % model)
     def test_sftp_connection_return(self, pysftp):


### PR DESCRIPTION
Adds support for `pysftp==0.2.9`

With this PR, if it's the first time we connect to that server (meaning, not in known hosts list), we add it to the list.

pinging authors:
@Yenthe666 
@archetipo 
@lasley 
