### PR TITLE
[12.0][IMP] auditlog: access menu according access rights

### DIFF
--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': "Audit Log",
-    'version': "12.0.1.0.0",
+    'version': "12.0.1.1.0",
     'author': "ABF OSIELL,Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'website': "https://github.com/OCA/server-tools/",

--- a/auditlog/views/auditlog_view.xml
+++ b/auditlog/views/auditlog_view.xml
@@ -2,7 +2,7 @@
 <odoo>
     <menuitem id="menu_audit" name="Audit"
         parent="base.menu_custom" sequence="50"
-        groups="base.group_system"/>
+        groups="base.group_erp_manager"/>
 
 
     <!-- auditlog.rule -->


### PR DESCRIPTION
Allow accessing auditlog's menu items according access rights defined on
auditlog objects. If user with group 'Administration / Access Rights'
has all access right on auditlog objects, he should be able to access
them via menu. Previously, only users with group 'Administration / Settings'
were able to see auditlog's menu items.