### PR TITLE
Update __manifest__.py

### DIFF
--- a/html_text/__manifest__.py
+++ b/html_text/__manifest__.py
@@ -16,7 +16,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "lxml.html",
+            "lxml",
         ],
     },
     "depends": [


### PR DESCRIPTION
To prevent the "No matching distribution" error to happen when you have the lxml installed. The same solution was made in branch 11.0