### PR TITLE
[FIX] unlink cronjobs for the model before purging it

### DIFF
--- a/database_cleanup/models/purge_models.py
+++ b/database_cleanup/models/purge_models.py
@@ -73,6 +73,13 @@ class CleanupPurgeLineModel(models.TransientModel):
             self.env['ir.model.constraint'].search([
                 ('model', '=', line.name),
             ]).unlink()
+            cronjobs = self.env['ir.cron'].with_context(
+                active_test=False
+            ).search([
+                ('model_id.model', '=', line.name),
+            ])
+            if cronjobs:
+                cronjobs.unlink()
             relations = self.env['ir.model.fields'].search([
                 ('relation', '=', row[1]),
             ]).with_context(**context_flags)

--- a/database_cleanup/tests/test_database_cleanup.py
+++ b/database_cleanup/tests/test_database_cleanup.py
@@ -73,6 +73,11 @@ class TestDatabaseCleanup(TransactionCase):
             'name': 'Database cleanup test model',
             'model': 'x_database.cleanup.test.model',
         })
+        # and a cronjob for it
+        cronjob = self.env['ir.cron'].create({
+            'name': 'testcronjob',
+            'model_id': self.models.id,
+        })
         self.env.cr.execute(
             'insert into ir_attachment (name, res_model, res_id, type) values '
             "('test attachment', 'database.cleanup.test.model', 42, 'binary')")
@@ -83,6 +88,7 @@ class TestDatabaseCleanup(TransactionCase):
         self.assertFalse(self.env['ir.model'].search([
             ('model', '=', 'x_database.cleanup.test.model'),
         ]))
+        self.assertFalse(cronjob.exists())
 
         # create an orphaned table
         self.env.cr.execute('create table database_cleanup_test (test int)')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ openpyxl
 xlrd
 xlwt
 pysftp
-pygount
+# version 1.2.0 deprecates the API module_analysis uses
+pygount<1.2.0


### PR DESCRIPTION
if we purge a model that has a cronjob, the server action will be [deleted](https://github.com/OCA/OCB/blob/12.0/odoo/addons/base/models/ir_actions.py#L386), but as the `ir.cron` model [restricts](https://github.com/OCA/OCB/blob/12.0/odoo/addons/base/models/ir_cron.py#L52) deletion of the linked server action, it breaks at this point without the patch