### PR TITLE
[9.0][Fix] dbfilter_from_header/__init__.py to avoid TypeError

### DIFF
--- a/dbfilter_from_header/__init__.py
+++ b/dbfilter_from_header/__init__.py
@@ -25,7 +25,7 @@ def db_filter(dbs, httprequest=None):
     return dbs
 
 if config.get('proxy_mode') and \
-   'dbfilter_from_header' in config.get('server_wide_modules'):
+   'dbfilter_from_header' in (config.get('server_wide_modules') or []):
     _logger = logging.getLogger(__name__)
     _logger.info('monkey patching http.db_filter')
     http.db_filter = db_filter


### PR DESCRIPTION
with this fix we avoid this error :
```
dbfilter_from_header/__init__.py", line 28, in <module>
    'dbfilter_from_header' in config.get('server_wide_modules'):
TypeError: argument of type 'NoneType' is not iterable
```