### PR TITLE
[9.0][IMP] auth_from_http_remote_user: allow multiple sessions for same user

### DIFF
--- a/auth_from_http_remote_user/README.rst
+++ b/auth_from_http_remote_user/README.rst
@@ -16,6 +16,22 @@ at startup; Add the *--load* parameter to the startup command: ::
 If the field is found in the header and no user matches the given one, the
 system issue a login error page. (*401* `Unauthorized`)
 
+System parameter
+================
+
+By default this module does not allow the same user to connect from different
+browser sessions at the same time. It generates a new random pseudo-password
+(sso_key) that will be different at each session creation.
+To allow the same user to connect from different browser sessions, a system
+parameter can be configured with a secret. At session creation, the pseudo-password
+generated will be a hash based on the secret and the user id making the
+pseudo-password the same for each session of the same user.
+The system parameter key must be ::
+
+  http_remote_user.secret
+
+and the value can be any string (Ex: 123456789abcdefgh).
+
 Use case.
 =========
 

--- a/auth_from_http_remote_user/models/res_users.py
+++ b/auth_from_http_remote_user/models/res_users.py
@@ -4,7 +4,7 @@
 
 from openerp import api, fields, models
 import openerp.exceptions
-from openerp.addons.auth_from_http_remote_user import utils
+from .. import utils
 
 
 class ResUsers(models.Model):


### PR DESCRIPTION
The PR objective is to solve the following issue: https://github.com/OCA/server-auth/issues/170
The module auth_from_http_remote_user exists in version 9.0 in this repository but not in the server-auth repository so I post my PR here.

---
By default the module _auth_from_http_remote_user_ does not allow the same user to connect from different browser sessions at the same time. It generates a new random pseudo-password (sso_key) that will be different at each session creation. 
To allow the same user to connect from different browser sessions, a system parameter can be configured with a secret. At session creation, the pseudo-password generated will be a hash based on the secret and the user id making the pseudo-password the same for each session of the same user. The system parameter key must be **http_remote_user.secret** and the value can be any string (_Ex: 123456789abcdefgh_).