### PR TITLE
[FIX] autovacuum_message_attachment : wrong message formating

### DIFF
--- a/autovacuum_message_attachment/models/autovacuum_mixin.py
+++ b/autovacuum_message_attachment/models/autovacuum_mixin.py
@@ -35,7 +35,7 @@ class AutovacuumMixin(models.AbstractModel):
                         new_env.cr.commit()
                 except Exception as e:
                     _logger.exception(
-                        "Failed to delete Ms : %s" % (self._name, str(e)))
+                        "Failed to delete Ms : %s - %s" % (self._name, str(e)))
 
     # Call by cron
     @api.model


### PR DESCRIPTION
```
    "Failed to delete Ms : %s" % (self._name, str(e)))
TypeError: not all arguments converted during string formatting
```

@alexis-via 