### PR TITLE
[13.0][FIX] base_view_inheritance_extension: add missing params on function apply_inheritance_specs

### DIFF
--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -39,7 +39,9 @@ class IrUiView(models.Model):
     _inherit = "ir.ui.view"
 
     @api.model
-    def apply_inheritance_specs(self, source, specs_tree, inherit_id):
+    def apply_inheritance_specs(
+        self, source, specs_tree, inherit_id, pre_locate=lambda s: True
+    ):
         for specs, handled_by in self._iter_inheritance_specs(specs_tree):
             source = handled_by(source, specs, inherit_id)
         return source


### PR DESCRIPTION
according to original function definition
https://github.com/odoo/odoo/blob/13.0/odoo/addons/base/models/ir_ui_view.py#L644


