### PR TITLE
[IMP] base_jsonify: Allow to export many2one and referene field as si…

### DIFF
--- a/base_jsonify/models/models.py
+++ b/base_jsonify/models/models.py
@@ -87,6 +87,13 @@ class Base(models.AbstractModel):
             # object
             value = fields.Datetime.context_timestamp(self, value)
             value = value.isoformat()
+        elif field_type in ("many2one", "reference"):
+            if not value:
+                value = None
+            else:
+                value = value.display_name
+        elif field_type in ("one2many", "many2many"):
+            value = [v.display_name for v in value]
         return value
 
     def _jsonify_value_subparser(self, field_name, subparser):


### PR DESCRIPTION
…mple field

Before this change, the result of the export of a relational field was always a dict or a list of dict.

ex:

<record id="ir_exp_shopinvader_variant_lang" model="ir.exports.line">
  <field name="name">publication_language_id/name</field>
  <field name="alias">publication_language_id/name:lang</field>
  <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
</record>

will output:
{
    ...
    "publication_language_id" : {
        "lang": "French"
    }
    ...
}

After this change it's now possible to define simple exporter for relational fields where the value into the result will be the display_name or a list of display_name of the related records.

ex:

<record id="ir_exp_shopinvader_variant_lang" model="ir.exports.line">
  <field name="name">publication_language_id</field>
  <field name="alias">publication_language_id:lang</field>
  <field name="export_id" ref="shopinvader.ir_exp_shopinvader_variant" />
</record>

will output:
{
    "lang": "French"
}