### PR TITLE
[12.0] Added purge actions for ir.actions.act_window and ir.ui.view

### DIFF
--- a/database_cleanup/__manifest__.py
+++ b/database_cleanup/__manifest__.py
@@ -17,6 +17,7 @@
         'views/purge_data.xml',
         "views/create_indexes.xml",
         'views/purge_properties.xml',
+        'views/purge_actions.xml',
         'views/menu.xml',
     ],
     'installable': True,

--- a/database_cleanup/__manifest__.py
+++ b/database_cleanup/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Database cleanup',
     'version': '12.0.1.0.3',
     'author': "Therp BV,Odoo Community Association (OCA)",
-    'depends': ['base'],
+    'depends': ['base', 'mail'],
     'license': 'AGPL-3',
     'category': 'Tools',
     'data': [
@@ -18,6 +18,7 @@
         "views/create_indexes.xml",
         'views/purge_properties.xml',
         'views/purge_actions.xml',
+        'views/purge_views.xml',
         'views/menu.xml',
     ],
     'installable': True,

--- a/database_cleanup/models/__init__.py
+++ b/database_cleanup/models/__init__.py
@@ -7,3 +7,4 @@ from . import purge_data
 from . import purge_menus
 from . import create_indexes
 from . import purge_properties
+from . import purge_actions

--- a/database_cleanup/models/__init__.py
+++ b/database_cleanup/models/__init__.py
@@ -8,3 +8,4 @@ from . import purge_menus
 from . import create_indexes
 from . import purge_properties
 from . import purge_actions
+from . import purge_views

--- a/database_cleanup/models/purge_actions.py
+++ b/database_cleanup/models/purge_actions.py
@@ -1,0 +1,61 @@
+# Copyright 2014-2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# pylint: disable=consider-merging-classes-inherited
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class CleanupPurgeLineAction(models.TransientModel):
+    _inherit = 'cleanup.purge.line'
+    _name = 'cleanup.purge.line.action'
+
+    wizard_id = fields.Many2one(
+        'cleanup.purge.wizard.action', 'Purge Wizard', readonly=True)
+    action_id = fields.Many2one('ir.actions.act_window', 'Action entry')
+    action_model = fields.Char(related="action_id.res_model", string="Missing model")
+    action_external_id = fields.Char(
+        size=128,
+        string="External ID",
+        help="ID of the window action defined in xml file"
+    )
+
+    @api.multi
+    def purge(self):
+        """Unlink action entries upon manual confirmation."""
+        if self:
+            objs = self
+        else:
+            objs = self.env['cleanup.purge.line.action']\
+                .browse(self._context.get('active_ids'))
+        to_unlink = objs.filtered(lambda x: not x.purged and x.action_id)
+        self.logger.info('Purging window action entries: %s', to_unlink.mapped('name'))
+        to_unlink.mapped('action_id').unlink()
+        return to_unlink.write({'purged': True})
+
+
+class CleanupPurgeWizardAction(models.TransientModel):
+    _inherit = 'cleanup.purge.wizard'
+    _name = 'cleanup.purge.wizard.action'
+    _description = 'Purge window actions'
+
+    @api.model
+    def find(self):
+        """
+        Search for models that cannot be instantiated.
+        """
+        res = []
+        for action in self.env['ir.actions.act_window'].with_context(active_test=False)\
+                .search([('res_model', '!=', False)]):
+
+            if (action.res_model not in self.env):
+                res.append((0, 0, {
+                    'name': action.name,
+                    'action_id': action.id,
+                    'action_external_id': action.get_external_id(),
+                }))
+        if not res:
+            raise UserError(_('No dangling window action entries found'))
+        return res
+
+    purge_line_ids = fields.One2many(
+        'cleanup.purge.line.action', 'wizard_id', 'Window actions to purge')

--- a/database_cleanup/models/purge_views.py
+++ b/database_cleanup/models/purge_views.py
@@ -1,0 +1,61 @@
+# Copyright 2014-2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# pylint: disable=consider-merging-classes-inherited
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class CleanupPurgeLineView(models.TransientModel):
+    _inherit = 'cleanup.purge.line'
+    _name = 'cleanup.purge.line.view'
+
+    wizard_id = fields.Many2one(
+        'cleanup.purge.wizard.view', 'Purge Wizard', readonly=True)
+    view_id = fields.Many2one('ir.ui.view', 'View entry')
+    view_model = fields.Char(related="view_id.model", string="Missing model")
+    view_external_id = fields.Char(
+        size=128,
+        string="External ID",
+        help="ID of the view defined in xml file"
+    )
+
+    @api.multi
+    def purge(self):
+        """Unlink view entries upon manual confirmation."""
+        if self:
+            objs = self
+        else:
+            objs = self.env['cleanup.purge.line.view']\
+                .browse(self._context.get('active_ids'))
+        to_unlink = objs.filtered(lambda x: not x.purged and x.view_id)
+        self.logger.info('Purging view entries: %s', to_unlink.mapped('name'))
+        to_unlink.mapped('view_id').unlink()
+        return to_unlink.write({'purged': True})
+
+
+class CleanupPurgeWizardView(models.TransientModel):
+    _inherit = 'cleanup.purge.wizard'
+    _name = 'cleanup.purge.wizard.view'
+    _description = 'Purge views'
+
+    @api.model
+    def find(self):
+        """
+        Search for views that cannot be displayed.
+        """
+        res = []
+        for view in self.env['ir.ui.view'].with_context(active_test=False)\
+                .search([('model', '!=', False)]):
+
+            if (view.model and view.model not in self.env):
+                res.append((0, 0, {
+                    'name': view.name,
+                    'view_id': view.id,
+                    'view_external_id': view.get_external_id(),
+                }))
+        if not res:
+            raise UserError(_('No dangling view entries found'))
+        return res
+
+    purge_line_ids = fields.One2many(
+        'cleanup.purge.line.view', 'wizard_id', 'views to purge')

--- a/database_cleanup/views/menu.xml
+++ b/database_cleanup/views/menu.xml
@@ -70,4 +70,12 @@
         <field name="action" ref="action_purge_actions" />
         <field name="parent_id" ref="menu_database_cleanup"/>
     </record>
+
+    <record model="ir.ui.menu" id="menu_purge_views">
+        <field name="name">Purge obsolete views</field>
+        <field name="sequence" eval="100" />
+        <field name="action" ref="action_purge_views" />
+        <field name="parent_id" ref="menu_database_cleanup"/>
+    </record>
+
 </odoo>

--- a/database_cleanup/views/menu.xml
+++ b/database_cleanup/views/menu.xml
@@ -63,4 +63,11 @@
         <field name="action" ref="action_purge_property" />
         <field name="parent_id" ref="menu_database_cleanup"/>
     </record>
+
+    <record model="ir.ui.menu" id="menu_purge_actions">
+        <field name="name">Purge obsolete window actions</field>
+        <field name="sequence" eval="90" />
+        <field name="action" ref="action_purge_actions" />
+        <field name="parent_id" ref="menu_database_cleanup"/>
+    </record>
 </odoo>

--- a/database_cleanup/views/purge_actions.xml
+++ b/database_cleanup/views/purge_actions.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purge_actions_view" model="ir.ui.view">
+        <field name="model">cleanup.purge.wizard.action</field>
+        <field name="inherit_id" ref="form_purge_wizard" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data/>
+        </field>
+    </record>
+
+    <record id="action_purge_actions" model="ir.actions.server">
+        <field name="name">Purge window actions</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_action" />
+        <field name="code">
+            action = env.get('cleanup.purge.wizard.action').get_wizard_action()
+        </field>
+    </record>
+
+    <record id="purge_action_line_tree" model="ir.ui.view">
+        <field name="model">cleanup.purge.line.action</field>
+        <field name="inherit_id" ref="tree_purge_line" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="action_model" />
+                <field name="action_external_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="action_purge_action_line" model="ir.actions.server">
+        <field name="name">Purge</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_action" />
+        <field name="code">records.purge()</field>
+        <field name="binding_model_id" ref="database_cleanup.model_cleanup_purge_line_action" />
+    </record>
+</odoo>

--- a/database_cleanup/views/purge_views.xml
+++ b/database_cleanup/views/purge_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purge_views_view" model="ir.ui.view">
+        <field name="model">cleanup.purge.wizard.view</field>
+        <field name="inherit_id" ref="form_purge_wizard" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data/>
+        </field>
+    </record>
+
+    <record id="action_purge_views" model="ir.actions.server">
+        <field name="name">Purge views</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_view" />
+        <field name="code">
+            action = env.get('cleanup.purge.wizard.view').get_wizard_action()
+        </field>
+    </record>
+
+    <record id="purge_view_line_tree" model="ir.ui.view">
+        <field name="model">cleanup.purge.line.view</field>
+        <field name="inherit_id" ref="tree_purge_line" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="view_model" />
+                <field name="view_external_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="action_purge_view_line" model="ir.actions.server">
+        <field name="name">Purge</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_view" />
+        <field name="code">records.purge()</field>
+        <field name="binding_model_id" ref="database_cleanup.model_cleanup_purge_line_view" />
+    </record>
+</odoo>


### PR DESCRIPTION
Purge actions:
This is essentially a copy of the purge obsolete menu wizard.
I made it to be able to remove obsolete actions that blocks opening view settings in odoo 12 due to _compute_search_view and _compute_params from ir_actions.py raising an exception.

