### PR TITLE
v8 FIX sql_request_abstract: do not merge params when no params

### DIFF
--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -146,7 +146,10 @@ class SQLRequestMixin(models.AbstractModel):
 
         params = params or {}
         # pylint: disable=sql-injection
-        query = self.query % params
+        if params:
+            query = self.query % params
+        else:
+            query = self.query
         query = query.decode('utf-8')
 
         if mode in ('fetchone', 'fetchall'):


### PR DESCRIPTION
Before PR

![2020-03-09_12-23](https://user-images.githubusercontent.com/1853434/76209119-60fe7680-6201-11ea-9d9a-4378d5b9dc76.png)

with this query 
`WHERE s.create_date > '2019-06-30' and t.name NOT LIKE '%notice%'`
because %n is interpreted but there is no params here

After PR
query don't fail and the code is like in v12

https://github.com/OCA/server-tools/blob/12.0/sql_request_abstract/models/sql_request_mixin.py#L151-L154