### PR TITLE
[FIX] sql_request_abstract: allow XML-RPC calls

### DIFF
--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -94,6 +94,7 @@ class SQLRequestMixin(models.AbstractModel):
             if item._check_execution_enabled:
                 item._check_execution()
             item.state = 'sql_valid'
+        return True
 
     @api.multi
     def button_set_draft(self):


### PR DESCRIPTION
Hi. trivial patch. add return True on one function, to allow XML-RPC calls.

Other exemple in Odoo Core :
odoo/odoo@dc043cf


Other similar PR : https://github.com/OCA/reporting-engine/pull/412