### PR TITLE
Pin pyotp to last version compatible with py 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@
   python-json-logger
   odoorpc
   raven
-  pyotp
+  pyotp<2.4


### PR DESCRIPTION
see https://github.com/pyauth/pyotp/pull/89/files

Without this fix branch fail

because of https://github.com/pyauth/pyotp/blob/master/src/pyotp/__init__.py#L14 using mypy

Also concern v10, v9