### PR TITLE
[9.0][FIX] Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ acme_tiny
 IPy
 validate_email
 pysftp
-pyotp
+pyotp<2.4
 fs==0.5.4
 oauthlib
 pyjwt


### PR DESCRIPTION
pyotp in python2.7 is supported in versions <2.4