### PR TITLE
[FIX] Fixes dbfilter_from_header if dbfilter_org returns no database

### DIFF
--- a/dbfilter_from_header/override.py
+++ b/dbfilter_from_header/override.py
@@ -12,11 +12,13 @@ db_filter_org = http.db_filter
 
 
 def db_filter(dbs, httprequest=None):
-    dbs = db_filter_org(dbs, httprequest)
+    dbs_orig = db_filter_org(dbs, httprequest)
     httprequest = httprequest or http.request.httprequest
     db_filter_hdr = httprequest.environ.get('HTTP_X_ODOO_DBFILTER')
     if db_filter_hdr:
         dbs = [db for db in dbs if re.match(db_filter_hdr, db)]
+    else:
+        dbs = dbs_orig
     return dbs
 
 


### PR DESCRIPTION
The original dbfilter returns [] when there is no database matching the original request
This PR fixes that case
cc @luceeasypme @kbouchek