### PR TITLE
[IMP] company_country: Don't create DB table for model

### DIFF
--- a/company_country/__manifest__.py
+++ b/company_country/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Company Country",
     "summary": "Set country to main company",
-    "version": "12.0.1.0.1",
+    "version": "12.0.1.0.2",
     "category": "base",
     "website": "https://github.com/OCA/server-tools/tree/12.0/company_country",
     "maintainers": ['moylop260', 'luisg123v'],

--- a/company_country/migrations/12.0.1.0.2/pre-migration.py
+++ b/company_country/migrations/12.0.1.0.2/pre-migration.py
@@ -1,0 +1,18 @@
+import logging
+from psycopg2.extensions import AsIs
+
+from odoo import tools
+
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    drop_table_model_company_country(cr)
+
+
+def drop_table_model_company_country(cr):
+    tablename = 'company_country_config_settings'
+    if tools.table_exists(cr, tablename):
+        _logger.info("Dropping table %s", tablename)
+        cr.execute("DROP TABLE IF EXISTS %s;", (AsIs(tablename),))

--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -9,7 +9,7 @@ from odoo.exceptions import ValidationError
 _logger = logging.getLogger(__name__)
 
 
-class CompanyCountryConfigSettings(models.TransientModel):
+class CompanyCountryConfigSettings(models.AbstractModel):
     _name = 'company.country.config.settings'
     _description = 'Company Country Configuration Settings'
 

--- a/company_country/readme/CONTRIBUTORS.rst
+++ b/company_country/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Moisés López <moylop260@vauxoo.com>
+* Luis González <lgonzalez@vauxoo.com>
 


### PR DESCRIPTION
That model is intended only to set config and has no fields, so there is
no need for creating a DB table for it. This is achieved by switching
the model type from transient to abstract.