### PR TITLE
[REF] company_country: Deprecate module

### DIFF
--- a/company_country/README.rst
+++ b/company_country/README.rst
@@ -25,6 +25,9 @@ Company Country
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
+**Note:** This module is not required anymore for Odoo >= 13.0, thanks to
+`this fix introduced in Odoo <https://github.com/odoo/odoo/pull/52117>`_.
+
 This module allows to set a country to the main company before the ``account``
 module is installed, so the hook of that module installs the correct
 ``l10n_***`` module.

--- a/company_country/__manifest__.py
+++ b/company_country/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Company Country",
     "summary": "Set country to main company",
-    "version": "13.0.1.0.2",
+    "version": "13.0.1.0.2",  # Note: module shouldn't be migrated, see README
     "category": "base",
     "website": "https://github.com/OCA/server-tools/tree/13.0/company_country",
     "maintainers": ["moylop260", "luisg123v"],

--- a/company_country/readme/DESCRIPTION.rst
+++ b/company_country/readme/DESCRIPTION.rst
@@ -1,3 +1,6 @@
+**Note:** This module is not required anymore for Odoo >= 13.0, thanks to
+`this fix introduced in Odoo <https://github.com/odoo/odoo/pull/52117>`_.
+
 This module allows to set a country to the main company before the ``account``
 module is installed, so the hook of that module installs the correct
 ``l10n_***`` module.

--- a/company_country/static/description/index.html
+++ b/company_country/static/description/index.html
@@ -368,6 +368,8 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/server-tools/tree/13.0/company_country"><img alt="OCA/server-tools" src="https://img.shields.io/badge/github-OCA%2Fserver--tools-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/server-tools-13-0/server-tools-13-0-company_country"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/149/13.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
+<p><strong>Note:</strong> This module is not required anymore for Odoo &gt;= 13.0, thanks to
+<a class="reference external" href="https://github.com/odoo/odoo/pull/52117">this fix introduced in Odoo</a>.</p>
 <p>This module allows to set a country to the main company before the <tt class="docutils literal">account</tt>
 module is installed, so the hook of that module installs the correct
 <tt class="docutils literal"><span class="pre">l10n_***</span></tt> module.</p>


### PR DESCRIPTION
This module was intended to avoid a wrong chart of account to be installed
by the account module's hook, but that has been fixed in Odoo v13: https://github.com/odoo/odoo/pull/52117

Because of that, a note was added on the README to mention this module is
not required anymore and it shouldn't be migrated to v14.