### PR TITLE
[12.0][FIX] Auditlog: avoid access rights errors while handling creation

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -225,7 +225,7 @@ class AuditlogRule(models.Model):
                 new_values.setdefault(new_record.id, {})
                 for fname, field in new_record._fields.items():
                     new_values[new_record.id][fname] = field.convert_to_read(
-                        new_record[fname], new_record)
+                        new_record.sudo()[fname], new_record.sudo())
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, new_records.ids,
                 'create', None, new_values, {'log_type': log_type})


### PR DESCRIPTION
This commit fixes following case:
When record has fields that user has no access to, and user tries to
create such record, the after record created auditlog tries to read all
fields of record, but record creation fails because user cannot read one
of fields.

This fix was caught on db where full-log was enabled on Partner model,
and some user has no access to signup_token field. So he was not able to
create partners.