### PR TITLE
[13.0] base_jsonify: fix rounding for float fields

### DIFF
--- a/base_jsonify/models/models.py
+++ b/base_jsonify/models/models.py
@@ -39,6 +39,8 @@ class Base(models.AbstractModel):
         """Override this function to support new field types."""
         if value is False and field.type != "boolean":
             value = None
+        elif field.type == "float":
+            value = float(field.convert_to_column(value, self))
         elif field.type == "date":
             value = fields.Date.to_date(value).isoformat()
         elif field.type == "datetime":

--- a/base_jsonify/tests/test_get_parser.py
+++ b/base_jsonify/tests/test_get_parser.py
@@ -38,6 +38,8 @@ class TestParser(SavepointCase):
                 "date": fields.Date.from_string("2019-10-31"),
             }
         )
+        # add value directly to have floating point
+        cls.partner.partner_latitude = 100 / 13.5
         Langs = cls.env["res.lang"].with_context(active_test=False)
         cls.lang = Langs.search([("code", "=", "fr_FR")])
         cls.lang.active = True
@@ -133,6 +135,7 @@ class TestParser(SavepointCase):
             "lang",
             "comment",
             "credit_limit",
+            "partner_latitude",
             "name",
             "color",
             (
@@ -160,6 +163,7 @@ class TestParser(SavepointCase):
             "lang": "en_US",
             "comment": None,
             "credit_limit": 0.0,
+            "partner_latitude": 7.40741,
             "name": "Akretion",
             "color": 0,
             "country": {"code": "FR", "name": "France"},


### PR DESCRIPTION
use precision defined on fields for data preparing 
before data "13.95" returned as "13.950000000000001"