### PR TITLE
[10.0][FIX] - Audit trail logs - Errors on read

### DIFF
--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': "Audit Log",
-    'version': "10.0.1.0.1",
+    'version': "10.0.1.0.0",
     'author': "ABF OSIELL,Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'website': "http://www.osiell.com",

--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': "Audit Log",
-    'version': "10.0.1.0.0",
+    'version': "10.0.1.0.1",
     'author': "ABF OSIELL,Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'website': "http://www.osiell.com",

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -2,7 +2,7 @@
 # © 2015 ABF OSIELL <http://osiell.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api, modules, _, sql_db
+from odoo import models, fields, api, modules, _
 
 FIELDS_BLACKLIST = [
     'id', 'create_uid', 'create_date', 'write_uid', 'write_date',

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -237,8 +237,8 @@ class AuditlogRule(models.Model):
         self.ensure_one()
         log_type = self.log_type
 
-        def read(self, *args, **kwargs):
-            result = read.origin(self, *args, **kwargs)
+        def read(self, fields=None, load='_classic_read', **kwargs):
+            result = read.origin(self, fields, load, **kwargs)
             # Sometimes the result is not a list but a dictionary
             # Also, we can not modify the current result as it will break calls
             result2 = result
@@ -246,34 +246,18 @@ class AuditlogRule(models.Model):
                 result2 = [result]
             read_values = dict((d['id'], d) for d in result2)
             # Old API
-            if args and isinstance(args[0], sql_db.Cursor):
-                cr, uid, ids = args[0], args[1], args[2]
-                if isinstance(ids, (int, long)):
-                    ids = [ids]
-                # If the call came from auditlog itself, skip logging:
-                # avoid logs on `read` produced by auditlog during internal
-                # processing: read data of relevant records, 'ir.model',
-                # 'ir.model.fields'... (no interest in logging such operations)
-                if kwargs.get('context', {}).get('auditlog_disabled'):
-                    return result
-                env = api.Environment(cr, uid, {'auditlog_disabled': True})
-                rule_model = env['auditlog.rule']
-                rule_model.sudo().create_logs(
-                    env.uid, self._name, ids,
-                    'read', read_values, None, {'log_type': log_type})
-            # New API
-            else:
-                # If the call came from auditlog itself, skip logging:
-                # avoid logs on `read` produced by auditlog during internal
-                # processing: read data of relevant records, 'ir.model',
-                # 'ir.model.fields'... (no interest in logging such operations)
-                if self.env.context.get('auditlog_disabled'):
-                    return result
-                self = self.with_context(auditlog_disabled=True)
-                rule_model = self.env['auditlog.rule']
-                rule_model.sudo().create_logs(
-                    self.env.uid, self._name, self.ids,
-                    'read', read_values, None, {'log_type': log_type})
+
+            # If the call came from auditlog itself, skip logging:
+            # avoid logs on `read` produced by auditlog during internal
+            # processing: read data of relevant records, 'ir.model',
+            # 'ir.model.fields'... (no interest in logging such operations)
+            if self.env.context.get('auditlog_disabled'):
+                return result
+            self = self.with_context(auditlog_disabled=True)
+            rule_model = self.env['auditlog.rule']
+            rule_model.sudo().create_logs(
+                self.env.uid, self._name, self.ids,
+                'read', read_values, None, {'log_type': log_type})
             return result
         return read
 

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -23,6 +23,12 @@ class TestAuditlog(object):
             ('method', '=', 'write'),
             ('res_id', '=', group.id),
         ]).ensure_one())
+        group.with_context(auditlog_disabled=False).read()
+        self.assertTrue(auditlog_log.search([
+            ('model_id', '=', self.groups_model_id),
+            ('method', '=', 'read'),
+            ('res_id', '=', group.id),
+        ]).ensure_one())
         group.unlink()
         self.assertTrue(auditlog_log.search([
             ('model_id', '=', self.groups_model_id),


### PR DESCRIPTION
Fix the error for users who are getting an error on read model. in view. for audit log
Getting error(`ValueError: dictionary update sequence element #0 has length) while read the log for any object, Here is the list of issues who are getting the same issue for read any object.

- #1122
- #924
- #946
- #747

Error: `ValueError: dictionary update sequence element #0 has length 10; 2 is required`
