### PR TITLE
[12.0][FIX] excel_import_export: external ids naming.

### DIFF
--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -46,7 +46,7 @@ class XLSXImport(models.AbstractModel):
         xml_id = record.get_external_id()
         if not xml_id or (record.id in xml_id and xml_id[record.id] == ''):
             ModelData.create({'name': '%s_%s' % (record._table, record.id),
-                              'module': 'excel_import_export',
+                              'module': '__excel_import_export__',
                               'model': record._name,
                               'res_id': record.id, })
             xml_id = record.get_external_id()


### PR DESCRIPTION
Because of the naming given to the external ID's, Odoo interprets all this data as regular module data and when you update the module and those external ID's are not present in the module files, it tries to delete them.

Fixes https://github.com/OCA/server-tools/issues/1898.

cc @kittiu 

@ForgeFlow