### PR TITLE
[FIX] base_multi_image_image hook

### DIFF
--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -33,15 +33,14 @@ def pre_init_hook_for_submodules(cr, model, field):
                 )
                 SELECT
                     id,
-                    %%s,
+                    %(model)s,
                     'db',
                     %(field)s
                 FROM
                     %(table)s
                 WHERE
                     %(field)s IS NOT NULL
-            """, {"table": AsIs(env[model]._table), "field": AsIs(field)},
-            (model,)
+            """, {"table": AsIs(env[model]._table), "field": AsIs(field), "model": (model,)}
         )
 
 

--- a/base_multi_image/hooks.py
+++ b/base_multi_image/hooks.py
@@ -40,7 +40,7 @@ def pre_init_hook_for_submodules(cr, model, field):
                     %(table)s
                 WHERE
                     %(field)s IS NOT NULL
-            """, {"table": AsIs(env[model]._table), "field": AsIs(field), "model": (model,)}
+            """, {"table": AsIs(env[model]._table), "field": AsIs(field), "model": model}
         )
 
 


### PR DESCRIPTION
```
2020-04-18 18:00:52,359 1672245 WARNING db openerp.addons.base.ir.ir_translation: module product_m2mcategories: no translation for language pt_BR
2020-04-18 18:00:52,387 1672245 ERROR db openerp.sql_db: Programming error: syntax error at or near "%"
LINE 10:                     %s,
                             ^
, in query 
                INSERT INTO base_multi_image_image (
                    owner_id,
                    owner_model,
                    storage,
                    file_db_store
                )
                SELECT
                    id,
                    %%s,
                    'db',
                    %(field)s
                FROM
                    %(table)s
                WHERE
                    %(field)s IS NOT NULL
            
2020-04-18 18:00:52,388 1672245 CRITICAL db openerp.service.server: Failed to initialize database `db`.
```