### PR TITLE
[FIX] company_country: Don't fail if account is already installed

### DIFF
--- a/company_country/README.rst
+++ b/company_country/README.rst
@@ -80,6 +80,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Moisés López <moylop260@vauxoo.com>
+* Luis González <lgonzalez@vauxoo.com>
 
 
 Other credits

--- a/company_country/__manifest__.py
+++ b/company_country/__manifest__.py
@@ -6,7 +6,7 @@
     "version": "12.0.1.0.0",
     "category": "base",
     "website": "https://github.com/OCA/server-tools/tree/12.0/company_country",
-    "maintainers": ['moylop260'],
+    "maintainers": ['moylop260', 'luisg123v'],
     "author": "Vauxoo, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": [],

--- a/company_country/__manifest__.py
+++ b/company_country/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Company Country",
     "summary": "Set country to main company",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "base",
     "website": "https://github.com/OCA/server-tools/tree/12.0/company_country",
     "maintainers": ['moylop260', 'luisg123v'],

--- a/company_country/tests/test_company_country.py
+++ b/company_country/tests/test_company_country.py
@@ -15,7 +15,9 @@ class TestCompanyCountry(TransactionCase):
         self.us_country = self.env.ref('base.us')
         self.mx_country = self.env.ref('base.mx')
         self.main_company = self.env.ref('base.main_company')
+        self.module_account = self.env.ref('base.module_account')
         self.main_company.write({'country_id': self.us_country.id})
+        self.module_account.write({'state': 'uninstalled'})
         self.env_country = os.environ.get('COUNTRY')
 
     def tearDown(self):
@@ -44,3 +46,7 @@ class TestCompanyCountry(TransactionCase):
             l10n_to_install.write({'state': 'uninstalled'})
             del os.environ['COUNTRY']
             self.wizard.load_company_country()
+
+        # Account is already installed, shouldn't raise
+        self.module_account.write({'state': 'installed'})
+        self.wizard.load_company_country()


### PR DESCRIPTION
When `company_country` is installed, it performs the following:
- Look for the `COUNTRY` environment variable
- If not found, look for a `l10n_*` module that is about to be installed
- If not found, raise an exception

However, If the account module is installed, it shouldn't fail even if
the environment variable is not defined, because changing the
company's country will have no effect anyway, as the account hook was
already run and an `l10n` module was already been installed.

This commit fixes the above by skipping the process if the `account`
module is installed, and print an informative message to the log.