### PR TITLE
[FIX] audit_log: Permission error on auditlog.log.line missing a requ…

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -373,6 +373,7 @@ class AuditlogRule(models.Model):
                 'user_id': uid,
                 'http_request_id': http_request_model.current_http_request(),
                 'http_session_id': http_session_model.current_http_session(),
+                'line_ids': False,
             }
             vals.update(additional_log_values or {})
             log = log_model.create(vals)


### PR DESCRIPTION
…ired field (field_id)

In some wird cases, Odoo tries to create an auditlog.log record with `line_ids: [{[(6, 0, [])]}, {(0, 0, [])}]`. This pull request seems to fix the issue.