### PR TITLE
[IMP] base_jsonify: add lang, custom resolvers, alias* support

### DIFF
--- a/base_jsonify/README.rst
+++ b/base_jsonify/README.rst
@@ -96,11 +96,11 @@ To use these features, a full parser follows the following structure:
             False: [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
-                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'display_name'}])
+                ({'name': 'partner_id', 'target': 'partner'}, [{'name': 'display_name'}])
             ],
             'fr_FR': [
-                {'name': 'description', 'alias': 'descriptions_fr'},
-                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'description', 'alias': 'description_fr'}])
+                {'name': 'description', 'target': 'descriptions_fr'},
+                ({'name': 'partner_id', 'target': 'partner'}, [{'name': 'description', 'target': 'description_fr'}])
             ],
         }
     }
@@ -132,7 +132,7 @@ but other features like custom resolvers are:
         "fields": [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
-                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}]),
+                ({'name': 'partner_id', 'target': 'partners'}, [{'name': 'display_name'}]),
         ],
     }
 
@@ -157,7 +157,7 @@ If the global resolver is given, then the json_dict goes through:
 Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.
 
-It is possible for an alias to end with a '*':
+It is possible for a target to end with a '*':
 in that case the result is put into a list.
 
 .. code-block:: python
@@ -165,8 +165,8 @@ in that case the result is put into a list.
   parser = {
       fields: [
           {'name': 'name'},
-          {'name': 'field_1', 'alias': 'customTags*'},
-          {'name': 'field_2', 'alias': 'customTags*'},
+          {'name': 'field_1', 'target': 'customTags*'},
+          {'name': 'field_2', 'target': 'customTags*'},
       ]
   }
 

--- a/base_jsonify/README.rst
+++ b/base_jsonify/README.rst
@@ -96,13 +96,28 @@ To use these features, a full parser follows the following structure:
             False: [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
-                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}])
+                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'display_name'}])
             ],
             'fr_FR': [
                 {'name': 'description', 'alias': 'descriptions_fr'},
-                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'description', 'alias': 'description_fr'}])
+                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'description', 'alias': 'description_fr'}])
             ],
         }
+    }
+
+
+One would get the a result having this structure (note that the translated fields are merged in the same dictionary):
+
+.. code-block:: python
+
+    exported_json == {
+        "description": "English description",
+        "description_fr": "French description, voilà",
+        "number": 42,
+        "partner": {
+            "display_name": "partner name",
+            "description_fr": "French description of that partner",
+        },
     }
 
 
@@ -114,7 +129,6 @@ but other features like custom resolvers are:
 
     parser = {
         "resolver": 3,
-        "language_agnostic": True,
         "fields": [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
@@ -122,6 +136,15 @@ but other features like custom resolvers are:
         ],
     }
 
+
+By passing the `fields` key instead of `langs`, we have essentially the same behaviour as simple parsers,
+with the added benefit of being able to use resolvers.
+
+Standard use-cases of resolvers are:
+- give field-specific defaults (e.g. `""` instead of `None`)
+- cast a field type (e.g. `int()`)
+- alias a particular field for a specific export
+- ...
 
 A simple parser is simply translated into a full parser at export.
 
@@ -135,18 +158,16 @@ Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.
 
 It is possible for an alias to end with a '*':
-in that case the result it put into a list.
+in that case the result is put into a list.
 
 .. code-block:: python
 
   parser = {
-      "langs": {
-          False: [
-              {'name': 'name'},
-              {'name': 'field_1', 'alias': 'customTags*'},
-              {'name': 'field_2', 'alias': 'customTags*'},
-          ]
-      }
+      fields: [
+          {'name': 'name'},
+          {'name': 'field_1', 'alias': 'customTags*'},
+          {'name': 'field_2', 'alias': 'customTags*'},
+      ]
   }
 
 

--- a/base_jsonify/README.rst
+++ b/base_jsonify/README.rst
@@ -29,7 +29,7 @@ This module adds a 'jsonify' method to every model of the ORM.
 It works on the current recordset and requires a single argument 'parser'
 that specify the field to extract.
 
-Example of parser:
+Example of a simple parser:
 
 
 .. code-block:: python
@@ -42,8 +42,8 @@ Example of parser:
         ('line_id', ['id', ('product_id', ['name']), 'price_unit'])
     ]
 
-In order to be consitent with the odoo api the jsonify method always
-return a list of object even if there is only one element in input
+In order to be consistent with the odoo api the jsonify method always
+return a list of object even if there is only one element in the recordset.
 
 By default the key into the json is the name of the field extracted
 from the model. If you need to specify an alternate name to use as key, you
@@ -79,6 +79,77 @@ you can pass a callable or the name of a method on the model:
 Also the module provide a method "get_json_parser" on the ir.exports object
 that generate a parser from an ir.exports configuration.
 
+Further features are available for advanced uses.
+It defines a simple "resolver" model that has a "python_code" field and an eval
+function so that arbitrary functions can be configured to transform fields,
+or process the resulting dictionary.
+It is also to specify a lang to extract the translation of any given field.
+
+To use these features, a full parser follows the following structure:
+
+.. code-block:: python
+
+    parser = {
+        "resolver": ir.exports.resolver(3),
+        "langs": {
+            False: [
+                {'name': 'description'},
+                {'name': 'number', 'resolver': ir.exports.resolver(5)},
+                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}])
+            ],
+            'fr_FR': [
+                {'name': 'description', 'alias': 'descriptions_fr'},
+                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'description', 'alias': 'description_fr'}])
+            ],
+        }
+    }
+
+
+A simple parser is simply translated into a full parser at export.
+
+If the global resolver is given, then the json_dict goes through:
+
+.. code-block:: python
+
+    resolver.eval(dict, record)
+
+Which allows to add external data from the context or transform the dictionary
+if necessary. Similarly if given for a field the resolver evaluates the result.
+
+It is possible for an alias to end with a '*':
+in that case the result it put into a list.
+
+.. code-block:: python
+
+  parser = {
+      "langs": {
+          False: [
+              {'name': 'name'},
+              {'name': 'field_1', 'alias': 'customTags*'},
+              {'name': 'field_2', 'alias': 'customTags*'},
+          ]
+      }
+  }
+
+
+Would result in the following json structure:
+
+.. code-block:: python
+
+    {
+        'name': 'record_name',
+        'customTags': ['field_1_value', 'field_2_value'],
+    }
+
+The intended use-case is to be compatible with APIs that require all translated
+parameters to be exported simultaneously, and ask for custom properties to be
+put in a sub-dictionary.
+Since it is often the case that some of these requirements are optional,
+new requirements could be met without needing to add field or change any code.
+
+Note that the export values with the simple parser depends on the record's lang;
+this is in contrast with full parsers which are designed to be language agnostic.
+
 **Table of contents**
 
 .. contents::
@@ -108,6 +179,7 @@ Contributors
 * BEAU Sébastien <sebastien.beau@akretion.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Nans Lefebvre <nans.lefebvre@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/base_jsonify/README.rst
+++ b/base_jsonify/README.rst
@@ -90,11 +90,12 @@ To use these features, a full parser follows the following structure:
 .. code-block:: python
 
     parser = {
-        "resolver": ir.exports.resolver(3),
+        "resolver": 3,
+        "language_agnostic": True,
         "langs": {
             False: [
                 {'name': 'description'},
-                {'name': 'number', 'resolver': ir.exports.resolver(5)},
+                {'name': 'number', 'resolver': 5},
                 ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}])
             ],
             'fr_FR': [
@@ -102,6 +103,23 @@ To use these features, a full parser follows the following structure:
                 ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'description', 'alias': 'description_fr'}])
             ],
         }
+    }
+
+
+Note that a resolver can be passed either as a recordset or as an id, so as to be fully serializable.
+A slightly simpler version in case the translation of fields is not needed,
+but other features like custom resolvers are:
+
+.. code-block:: python
+
+    parser = {
+        "resolver": 3,
+        "language_agnostic": True,
+        "fields": [
+                {'name': 'description'},
+                {'name': 'number', 'resolver': 5},
+                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}]),
+        ],
     }
 
 

--- a/base_jsonify/README.rst
+++ b/base_jsonify/README.rst
@@ -80,7 +80,7 @@ Also the module provide a method "get_json_parser" on the ir.exports object
 that generate a parser from an ir.exports configuration.
 
 Further features are available for advanced uses.
-It defines a simple "resolver" model that has a "python_code" field and an eval
+It defines a simple "resolver" model that has a "python_code" field and a resolve
 function so that arbitrary functions can be configured to transform fields,
 or process the resulting dictionary.
 It is also to specify a lang to extract the translation of any given field.
@@ -152,12 +152,12 @@ If the global resolver is given, then the json_dict goes through:
 
 .. code-block:: python
 
-    resolver.eval(dict, record)
+    resolver.resolve(dict, record)
 
 Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.
 
-It is possible for a target to end with a '*':
+It is possible for a target to have a marshaller by ending the target with '=list':
 in that case the result is put into a list.
 
 .. code-block:: python
@@ -165,8 +165,8 @@ in that case the result is put into a list.
   parser = {
       fields: [
           {'name': 'name'},
-          {'name': 'field_1', 'target': 'customTags*'},
-          {'name': 'field_2', 'target': 'customTags*'},
+          {'name': 'field_1', 'target': 'customTags=list'},
+          {'name': 'field_2', 'target': 'customTags=list'},
       ]
   }
 

--- a/base_jsonify/__manifest__.py
+++ b/base_jsonify/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Base Jsonify",
     "summary": "Base module that provide the jsonify method on all models",
-    "version": "13.0.1.3.1",
+    "version": "13.0.2.0.0",
     "category": "Uncategorized",
     "website": "https://github.com/OCA/server-tools",
     "author": "Akretion, Odoo Community Association (OCA)",

--- a/base_jsonify/__manifest__.py
+++ b/base_jsonify/__manifest__.py
@@ -13,6 +13,14 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["base"],
-    "data": ["views/ir_exports_view.xml"],
-    "demo": ["demo/export_demo.xml", "demo/ir.exports.line.csv"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/ir_exports_view.xml",
+        "views/ir_exports_resolver_view.xml",
+    ],
+    "demo": [
+        "demo/resolver_demo.xml",
+        "demo/export_demo.xml",
+        "demo/ir.exports.line.csv",
+    ],
 }

--- a/base_jsonify/demo/resolver_demo.xml
+++ b/base_jsonify/demo/resolver_demo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="ir_exports_resolver_dict" model="ir.exports.resolver">
+        <field name="name">ExtraData dictionary (number/text)</field>
+        <field name="python_code">
+is_number = field_type in ('integer', 'float')
+ftype = "NUMBER" if is_number else "TEXT"
+value = value if is_number else str(value)
+result = {"Key": name, "Value": value, "Type": ftype, "IsPublic": True}
+        </field>
+    </record>
+</odoo>

--- a/base_jsonify/i18n/base_jsonify.pot
+++ b/base_jsonify/i18n/base_jsonify.pot
@@ -19,8 +19,8 @@ msgid "Active"
 msgstr ""
 
 #. module: base_jsonify
-#: model:ir.model.fields,field_description:base_jsonify.field_ir_exports_line__alias
-msgid "Alias"
+#: model:ir.model.fields,field_description:base_jsonify.field_ir_exports_line__target
+msgid "Target"
 msgstr ""
 
 #. module: base_jsonify
@@ -57,20 +57,20 @@ msgstr ""
 #. module: base_jsonify
 #: code:addons/base_jsonify/models/ir_exports_line.py:0
 #, python-format
-msgid "Name and Alias must have the same hierarchy depth"
+msgid "Name and Target must have the same hierarchy depth"
 msgstr ""
 
 #. module: base_jsonify
 #: code:addons/base_jsonify/models/ir_exports_line.py:0
 #, python-format
-msgid "The alias must reference the same field as in name '%s' not in '%s'"
+msgid "The target must reference the same field as in name '%s' not in '%s'"
 msgstr ""
 
 #. module: base_jsonify
-#: model:ir.model.fields,help:base_jsonify.field_ir_exports_line__alias
+#: model:ir.model.fields,help:base_jsonify.field_ir_exports_line__target
 msgid ""
-"The complete path to the field where you can specify an alias on the a step "
-"as field:alias"
+"The complete path to the field where you can specify a target on the a step "
+"as field:target"
 msgstr ""
 
 #. module: base_jsonify

--- a/base_jsonify/i18n/zh_CN.po
+++ b/base_jsonify/i18n/zh_CN.po
@@ -22,8 +22,8 @@ msgid "Active"
 msgstr ""
 
 #. module: base_jsonify
-#: model:ir.model.fields,field_description:base_jsonify.field_ir_exports_line__alias
-msgid "Alias"
+#: model:ir.model.fields,field_description:base_jsonify.field_ir_exports_line__target
+msgid "Target"
 msgstr "别名"
 
 #. module: base_jsonify
@@ -60,20 +60,20 @@ msgstr "索引"
 #. module: base_jsonify
 #: code:addons/base_jsonify/models/ir_exports_line.py:0
 #, python-format
-msgid "Name and Alias must have the same hierarchy depth"
+msgid "Name and Target must have the same hierarchy depth"
 msgstr "名称和别名必须具有相同的层次结构深度"
 
 #. module: base_jsonify
 #: code:addons/base_jsonify/models/ir_exports_line.py:0
 #, python-format
-msgid "The alias must reference the same field as in name '%s' not in '%s'"
+msgid "The target must reference the same field as in name '%s' not in '%s'"
 msgstr "别名必须引用与名称相同的字段'%s'不在'%s'"
 
 #. module: base_jsonify
-#: model:ir.model.fields,help:base_jsonify.field_ir_exports_line__alias
+#: model:ir.model.fields,help:base_jsonify.field_ir_exports_line__target
 msgid ""
-"The complete path to the field where you can specify an alias on the a step "
-"as field:alias"
+"The complete path to the field where you can specify a target on the a step "
+"as field:target"
 msgstr "字段的完整路径，您可以在其中指定步骤作为字段的别名：别名"
 
 #. module: base_jsonify

--- a/base_jsonify/migrations/13.0.2.0.0/pre-migrate.py
+++ b/base_jsonify/migrations/13.0.2.0.0/pre-migrate.py
@@ -1,0 +1,6 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    query = """ALTER TABLE "ir_exports_line" RENAME COLUMN "alias" TO "target";"""
+    cr.execute(query)

--- a/base_jsonify/migrations/13.0.2.0.0/pre-migrate.py
+++ b/base_jsonify/migrations/13.0.2.0.0/pre-migrate.py
@@ -1,6 +1,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from openupgradelib import openupgrade
 
-def migrate(cr, version):
-    query = """ALTER TABLE "ir_exports_line" RENAME COLUMN "alias" TO "target";"""
-    cr.execute(query)
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, {"ir_exports_line": [("alias", "target")]})

--- a/base_jsonify/models/__init__.py
+++ b/base_jsonify/models/__init__.py
@@ -1,3 +1,4 @@
 from . import models
 from . import ir_export
 from . import ir_exports_line
+from . import ir_exports_resolver

--- a/base_jsonify/models/__init__.py
+++ b/base_jsonify/models/__init__.py
@@ -1,3 +1,4 @@
+from . import utils
 from . import models
 from . import ir_export
 from . import ir_exports_line

--- a/base_jsonify/models/ir_export.py
+++ b/base_jsonify/models/ir_export.py
@@ -5,6 +5,7 @@
 from collections import OrderedDict
 
 from odoo import fields, models
+from odoo.tools import ormcache
 
 
 def partition(l, accessor):
@@ -88,6 +89,11 @@ class IrExport(models.Model):
         help="If set, will apply the global resolver to the result",
     )
 
+    @ormcache(
+        "self.language_agnostic",
+        "self.global_resolver_id.id",
+        "tuple(self.export_fields.mapped('write_date'))",
+    )
     def get_json_parser(self):
         """Creates a parser from ir.exports record and return it.
 

--- a/base_jsonify/models/ir_export.py
+++ b/base_jsonify/models/ir_export.py
@@ -49,7 +49,7 @@ def update_dict(data, fields, options):
 def convert_dict(dict_parser):
     """Convert dict returned by update_dict to list consistent w/ Odoo API.
 
-    The list is composed of strings (field names or aliases) or tuples.
+    The list is composed of strings (field names or targets) or tuples.
     """
     parser = []
     for field, value in dict_parser.items():
@@ -63,7 +63,7 @@ def convert_dict(dict_parser):
 def field_dict(field, options=None):
     result = {"name": field.split(":")[0]}
     if len(field.split(":")) > 1:
-        result["alias"] = field.split(":")[1]
+        result["target"] = field.split(":")[1]
     for option in options or {}:
         if options[option]:
             result[option] = options[option]
@@ -100,8 +100,8 @@ class IrExport(models.Model):
             dict_parser = OrderedDict()
             for line in lang_to_lines[lang]:
                 names = line.name.split("/")
-                if line.alias:
-                    names = line.alias.split("/")
+                if line.target:
+                    names = line.target.split("/")
                 options = {"resolver": line.resolver_id, "function": line.function}
                 update_dict(dict_parser, names, options)
             lang_parsers[lang] = convert_dict(dict_parser)

--- a/base_jsonify/models/ir_export.py
+++ b/base_jsonify/models/ir_export.py
@@ -7,7 +7,13 @@ from collections import OrderedDict
 from odoo import fields, models
 
 
-def partition(l, accessor):  # -> Dict
+def partition(l, accessor):
+    """Partition an iterable (e.g. a recordset) according to an accessor (e.g. a lambda)
+       Return a dictionary whose keys are the values obtained from accessor, and values
+       are the items that have this value.
+       Example: partition([{"name": "ax"}, {"name": "by"}], lambda x: "x" in x["name"])
+                => {True: [{"name": "ax"}], False: [{"name": "by"}]}
+    """
     result = {}
     for item in l:
         key = accessor(item)

--- a/base_jsonify/models/ir_export.py
+++ b/base_jsonify/models/ir_export.py
@@ -99,7 +99,10 @@ class IrExport(models.Model):
                 options = {"resolver": line.resolver_id, "function": line.function}
                 update_dict(dict_parser, names, options)
             lang_parsers[lang] = convert_dict(dict_parser)
-        parser["langs"] = lang_parsers
+        if list(lang_parsers.keys()) == [False]:
+            parser["fields"] = lang_parsers[False]
+        else:
+            parser["langs"] = lang_parsers
         if self.global_resolver_id:
             parser["resolver"] = self.global_resolver_id
         return parser

--- a/base_jsonify/models/ir_exports_line.py
+++ b/base_jsonify/models/ir_exports_line.py
@@ -8,10 +8,10 @@ from odoo.exceptions import ValidationError
 class IrExportsLine(models.Model):
     _inherit = "ir.exports.line"
 
-    alias = fields.Char(
-        "Alias",
-        help="The complete path to the field where you can specify an "
-        "alias on the a step as field:alias",
+    target = fields.Char(
+        "Target",
+        help="The complete path to the field where you can specify a "
+        "target on the a step as field:target",
     )
     active = fields.Boolean(string="Active", default=True)
     lang_id = fields.Many2one(
@@ -38,24 +38,24 @@ class IrExportsLine(models.Model):
                     _("Either set a function or a resolver, not both.")
                 )
 
-    @api.constrains("alias", "name")
-    def _check_alias(self):
+    @api.constrains("target", "name")
+    def _check_target(self):
         for rec in self:
-            if not rec.alias:
+            if not rec.target:
                 continue
             names = rec.name.split("/")
-            names_with_alias = rec.alias.split("/")
-            if len(names) != len(names_with_alias):
+            names_with_target = rec.target.split("/")
+            if len(names) != len(names_with_target):
                 raise ValidationError(
-                    _("Name and Alias must have the same hierarchy depth")
+                    _("Name and Target must have the same hierarchy depth")
                 )
-            for name, name_with_alias in zip(names, names_with_alias):
-                field_name = name_with_alias.split(":")[0]
+            for name, name_with_target in zip(names, names_with_target):
+                field_name = name_with_target.split(":")[0]
                 if name != field_name:
                     raise ValidationError(
                         _(
-                            "The alias must reference the same field as in "
+                            "The target must reference the same field as in "
                             "name '%s' not in '%s'"
                         )
-                        % (name, name_with_alias)
+                        % (name, name_with_target)
                     )

--- a/base_jsonify/models/ir_exports_line.py
+++ b/base_jsonify/models/ir_exports_line.py
@@ -14,6 +14,29 @@ class IrExportsLine(models.Model):
         "alias on the a step as field:alias",
     )
     active = fields.Boolean(string="Active", default=True)
+    lang_id = fields.Many2one(
+        comodel_name="res.lang",
+        string="Language",
+        help="If set, the language in which the field is exported",
+    )
+    resolver_id = fields.Many2one(
+        comodel_name="ir.exports.resolver",
+        string="Custom resolver",
+        help="If set, will apply the resolver on the field value",
+    )
+    function = fields.Char(
+        comodel_name="ir.exports.resolver",
+        string="Function",
+        help="A method defined on the model that takes a record and a field_name",
+    )
+
+    @api.constrains("resolver_id", "function")
+    def _check_function_resolver(self):
+        for rec in self:
+            if rec.resolver_id and rec.function:
+                raise ValidationError(
+                    _("Either set a function or a resolver, not both.")
+                )
 
     @api.constrains("alias", "name")
     def _check_alias(self):

--- a/base_jsonify/models/ir_exports_line.py
+++ b/base_jsonify/models/ir_exports_line.py
@@ -24,19 +24,18 @@ class IrExportsLine(models.Model):
         string="Custom resolver",
         help="If set, will apply the resolver on the field value",
     )
-    function = fields.Char(
+    instance_method_name = fields.Char(
         comodel_name="ir.exports.resolver",
         string="Function",
         help="A method defined on the model that takes a record and a field_name",
     )
 
-    @api.constrains("resolver_id", "function")
+    @api.constrains("resolver_id", "instance_method_name")
     def _check_function_resolver(self):
         for rec in self:
-            if rec.resolver_id and rec.function:
-                raise ValidationError(
-                    _("Either set a function or a resolver, not both.")
-                )
+            if rec.resolver_id and rec.instance_method_name:
+                msg = _("Either set a function or a resolver, not both.")
+                raise ValidationError(msg)
 
     @api.constrains("target", "name")
     def _check_target(self):

--- a/base_jsonify/models/ir_exports_resolver.py
+++ b/base_jsonify/models/ir_exports_resolver.py
@@ -34,10 +34,11 @@ class FieldResolver(models.Model):
     def eval(self, param, records):
         self.ensure_one()
         result = []
+        context = records.env.context
         if self.type == "global":
             assert len(param) == len(records)
             for value, record in zip(param, records):
-                values = {"value": value, "record": record}
+                values = {"value": value, "record": record, "context": context}
                 safe_eval(self.python_code, values, mode="exec", nocopy=True)
                 result.append(values["result"])
         else:  # param is a field
@@ -46,6 +47,7 @@ class FieldResolver(models.Model):
                     "value": record[param.name],
                     "name": param.name,
                     "field_type": param.type,
+                    "context": context,
                 }
                 safe_eval(self.python_code, values, mode="exec", nocopy=True)
                 result.append(values["result"])

--- a/base_jsonify/models/ir_exports_resolver.py
+++ b/base_jsonify/models/ir_exports_resolver.py
@@ -21,7 +21,7 @@ class FieldResolver(models.Model):
     """
 
     _name = "ir.exports.resolver"
-    _description = "Resolver"
+    _description = "Export Resolver"
 
     name = fields.Char()
     type = fields.Selection([("field", "Field"), ("global", "Global")])
@@ -31,7 +31,7 @@ class FieldResolver(models.Model):
         help="\n".join(help_message),
     )
 
-    def eval(self, param, records):
+    def resolve(self, param, records):
         self.ensure_one()
         result = []
         context = records.env.context

--- a/base_jsonify/models/ir_exports_resolver.py
+++ b/base_jsonify/models/ir_exports_resolver.py
@@ -1,0 +1,52 @@
+# Copyright 2020 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+from odoo.tools.safe_eval import safe_eval
+
+help_message = [
+    "Compute the result from 'value' by setting the variable 'result'.",
+    "For fields resolvers:",
+    ":param name: name of the field",
+    ":param value: value of the field",
+    ":param field_type: type of the field",
+    "For global resolvers:",
+    ":param value: json dict",
+    ":param record: the record",
+]
+
+
+class FieldResolver(models.Model):
+    """Arbitrary function to process a field or a dict at export time.
+    """
+
+    _name = "ir.exports.resolver"
+    _description = "Resolver"
+
+    name = fields.Char()
+    type = fields.Selection([("field", "Field"), ("global", "Global")])
+    python_code = fields.Text(
+        string="Python Code",
+        default="\n# ".join(["result = value"] + help_message),
+        help="\n".join(help_message),
+    )
+
+    def eval(self, param, records):
+        self.ensure_one()
+        result = []
+        if self.type == "global":
+            assert len(param) == len(records)
+            for value, record in zip(param, records):
+                values = {"value": value, "record": record}
+                safe_eval(self.python_code, values, mode="exec", nocopy=True)
+                result.append(values["result"])
+        else:  # param is a field
+            for record in records:
+                values = {
+                    "value": record[param.name],
+                    "name": param.name,
+                    "field_type": param.type,
+                }
+                safe_eval(self.python_code, values, mode="exec", nocopy=True)
+                result.append(values["result"])
+        return result

--- a/base_jsonify/models/ir_exports_resolver.py
+++ b/base_jsonify/models/ir_exports_resolver.py
@@ -27,7 +27,7 @@ class FieldResolver(models.Model):
     type = fields.Selection([("field", "Field"), ("global", "Global")])
     python_code = fields.Text(
         string="Python Code",
-        default="\n# ".join(["result = value"] + help_message),
+        default="\n".join(["# " + h for h in help_message] + ["result = value"]),
         help="\n".join(help_message),
     )
 

--- a/base_jsonify/models/models.py
+++ b/base_jsonify/models/models.py
@@ -17,19 +17,103 @@ class Base(models.AbstractModel):
     @api.model
     def __parse_field(self, parser_field):
         """Deduct how to handle a field from its parser."""
-        field_name = parser_field
-        subparser = None
-        if isinstance(parser_field, tuple):
-            field_name, subparser = parser_field
-        json_key = field_name
-        if ":" in field_name:
-            field_name, json_key = field_name.split(":")
-        return field_name, json_key, subparser
+        return parser_field if isinstance(parser_field, tuple) else (parser_field, None)
+
+    @api.model
+    def convert_simple_to_full_parser(self, parser):
+        def _f(f, function=None):
+            field_split = f.split(":")
+            field_dict = {"name": field_split[0]}
+            if len(field_split) > 1:
+                field_dict["alias"] = field_split[1]
+            if function:
+                field_dict["function"] = function
+            return field_dict
+
+        def _convert_parser(parser):
+            result = []
+            for line in parser:
+                if isinstance(line, str):
+                    result.append(_f(line))
+                else:
+                    f, sub = line
+                    if callable(sub) or isinstance(sub, str):
+                        result.append(_f(f, sub))
+                    else:
+                        result.append((_f(f), _convert_parser(sub)))
+            return result
+
+        return {"language_agnostic": False, "langs": {False: _convert_parser(parser)}}
+
+    @api.model
+    def _jsonify_bad_parser_error(self, field_name):
+        raise UserError(_("Wrong parser configuration for field: `%s`") % field_name)
+
+    def _function_value(self, record, function, field_name):
+        if function in dir(record):
+            method = getattr(self, function, None)
+            return method(field_name)
+        elif callable(function):
+            return function(record, field_name)
+        else:
+            return self._jsonify_bad_parser_error(field_name)
+
+    @api.model
+    def _jsonify_value(self, record, field, resolver):
+        # TODO: we should get default by field (eg: char field -> "")
+        value = record[field.name]
+        if value is False and field.type != "boolean":
+            value = None
+        elif field.type == "date":
+            value = fields.Date.to_date(value).isoformat()
+        elif field.type == "datetime":
+            # Ensures value is a datetime
+            value = fields.Datetime.to_datetime(value)
+            # Get the timestamp converted to the client's timezone.
+            # This call also add the tzinfo into the datetime object
+            value = fields.Datetime.context_timestamp(record, value)
+            value = value.isoformat()
+        return self._resolve(resolver, field, record)[0] if resolver else value
+
+    @api.model
+    def _resolve(self, resolver, *args):
+        if isinstance(resolver, int):
+            resolver = self.env["ir.exports.resolver"].browse(resolver)
+        return resolver.eval(*args)
+
+    @api.model
+    def _jsonify_record(self, parser, rec, root):
+        for field in parser:
+            field_dict, subparser = rec.__parse_field(field)
+            field_name = field_dict["name"]
+            json_key = field_dict.get("alias", field_name)
+            field = rec._fields[field_name]
+            if field_dict.get("function"):
+                function = field_dict["function"]
+                value = self._function_value(rec, function, field_name)
+            elif subparser:
+                if not (field.relational or field.type == "reference"):
+                    self._jsonify_bad_parser_error(field_name)
+                value = [
+                    self._jsonify_record(subparser, r, {}) for r in rec[field_name]
+                ]
+                if field.type in ("many2one", "reference"):
+                    value = value[0] if value else None
+            else:
+                value = self._jsonify_value(rec, field, field_dict.get("resolver"))
+            if json_key.endswith("*"):  # sublist field
+                key = json_key[:-1]
+                if not root.get(key):
+                    root[key] = []
+                root[key].append(value)
+            else:
+                root[json_key] = value
+        return root
 
     def jsonify(self, parser, one=False):
         """Convert the record according to the given parser.
 
-        Example of parser:
+        Example of (simple) parser:
             parser = [
                 'name',
                 'number',
@@ -55,68 +139,16 @@ class Base(models.AbstractModel):
         """
         if one:
             self.ensure_one()
+        if isinstance(parser, list):
+            parser = self.convert_simple_to_full_parser(parser)
+        resolver = parser.get("resolver")
 
-        result = []
+        results = [{} for record in self]
+        for lang in parser["langs"]:
+            translate = lang or parser["language_agnostic"]
+            records = self.with_context(lang=lang) if translate else self
+            for record, json in zip(records, results):
+                self._jsonify_record(parser["langs"][lang], record, json)
 
-        for rec in self:
-            res = {}
-            for field in parser:
-                field_name, json_key, subparser = self.__parse_field(field)
-                if subparser:
-                    res[json_key] = rec._jsonify_value_subparser(field_name, subparser)
-                else:
-                    res[json_key] = rec._jsonify_value(field_name)
-            result.append(res)
-        if one:
-            return result[0] if result else {}
-        return result
-
-    def _jsonify_value(self, field_name):
-        field_type = self._fields[field_name].type
-        value = self[field_name]
-        # TODO: we should get default by field (eg: char field -> "")
-        if value is False and field_type != "boolean":
-            value = None
-        elif field_type == "date":
-            value = fields.Date.to_date(value).isoformat()
-        elif field_type == "datetime":
-            # Ensures value is a datetime
-            value = fields.Datetime.to_datetime(value)
-            # Get the timestamp converted to the client's timezone.
-            # This call also add the tzinfo into the datetime
-            # object
-            value = fields.Datetime.context_timestamp(self, value)
-            value = value.isoformat()
-        elif field_type in ("many2one", "reference"):
-            if not value:
-                value = None
-            else:
-                value = value.display_name
-        elif field_type in ("one2many", "many2many"):
-            value = [v.display_name for v in value]
-        return value
-
-    def _jsonify_value_subparser(self, field_name, subparser):
-        value = None
-        if callable(subparser):
-            # a simple function
-            value = subparser(self, field_name)
-        elif isinstance(subparser, str):
-            # a method on the record itself
-            method = getattr(self, subparser, None)
-            if method:
-                value = method(field_name)
-            else:
-                self._jsonify_bad_parser_error(field_name)
-        else:
-            field = self._fields[field_name]
-            if not (field.relational or field.type == "reference"):
-                self._jsonify_bad_parser_error(field_name)
-            rec_value = self[field_name]
-            value = rec_value.jsonify(subparser) if rec_value else []
-            if field.type in ("many2one", "reference"):
-                value = value[0] if value else None
-        return value
-
-    def _jsonify_bad_parser_error(self, field_name):
-        raise UserError(_("Wrong parser configuration for field: `%s`") % field_name)
+        results = self._resolve(resolver, results, self) if resolver else results
+        return results[0] if one else results

--- a/base_jsonify/models/models.py
+++ b/base_jsonify/models/models.py
@@ -25,7 +25,7 @@ class Base(models.AbstractModel):
             field_split = f.split(":")
             field_dict = {"name": field_split[0]}
             if len(field_split) > 1:
-                field_dict["alias"] = field_split[1]
+                field_dict["target"] = field_split[1]
             if function:
                 field_dict["function"] = function
             return field_dict
@@ -86,7 +86,7 @@ class Base(models.AbstractModel):
         for field in parser:
             field_dict, subparser = rec.__parse_field(field)
             field_name = field_dict["name"]
-            json_key = field_dict.get("alias", field_name)
+            json_key = field_dict.get("target", field_name)
             field = rec._fields[field_name]
             if field_dict.get("function"):
                 function = field_dict["function"]

--- a/base_jsonify/models/models.py
+++ b/base_jsonify/models/models.py
@@ -43,7 +43,7 @@ class Base(models.AbstractModel):
                         result.append((_f(f), _convert_parser(sub)))
             return result
 
-        return {"language_agnostic": False, "langs": {False: _convert_parser(parser)}}
+        return {"language_agnostic": False, "fields": _convert_parser(parser)}
 
     @api.model
     def _jsonify_bad_parser_error(self, field_name):
@@ -144,11 +144,12 @@ class Base(models.AbstractModel):
         resolver = parser.get("resolver")
 
         results = [{} for record in self]
-        for lang in parser["langs"]:
-            translate = lang or parser["language_agnostic"]
+        parsers = {False: parser["fields"]} if "fields" in parser else parser["langs"]
+        for lang in parsers:
+            translate = lang or parser.get("language_agnostic")
             records = self.with_context(lang=lang) if translate else self
             for record, json in zip(records, results):
-                self._jsonify_record(parser["langs"][lang], record, json)
+                self._jsonify_record(parsers[lang], record, json)
 
         results = self._resolve(resolver, results, self) if resolver else results
         return results[0] if one else results

--- a/base_jsonify/models/utils.py
+++ b/base_jsonify/models/utils.py
@@ -1,0 +1,34 @@
+def convert_simple_to_full_parser(parser):
+    """Convert a simple API style parser to a full parser"""
+    assert isinstance(parser, list)
+    return {"fields": _convert_parser(parser)}
+
+
+def _f(f, function=None):
+    """Return a dict from the string encoding a field to export.
+       The : is used as a separator to specify a target, if any.
+    """
+    field_split = f.split(":")
+    field_dict = {"name": field_split[0]}
+    if len(field_split) > 1:
+        field_dict["target"] = field_split[1]
+    if function:
+        field_dict["function"] = function
+    return field_dict
+
+
+def _convert_parser(parser):
+    """Recursively process each list to replace encoding fields as string
+       by dicts specifying each attribute by its relevant key.
+    """
+    result = []
+    for line in parser:
+        if isinstance(line, str):
+            result.append(_f(line))
+        else:
+            f, sub = line
+            if callable(sub) or isinstance(sub, str):
+                result.append(_f(f, sub))
+            else:
+                result.append((_f(f), _convert_parser(sub)))
+    return result

--- a/base_jsonify/readme/CONTRIBUTORS.rst
+++ b/base_jsonify/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * BEAU Sébastien <sebastien.beau@akretion.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Nans Lefebvre <nans.lefebvre@acsone.eu>

--- a/base_jsonify/readme/DESCRIPTION.rst
+++ b/base_jsonify/readme/DESCRIPTION.rst
@@ -63,11 +63,12 @@ To use these features, a full parser follows the following structure:
 .. code-block:: python
 
     parser = {
-        "resolver": ir.exports.resolver(3),
+        "resolver": 3,
+        "language_agnostic": True,
         "langs": {
             False: [
                 {'name': 'description'},
-                {'name': 'number', 'resolver': ir.exports.resolver(5)},
+                {'name': 'number', 'resolver': 5},
                 ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}])
             ],
             'fr_FR': [
@@ -75,6 +76,23 @@ To use these features, a full parser follows the following structure:
                 ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'description', 'alias': 'description_fr'}])
             ],
         }
+    }
+
+
+Note that a resolver can be passed either as a recordset or as an id, so as to be fully serializable.
+A slightly simpler version in case the translation of fields is not needed,
+but other features like custom resolvers are:
+
+.. code-block:: python
+
+    parser = {
+        "resolver": 3,
+        "language_agnostic": True,
+        "fields": [
+                {'name': 'description'},
+                {'name': 'number', 'resolver': 5},
+                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}]),
+        ],
     }
 
 

--- a/base_jsonify/readme/DESCRIPTION.rst
+++ b/base_jsonify/readme/DESCRIPTION.rst
@@ -69,13 +69,28 @@ To use these features, a full parser follows the following structure:
             False: [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
-                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}])
+                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'display_name'}])
             ],
             'fr_FR': [
                 {'name': 'description', 'alias': 'descriptions_fr'},
-                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'description', 'alias': 'description_fr'}])
+                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'description', 'alias': 'description_fr'}])
             ],
         }
+    }
+
+
+One would get the a result having this structure (note that the translated fields are merged in the same dictionary):
+
+.. code-block:: python
+
+    exported_json == {
+        "description": "English description",
+        "description_fr": "French description, voilà",
+        "number": 42,
+        "partner": {
+            "display_name": "partner name",
+            "description_fr": "French description of that partner",
+        },
     }
 
 
@@ -87,7 +102,6 @@ but other features like custom resolvers are:
 
     parser = {
         "resolver": 3,
-        "language_agnostic": True,
         "fields": [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
@@ -95,6 +109,15 @@ but other features like custom resolvers are:
         ],
     }
 
+
+By passing the `fields` key instead of `langs`, we have essentially the same behaviour as simple parsers,
+with the added benefit of being able to use resolvers.
+
+Standard use-cases of resolvers are:
+- give field-specific defaults (e.g. `""` instead of `None`)
+- cast a field type (e.g. `int()`)
+- alias a particular field for a specific export
+- ...
 
 A simple parser is simply translated into a full parser at export.
 
@@ -108,18 +131,16 @@ Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.
 
 It is possible for an alias to end with a '*':
-in that case the result it put into a list.
+in that case the result is put into a list.
 
 .. code-block:: python
 
   parser = {
-      "langs": {
-          False: [
-              {'name': 'name'},
-              {'name': 'field_1', 'alias': 'customTags*'},
-              {'name': 'field_2', 'alias': 'customTags*'},
-          ]
-      }
+      fields: [
+          {'name': 'name'},
+          {'name': 'field_1', 'alias': 'customTags*'},
+          {'name': 'field_2', 'alias': 'customTags*'},
+      ]
   }
 
 

--- a/base_jsonify/readme/DESCRIPTION.rst
+++ b/base_jsonify/readme/DESCRIPTION.rst
@@ -2,7 +2,7 @@ This module adds a 'jsonify' method to every model of the ORM.
 It works on the current recordset and requires a single argument 'parser'
 that specify the field to extract.
 
-Example of parser:
+Example of a simple parser:
 
 
 .. code-block:: python
@@ -15,8 +15,8 @@ Example of parser:
         ('line_id', ['id', ('product_id', ['name']), 'price_unit'])
     ]
 
-In order to be consitent with the odoo api the jsonify method always
-return a list of object even if there is only one element in input
+In order to be consistent with the odoo api the jsonify method always
+return a list of object even if there is only one element in the recordset.
 
 By default the key into the json is the name of the field extracted
 from the model. If you need to specify an alternate name to use as key, you
@@ -51,3 +51,74 @@ you can pass a callable or the name of a method on the model:
 
 Also the module provide a method "get_json_parser" on the ir.exports object
 that generate a parser from an ir.exports configuration.
+
+Further features are available for advanced uses.
+It defines a simple "resolver" model that has a "python_code" field and an eval
+function so that arbitrary functions can be configured to transform fields,
+or process the resulting dictionary.
+It is also to specify a lang to extract the translation of any given field.
+
+To use these features, a full parser follows the following structure:
+
+.. code-block:: python
+
+    parser = {
+        "resolver": ir.exports.resolver(3),
+        "langs": {
+            False: [
+                {'name': 'description'},
+                {'name': 'number', 'resolver': ir.exports.resolver(5)},
+                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}])
+            ],
+            'fr_FR': [
+                {'name': 'description', 'alias': 'descriptions_fr'},
+                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'description', 'alias': 'description_fr'}])
+            ],
+        }
+    }
+
+
+A simple parser is simply translated into a full parser at export.
+
+If the global resolver is given, then the json_dict goes through:
+
+.. code-block:: python
+
+    resolver.eval(dict, record)
+
+Which allows to add external data from the context or transform the dictionary
+if necessary. Similarly if given for a field the resolver evaluates the result.
+
+It is possible for an alias to end with a '*':
+in that case the result it put into a list.
+
+.. code-block:: python
+
+  parser = {
+      "langs": {
+          False: [
+              {'name': 'name'},
+              {'name': 'field_1', 'alias': 'customTags*'},
+              {'name': 'field_2', 'alias': 'customTags*'},
+          ]
+      }
+  }
+
+
+Would result in the following json structure:
+
+.. code-block:: python
+
+    {
+        'name': 'record_name',
+        'customTags': ['field_1_value', 'field_2_value'],
+    }
+
+The intended use-case is to be compatible with APIs that require all translated
+parameters to be exported simultaneously, and ask for custom properties to be
+put in a sub-dictionary.
+Since it is often the case that some of these requirements are optional,
+new requirements could be met without needing to add field or change any code.
+
+Note that the export values with the simple parser depends on the record's lang;
+this is in contrast with full parsers which are designed to be language agnostic.

--- a/base_jsonify/readme/DESCRIPTION.rst
+++ b/base_jsonify/readme/DESCRIPTION.rst
@@ -69,11 +69,11 @@ To use these features, a full parser follows the following structure:
             False: [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
-                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'display_name'}])
+                ({'name': 'partner_id', 'target': 'partner'}, [{'name': 'display_name'}])
             ],
             'fr_FR': [
-                {'name': 'description', 'alias': 'descriptions_fr'},
-                ({'name': 'partner_id', 'alias': 'partner'}, [{'name': 'description', 'alias': 'description_fr'}])
+                {'name': 'description', 'target': 'descriptions_fr'},
+                ({'name': 'partner_id', 'target': 'partner'}, [{'name': 'description', 'target': 'description_fr'}])
             ],
         }
     }
@@ -105,7 +105,7 @@ but other features like custom resolvers are:
         "fields": [
                 {'name': 'description'},
                 {'name': 'number', 'resolver': 5},
-                ({'name': 'partner_id', 'alias': 'partners'}, [{'name': 'display_name'}]),
+                ({'name': 'partner_id', 'target': 'partners'}, [{'name': 'display_name'}]),
         ],
     }
 
@@ -130,7 +130,7 @@ If the global resolver is given, then the json_dict goes through:
 Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.
 
-It is possible for an alias to end with a '*':
+It is possible for a target to end with a '*':
 in that case the result is put into a list.
 
 .. code-block:: python
@@ -138,8 +138,8 @@ in that case the result is put into a list.
   parser = {
       fields: [
           {'name': 'name'},
-          {'name': 'field_1', 'alias': 'customTags*'},
-          {'name': 'field_2', 'alias': 'customTags*'},
+          {'name': 'field_1', 'target': 'customTags*'},
+          {'name': 'field_2', 'target': 'customTags*'},
       ]
   }
 

--- a/base_jsonify/readme/DESCRIPTION.rst
+++ b/base_jsonify/readme/DESCRIPTION.rst
@@ -53,7 +53,7 @@ Also the module provide a method "get_json_parser" on the ir.exports object
 that generate a parser from an ir.exports configuration.
 
 Further features are available for advanced uses.
-It defines a simple "resolver" model that has a "python_code" field and an eval
+It defines a simple "resolver" model that has a "python_code" field and a resolve
 function so that arbitrary functions can be configured to transform fields,
 or process the resulting dictionary.
 It is also to specify a lang to extract the translation of any given field.
@@ -125,12 +125,12 @@ If the global resolver is given, then the json_dict goes through:
 
 .. code-block:: python
 
-    resolver.eval(dict, record)
+    resolver.resolve(dict, record)
 
 Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.
 
-It is possible for a target to end with a '*':
+It is possible for a target to have a marshaller by ending the target with '=list':
 in that case the result is put into a list.
 
 .. code-block:: python
@@ -138,8 +138,8 @@ in that case the result is put into a list.
   parser = {
       fields: [
           {'name': 'name'},
-          {'name': 'field_1', 'target': 'customTags*'},
-          {'name': 'field_2', 'target': 'customTags*'},
+          {'name': 'field_1', 'target': 'customTags=list'},
+          {'name': 'field_2', 'target': 'customTags=list'},
       ]
   }
 

--- a/base_jsonify/security/ir.model.access.csv
+++ b/base_jsonify/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_ir_exports_resolver,ir.exports.resolver,model_ir_exports_resolver,base.group_system,1,1,1,1

--- a/base_jsonify/static/description/index.html
+++ b/base_jsonify/static/description/index.html
@@ -371,7 +371,7 @@ ul.auto-toc {
 <p>This module adds a ‘jsonify’ method to every model of the ORM.
 It works on the current recordset and requires a single argument ‘parser’
 that specify the field to extract.</p>
-<p>Example of parser:</p>
+<p>Example of a simple parser:</p>
 <pre class="code python literal-block">
 <span class="n">parser</span> <span class="o">=</span> <span class="p">[</span>
     <span class="s1">'name'</span><span class="p">,</span>
@@ -381,8 +381,8 @@ that specify the field to extract.</p>
     <span class="p">(</span><span class="s1">'line_id'</span><span class="p">,</span> <span class="p">[</span><span class="s1">'id'</span><span class="p">,</span> <span class="p">(</span><span class="s1">'product_id'</span><span class="p">,</span> <span class="p">[</span><span class="s1">'name'</span><span class="p">]),</span> <span class="s1">'price_unit'</span><span class="p">])</span>
 <span class="p">]</span>
 </pre>
-<p>In order to be consitent with the odoo api the jsonify method always
-return a list of object even if there is only one element in input</p>
+<p>In order to be consistent with the odoo api the jsonify method always
+return a list of object even if there is only one element in the recordset.</p>
 <p>By default the key into the json is the name of the field extracted
 from the model. If you need to specify an alternate name to use as key, you
 can define your mapping as follow into the parser definition:</p>
@@ -410,6 +410,62 @@ you can pass a callable or the name of a method on the model:</p>
 </pre>
 <p>Also the module provide a method “get_json_parser” on the ir.exports object
 that generate a parser from an ir.exports configuration.</p>
+<p>Further features are available for advanced uses.
+It defines a simple “resolver” model that has a “python_code” field and an eval
+function so that arbitrary functions can be configured to transform fields,
+or process the resulting dictionary.
+It is also to specify a lang to extract the translation of any given field.</p>
+<p>To use these features, a full parser follows the following structure:</p>
+<pre class="code python literal-block">
+<span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="s2">&quot;resolver&quot;</span><span class="p">:</span> <span class="n">ir</span><span class="o">.</span><span class="n">exports</span><span class="o">.</span><span class="n">resolver</span><span class="p">(</span><span class="mi">3</span><span class="p">),</span>
+    <span class="s2">&quot;langs&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="kc">False</span><span class="p">:</span> <span class="p">[</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="n">ir</span><span class="o">.</span><span class="n">exports</span><span class="o">.</span><span class="n">resolver</span><span class="p">(</span><span class="mi">5</span><span class="p">)},</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}])</span>
+        <span class="p">],</span>
+        <span class="s1">'fr_FR'</span><span class="p">:</span> <span class="p">[</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'descriptions_fr'</span><span class="p">},</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'description_fr'</span><span class="p">}])</span>
+        <span class="p">],</span>
+    <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+<p>A simple parser is simply translated into a full parser at export.</p>
+<p>If the global resolver is given, then the json_dict goes through:</p>
+<pre class="code python literal-block">
+<span class="n">resolver</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="nb">dict</span><span class="p">,</span> <span class="n">record</span><span class="p">)</span>
+</pre>
+<p>Which allows to add external data from the context or transform the dictionary
+if necessary. Similarly if given for a field the resolver evaluates the result.</p>
+<p>It is possible for an alias to end with a ‘*’:
+in that case the result it put into a list.</p>
+<pre class="code python literal-block">
+<span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="s2">&quot;langs&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="kc">False</span><span class="p">:</span> <span class="p">[</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'name'</span><span class="p">},</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+        <span class="p">]</span>
+    <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+<p>Would result in the following json structure:</p>
+<pre class="code python literal-block">
+<span class="p">{</span>
+    <span class="s1">'name'</span><span class="p">:</span> <span class="s1">'record_name'</span><span class="p">,</span>
+    <span class="s1">'customTags'</span><span class="p">:</span> <span class="p">[</span><span class="s1">'field_1_value'</span><span class="p">,</span> <span class="s1">'field_2_value'</span><span class="p">],</span>
+<span class="p">}</span>
+</pre>
+<p>The intended use-case is to be compatible with APIs that require all translated
+parameters to be exported simultaneously, and ask for custom properties to be
+put in a sub-dictionary.
+Since it is often the case that some of these requirements are optional,
+new requirements could be met without needing to add field or change any code.</p>
+<p>Note that the export values with the simple parser depends on the record’s lang;
+this is in contrast with full parsers which are designed to be language agnostic.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -444,6 +500,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>BEAU Sébastien &lt;<a class="reference external" href="mailto:sebastien.beau&#64;akretion.com">sebastien.beau&#64;akretion.com</a>&gt;</li>
 <li>Raphaël Reverdy &lt;<a class="reference external" href="mailto:raphael.reverdy&#64;akretion.com">raphael.reverdy&#64;akretion.com</a>&gt;</li>
 <li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
+<li>Nans Lefebvre &lt;<a class="reference external" href="mailto:nans.lefebvre&#64;acsone.eu">nans.lefebvre&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/base_jsonify/static/description/index.html
+++ b/base_jsonify/static/description/index.html
@@ -424,13 +424,25 @@ It is also to specify a lang to extract the translation of any given field.</p>
         <span class="kc">False</span><span class="p">:</span> <span class="p">[</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="mi">5</span><span class="p">},</span>
-            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}])</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partner'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}])</span>
         <span class="p">],</span>
         <span class="s1">'fr_FR'</span><span class="p">:</span> <span class="p">[</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'descriptions_fr'</span><span class="p">},</span>
-            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'description_fr'</span><span class="p">}])</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partner'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'description_fr'</span><span class="p">}])</span>
         <span class="p">],</span>
     <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+<p>One would get the a result having this structure (note that the translated fields are merged in the same dictionary):</p>
+<pre class="code python literal-block">
+<span class="n">exported_json</span> <span class="o">==</span> <span class="p">{</span>
+    <span class="s2">&quot;description&quot;</span><span class="p">:</span> <span class="s2">&quot;English description&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;description_fr&quot;</span><span class="p">:</span> <span class="s2">&quot;French description, voilà&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;number&quot;</span><span class="p">:</span> <span class="mi">42</span><span class="p">,</span>
+    <span class="s2">&quot;partner&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;display_name&quot;</span><span class="p">:</span> <span class="s2">&quot;partner name&quot;</span><span class="p">,</span>
+        <span class="s2">&quot;description_fr&quot;</span><span class="p">:</span> <span class="s2">&quot;French description of that partner&quot;</span><span class="p">,</span>
+    <span class="p">},</span>
 <span class="p">}</span>
 </pre>
 <p>Note that a resolver can be passed either as a recordset or as an id, so as to be fully serializable.
@@ -439,7 +451,6 @@ but other features like custom resolvers are:</p>
 <pre class="code python literal-block">
 <span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
     <span class="s2">&quot;resolver&quot;</span><span class="p">:</span> <span class="mi">3</span><span class="p">,</span>
-    <span class="s2">&quot;language_agnostic&quot;</span><span class="p">:</span> <span class="kc">True</span><span class="p">,</span>
     <span class="s2">&quot;fields&quot;</span><span class="p">:</span> <span class="p">[</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="mi">5</span><span class="p">},</span>
@@ -447,6 +458,13 @@ but other features like custom resolvers are:</p>
     <span class="p">],</span>
 <span class="p">}</span>
 </pre>
+<p>By passing the <cite>fields</cite> key instead of <cite>langs</cite>, we have essentially the same behaviour as simple parsers,
+with the added benefit of being able to use resolvers.</p>
+<p>Standard use-cases of resolvers are:
+- give field-specific defaults (e.g. <cite>“”</cite> instead of <cite>None</cite>)
+- cast a field type (e.g. <cite>int()</cite>)
+- alias a particular field for a specific export
+- …</p>
 <p>A simple parser is simply translated into a full parser at export.</p>
 <p>If the global resolver is given, then the json_dict goes through:</p>
 <pre class="code python literal-block">
@@ -455,16 +473,14 @@ but other features like custom resolvers are:</p>
 <p>Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.</p>
 <p>It is possible for an alias to end with a ‘*’:
-in that case the result it put into a list.</p>
+in that case the result is put into a list.</p>
 <pre class="code python literal-block">
 <span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
-    <span class="s2">&quot;langs&quot;</span><span class="p">:</span> <span class="p">{</span>
-        <span class="kc">False</span><span class="p">:</span> <span class="p">[</span>
-            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'name'</span><span class="p">},</span>
-            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
-            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
-        <span class="p">]</span>
-    <span class="p">}</span>
+    <span class="n">fields</span><span class="p">:</span> <span class="p">[</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'name'</span><span class="p">},</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+    <span class="p">]</span>
 <span class="p">}</span>
 </pre>
 <p>Would result in the following json structure:</p>

--- a/base_jsonify/static/description/index.html
+++ b/base_jsonify/static/description/index.html
@@ -424,11 +424,11 @@ It is also to specify a lang to extract the translation of any given field.</p>
         <span class="kc">False</span><span class="p">:</span> <span class="p">[</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="mi">5</span><span class="p">},</span>
-            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partner'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}])</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'partner'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}])</span>
         <span class="p">],</span>
         <span class="s1">'fr_FR'</span><span class="p">:</span> <span class="p">[</span>
-            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'descriptions_fr'</span><span class="p">},</span>
-            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partner'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'description_fr'</span><span class="p">}])</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'descriptions_fr'</span><span class="p">},</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'partner'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'description_fr'</span><span class="p">}])</span>
         <span class="p">],</span>
     <span class="p">}</span>
 <span class="p">}</span>
@@ -454,7 +454,7 @@ but other features like custom resolvers are:</p>
     <span class="s2">&quot;fields&quot;</span><span class="p">:</span> <span class="p">[</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="mi">5</span><span class="p">},</span>
-            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}]),</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}]),</span>
     <span class="p">],</span>
 <span class="p">}</span>
 </pre>
@@ -472,14 +472,14 @@ with the added benefit of being able to use resolvers.</p>
 </pre>
 <p>Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.</p>
-<p>It is possible for an alias to end with a ‘*’:
+<p>It is possible for a target to end with a ‘*’:
 in that case the result is put into a list.</p>
 <pre class="code python literal-block">
 <span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
     <span class="n">fields</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'name'</span><span class="p">},</span>
-        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
-        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
     <span class="p">]</span>
 <span class="p">}</span>
 </pre>

--- a/base_jsonify/static/description/index.html
+++ b/base_jsonify/static/description/index.html
@@ -411,7 +411,7 @@ you can pass a callable or the name of a method on the model:</p>
 <p>Also the module provide a method “get_json_parser” on the ir.exports object
 that generate a parser from an ir.exports configuration.</p>
 <p>Further features are available for advanced uses.
-It defines a simple “resolver” model that has a “python_code” field and an eval
+It defines a simple “resolver” model that has a “python_code” field and a resolve
 function so that arbitrary functions can be configured to transform fields,
 or process the resulting dictionary.
 It is also to specify a lang to extract the translation of any given field.</p>
@@ -468,18 +468,18 @@ with the added benefit of being able to use resolvers.</p>
 <p>A simple parser is simply translated into a full parser at export.</p>
 <p>If the global resolver is given, then the json_dict goes through:</p>
 <pre class="code python literal-block">
-<span class="n">resolver</span><span class="o">.</span><span class="n">eval</span><span class="p">(</span><span class="nb">dict</span><span class="p">,</span> <span class="n">record</span><span class="p">)</span>
+<span class="n">resolver</span><span class="o">.</span><span class="n">resolve</span><span class="p">(</span><span class="nb">dict</span><span class="p">,</span> <span class="n">record</span><span class="p">)</span>
 </pre>
 <p>Which allows to add external data from the context or transform the dictionary
 if necessary. Similarly if given for a field the resolver evaluates the result.</p>
-<p>It is possible for a target to end with a ‘*’:
+<p>It is possible for a target to have a marshaller by ending the target with ‘=list’:
 in that case the result is put into a list.</p>
 <pre class="code python literal-block">
 <span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
     <span class="n">fields</span><span class="p">:</span> <span class="p">[</span>
         <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'name'</span><span class="p">},</span>
-        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
-        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'customTags*'</span><span class="p">},</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_1'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'customTags=list'</span><span class="p">},</span>
+        <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'field_2'</span><span class="p">,</span> <span class="s1">'target'</span><span class="p">:</span> <span class="s1">'customTags=list'</span><span class="p">},</span>
     <span class="p">]</span>
 <span class="p">}</span>
 </pre>

--- a/base_jsonify/static/description/index.html
+++ b/base_jsonify/static/description/index.html
@@ -418,11 +418,12 @@ It is also to specify a lang to extract the translation of any given field.</p>
 <p>To use these features, a full parser follows the following structure:</p>
 <pre class="code python literal-block">
 <span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
-    <span class="s2">&quot;resolver&quot;</span><span class="p">:</span> <span class="n">ir</span><span class="o">.</span><span class="n">exports</span><span class="o">.</span><span class="n">resolver</span><span class="p">(</span><span class="mi">3</span><span class="p">),</span>
+    <span class="s2">&quot;resolver&quot;</span><span class="p">:</span> <span class="mi">3</span><span class="p">,</span>
+    <span class="s2">&quot;language_agnostic&quot;</span><span class="p">:</span> <span class="kc">True</span><span class="p">,</span>
     <span class="s2">&quot;langs&quot;</span><span class="p">:</span> <span class="p">{</span>
         <span class="kc">False</span><span class="p">:</span> <span class="p">[</span>
             <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
-            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="n">ir</span><span class="o">.</span><span class="n">exports</span><span class="o">.</span><span class="n">resolver</span><span class="p">(</span><span class="mi">5</span><span class="p">)},</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="mi">5</span><span class="p">},</span>
             <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}])</span>
         <span class="p">],</span>
         <span class="s1">'fr_FR'</span><span class="p">:</span> <span class="p">[</span>
@@ -430,6 +431,20 @@ It is also to specify a lang to extract the translation of any given field.</p>
             <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'description_fr'</span><span class="p">}])</span>
         <span class="p">],</span>
     <span class="p">}</span>
+<span class="p">}</span>
+</pre>
+<p>Note that a resolver can be passed either as a recordset or as an id, so as to be fully serializable.
+A slightly simpler version in case the translation of fields is not needed,
+but other features like custom resolvers are:</p>
+<pre class="code python literal-block">
+<span class="n">parser</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="s2">&quot;resolver&quot;</span><span class="p">:</span> <span class="mi">3</span><span class="p">,</span>
+    <span class="s2">&quot;language_agnostic&quot;</span><span class="p">:</span> <span class="kc">True</span><span class="p">,</span>
+    <span class="s2">&quot;fields&quot;</span><span class="p">:</span> <span class="p">[</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'description'</span><span class="p">},</span>
+            <span class="p">{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'number'</span><span class="p">,</span> <span class="s1">'resolver'</span><span class="p">:</span> <span class="mi">5</span><span class="p">},</span>
+            <span class="p">({</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'partner_id'</span><span class="p">,</span> <span class="s1">'alias'</span><span class="p">:</span> <span class="s1">'partners'</span><span class="p">},</span> <span class="p">[{</span><span class="s1">'name'</span><span class="p">:</span> <span class="s1">'display_name'</span><span class="p">}]),</span>
+    <span class="p">],</span>
 <span class="p">}</span>
 </pre>
 <p>A simple parser is simply translated into a full parser at export.</p>

--- a/base_jsonify/tests/test_get_parser.py
+++ b/base_jsonify/tests/test_get_parser.py
@@ -5,6 +5,8 @@ from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests.common import SavepointCase
 
+from ..models.utils import convert_simple_to_full_parser
+
 
 def jsonify_custom(self, field_name):
     return "yeah!"
@@ -113,7 +115,7 @@ class TestParser(SavepointCase):
 
         exporter = self.env.ref("base_jsonify.ir_exp_partner")
         parser = exporter.get_json_parser()
-        expected_full_parser = exporter.convert_simple_to_full_parser(expected_parser)
+        expected_full_parser = convert_simple_to_full_parser(expected_parser)
         self.assertEqual(parser, expected_full_parser)
 
         # modify an ir.exports_line to put a target for a field
@@ -122,7 +124,7 @@ class TestParser(SavepointCase):
         )
         expected_parser[4] = ("category_id:category", ["name"])
         parser = exporter.get_json_parser()
-        expected_full_parser = exporter.convert_simple_to_full_parser(expected_parser)
+        expected_full_parser = convert_simple_to_full_parser(expected_parser)
         self.assertEqual(parser, expected_full_parser)
 
     def test_json_export(self):
@@ -251,8 +253,8 @@ class TestParser(SavepointCase):
         )
         resolver = self.env["ir.exports.resolver"].create({"python_code": code})
         lang_parser = [
-            {"target": "customTags*", "name": "name", "resolver": resolver.id},
-            {"target": "customTags*", "name": "id", "resolver": resolver.id},
+            {"target": "customTags=list", "name": "name", "resolver": resolver},
+            {"target": "customTags=list", "name": "id", "resolver": resolver},
         ]
         parser = {"language_agnostic": True, "langs": {False: lang_parser}}
         expected_json = {
@@ -275,7 +277,7 @@ class TestParser(SavepointCase):
         export = self.env["ir.exports"].create(
             {
                 "export_fields": [
-                    (0, 0, {"name": "name", "function": "jsonify_custom"}),
+                    (0, 0, {"name": "name", "instance_method_name": "jsonify_custom"}),
                 ],
             }
         )

--- a/base_jsonify/tests/test_get_parser.py
+++ b/base_jsonify/tests/test_get_parser.py
@@ -41,7 +41,7 @@ class TestParser(SavepointCase):
         cls.lang.active = True
         cls.env["ir.translation"]._load_module_terms(["base"], [cls.lang.code])
         category = cls.env["res.partner.category"].create({"name": "name"})
-        cls.translated_alias = "name_{}".format(cls.lang.code)
+        cls.translated_target = "name_{}".format(cls.lang.code)
         cls.env["ir.translation"].create(
             {
                 "type": "model",
@@ -49,7 +49,7 @@ class TestParser(SavepointCase):
                 "module": "base",
                 "lang": cls.lang.code,
                 "res_id": category.id,
-                "value": cls.translated_alias,
+                "value": cls.translated_target,
                 "state": "translated",
             }
         )
@@ -70,7 +70,7 @@ class TestParser(SavepointCase):
                         0,
                         {
                             "name": "name",
-                            "alias": "name:{}".format(cls.translated_alias),
+                            "target": "name:{}".format(cls.translated_target),
                             "lang_id": cls.lang.id,
                         },
                     ),
@@ -79,7 +79,7 @@ class TestParser(SavepointCase):
                         0,
                         {
                             "name": "name",
-                            "alias": "name:name_resolved",
+                            "target": "name:name_resolved",
                             "resolver_id": cls.resolver.id,
                         },
                     ),
@@ -116,9 +116,9 @@ class TestParser(SavepointCase):
         expected_full_parser = exporter.convert_simple_to_full_parser(expected_parser)
         self.assertEqual(parser, expected_full_parser)
 
-        # modify an ir.exports_line to put an alias for a field
+        # modify an ir.exports_line to put a target for a field
         self.env.ref("base_jsonify.category_id_name").write(
-            {"alias": "category_id:category/name"}
+            {"target": "category_id:category/name"}
         )
         expected_parser[4] = ("category_id:category", ["name"])
         parser = exporter.get_json_parser()
@@ -226,7 +226,7 @@ class TestParser(SavepointCase):
         self.assertEqual(
             json, json_fr
         )  # starting from different languages should not change anything
-        self.assertEqual(json[self.translated_alias], self.translated_alias)
+        self.assertEqual(json[self.translated_target], self.translated_target)
         self.assertEqual(json["name_resolved"], "name_pidgin")  # field resolver
         self.assertEqual(json["X"], "X")  # added by global resolver
 
@@ -238,9 +238,9 @@ class TestParser(SavepointCase):
         json_fr = self.category_lang.jsonify(parser)[0]
 
         self.assertEqual(json["name"], "name")
-        self.assertEqual(json_fr["name"], self.translated_alias)
+        self.assertEqual(json_fr["name"], self.translated_target)
 
-    def test_simple_star_alias_and_field_resolver(self):
+    def test_simple_star_target_and_field_resolver(self):
         """The simple parser result should depend on the context language.
         """
         code = (
@@ -251,8 +251,8 @@ class TestParser(SavepointCase):
         )
         resolver = self.env["ir.exports.resolver"].create({"python_code": code})
         lang_parser = [
-            {"alias": "customTags*", "name": "name", "resolver": resolver.id},
-            {"alias": "customTags*", "name": "id", "resolver": resolver.id},
+            {"target": "customTags*", "name": "name", "resolver": resolver.id},
+            {"target": "customTags*", "name": "id", "resolver": resolver.id},
         ]
         parser = {"language_agnostic": True, "langs": {False: lang_parser}}
         expected_json = {

--- a/base_jsonify/tests/test_get_parser.py
+++ b/base_jsonify/tests/test_get_parser.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
+from odoo.exceptions import UserError
 from odoo.tests.common import SavepointCase
 
 
@@ -281,3 +282,16 @@ class TestParser(SavepointCase):
 
         json = self.category.jsonify(export.get_json_parser())[0]
         self.assertEqual(json, {"name": "yeah!"})
+
+    def test_bad_parsers(self):
+        bad_field_name = ["Name"]
+        with self.assertRaises(KeyError):
+            self.category.jsonify(bad_field_name, one=True)
+
+        bad_function_name = {"fields": [{"name": "name", "function": "notafunction"}]}
+        with self.assertRaises(UserError):
+            self.category.jsonify(bad_function_name, one=True)
+
+        bad_subparser = {"fields": [({"name": "name"}, [{"name": "subparser_name"}])]}
+        with self.assertRaises(UserError):
+            self.category.jsonify(bad_subparser, one=True)

--- a/base_jsonify/tests/test_ir_exports_line.py
+++ b/base_jsonify/tests/test_ir_exports_line.py
@@ -49,3 +49,19 @@ class TestIrExportsLine(TransactionCase):
             }
         )
         self.assertTrue(line)
+
+    def test_resolver_function_constrains(self):
+        resolver = self.env["ir.exports.resolver"].create(
+            {"python_code": "result = value", "type": "field"}
+        )
+        ir_export_lines_model = self.env["ir.exports.line"]
+        with self.assertRaises(ValidationError):
+            # the callable should be an existing model function, but it's not checked
+            ir_export_lines_model.create(
+                {
+                    "export_id": self.ir_export.id,
+                    "name": "name",
+                    "resolver_id": resolver.id,
+                    "function": "function_name",
+                }
+            )

--- a/base_jsonify/tests/test_ir_exports_line.py
+++ b/base_jsonify/tests/test_ir_exports_line.py
@@ -62,6 +62,6 @@ class TestIrExportsLine(TransactionCase):
                     "export_id": self.ir_export.id,
                     "name": "name",
                     "resolver_id": resolver.id,
-                    "function": "function_name",
+                    "instance_method_name": "function_name",
                 }
             )

--- a/base_jsonify/tests/test_ir_exports_line.py
+++ b/base_jsonify/tests/test_ir_exports_line.py
@@ -10,42 +10,42 @@ class TestIrExportsLine(TransactionCase):
         super(TestIrExportsLine, self).setUp()
         self.ir_export = self.env.ref("base_jsonify.ir_exp_partner")
 
-    def test_alias_contrains(self):
+    def test_target_contrains(self):
         ir_export_lines_model = self.env["ir.exports.line"]
         with self.assertRaises(ValidationError):
-            # The field into the name must be also into the alias
+            # The field into the name must be also into the target
             ir_export_lines_model.create(
                 {
                     "export_id": self.ir_export.id,
                     "name": "name",
-                    "alias": "toto:my_alias",
+                    "target": "toto:my_target",
                 }
             )
         with self.assertRaises(ValidationError):
-            # The hierarchy into the alias must be the same as the one into
+            # The hierarchy into the target must be the same as the one into
             # the name
             ir_export_lines_model.create(
                 {
                     "export_id": self.ir_export.id,
                     "name": "child_ids/child_ids/name",
-                    "alias": "child_ids:children/name",
+                    "target": "child_ids:children/name",
                 }
             )
         with self.assertRaises(ValidationError):
-            # The hierarchy into the alias must be the same as the one into
+            # The hierarchy into the target must be the same as the one into
             # the name and must contains the same fields as into the name
             ir_export_lines_model.create(
                 {
                     "export_id": self.ir_export.id,
                     "name": "child_ids/child_ids/name",
-                    "alias": "child_ids:children/category_id:category/name",
+                    "target": "child_ids:children/category_id:category/name",
                 }
             )
         line = ir_export_lines_model.create(
             {
                 "export_id": self.ir_export.id,
                 "name": "child_ids/child_ids/name",
-                "alias": "child_ids:children/child_ids:children/name",
+                "target": "child_ids:children/child_ids:children/name",
             }
         )
         self.assertTrue(line)

--- a/base_jsonify/views/ir_exports_resolver_view.xml
+++ b/base_jsonify/views/ir_exports_resolver_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_ir_exports_resolver">
+        <field name="model">ir.exports.resolver</field>
+        <field name="priority">50</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="name" />
+                    <field name="type" />
+                    <field name="python_code" />
+                </group>
+            </form>
+        </field>
+    </record>
+    <record id="act_ui_exports_resolver_view" model="ir.actions.act_window">
+        <field name="name">Custom Export Resolvers</field>
+        <field name="res_model">ir.exports.resolver</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem
+        id="ui_exports_resolvers"
+        action="act_ui_exports_resolver_view"
+        parent="base.next_id_2"
+    />
+</odoo>

--- a/base_jsonify/views/ir_exports_view.xml
+++ b/base_jsonify/views/ir_exports_view.xml
@@ -21,7 +21,7 @@
                                 <field name="target" />
                                 <field name="lang_id" />
                                 <field name="resolver_id" />
-                                <field name="function" />
+                                <field name="instance_method_name" />
                             </tree>
                         </field>
                     </group>

--- a/base_jsonify/views/ir_exports_view.xml
+++ b/base_jsonify/views/ir_exports_view.xml
@@ -10,6 +10,8 @@
                         <group colspan="4" col="4" name="se-main">
                             <field name="name" />
                             <field name="resource" />
+                            <field name="language_agnostic" />
+                            <field name="global_resolver_id" />
                         </group>
                     </group>
                     <group name="index" string="Index">
@@ -17,6 +19,9 @@
                             <tree editable="bottom">
                                 <field name="name" />
                                 <field name="alias" />
+                                <field name="lang_id" />
+                                <field name="resolver_id" />
+                                <field name="function" />
                             </tree>
                         </field>
                     </group>

--- a/base_jsonify/views/ir_exports_view.xml
+++ b/base_jsonify/views/ir_exports_view.xml
@@ -18,7 +18,7 @@
                         <field name="export_fields" nolabel="1">
                             <tree editable="bottom">
                                 <field name="name" />
-                                <field name="alias" />
+                                <field name="target" />
                                 <field name="lang_id" />
                                 <field name="resolver_id" />
                                 <field name="function" />


### PR DESCRIPTION
This PR introduces the following features:
- translate the export of fields (e.g. description_fr, description_en, description_nl)
- allow to add arguments to a list by ending the alias by * (e.g. all fields with alias customValues* will end up in customValues: [...])
- pass each field through a custom function, configurable from the interface (resolvers)
- pass the obtained json through a global resolver

A resolver is simply a record with a python code field and an eval method;
it comes in two variant, one to work at the field level and the second at the global level.
The idea is to extend the export in a way that new requirements could be met without needing to change any code.

The intended use-case is to be compatible with APIs that require all translated parameters to be exported simultaneously,
and ask for custom properties to be put in a sub-dictionary.
Since these requirements are fairly standard, we extend the module in a way that could fit most use-cases.

Note that the intermediate data structure "json parser" is insufficient for our requirements as it follows the BNF:
```
    Ps = [ps*]
    ps = Fs | (Fs, C) |(Fs, Ps)
    Fs = f | f:a
    C = method | callable
        f in field_names for the fields of the target model
        a = E* any alias, i.e. E is the alphabet 
```
We extend it to the following:
```
    Pf = {"langs": {L: P}*, "resolver"?: R}
    P = [p*]
    p = F | (F, P)
    F = {"name": f, "alias"?: a, "resolver"?: R, "callable"?: C}
    R = resolver
    L = lang
```
To put it simply, we keep the same structure be replace the simple string representation of fields by dictionaries,
and have an outer dictionary so that we can have a parser for each lang, and a global resolver.
To keep things simple we keep compatibility with that simpler API and convert the simple parser to a full parser.