### PR TITLE
[10.0][FIX] pin packages to pre-python3 or pre-deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   # Install libraries that require specific development headers, but not during lint test
-  - if ! [ "$LINT_CHECK" = "1" ]; then pip install pymssql MySQL-python pyodbc; fi
+  - if ! [ "$LINT_CHECK" = "1" ]; then pip install "pymssql<3.0" MySQL-python pyodbc; fi
   - printf '[options]\n\nrunning_env = dev\n' > ${HOME}/.openerp_serverrc
   - ln -s ${TRAVIS_BUILD_DIR}/server_environment_files_sample ${TRAVIS_BUILD_DIR}/server_environment_files
 script:


### PR DESCRIPTION
as a lot of other repos depend on server-tools building properly, we need this to work