### PR TITLE
[12.0] Adding oca_dependencies.txt to server_tools

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+storage


### PR DESCRIPTION
As explained in the issue #1902, this file might be needed as there is a dependency to another OCA repository. 