### PR TITLE
base_jsonify: allow export line exclusion

### DIFF
--- a/base_jsonify/models/ir_exports_line.py
+++ b/base_jsonify/models/ir_exports_line.py
@@ -13,6 +13,7 @@ class IrExportsLine(models.Model):
         help="The complete path to the field where you can specify an "
         "alias on the a step as field:alias",
     )
+    active = fields.Boolean(string="Active", default=True)
 
     @api.constrains("alias", "name")
     def _check_alias(self):


### PR DESCRIPTION
Sometimes you just want to turn off via configuration
lines created by some other modules.