### PR TITLE
[FIX] autovacuum_message_attachment: The field name cannot be used as it is already present in other models

### DIFF
--- a/autovacuum_message_attachment/models/base.py
+++ b/autovacuum_message_attachment/models/base.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class Base(models.AbstractModel):
     _inherit = "base"
 
-    attachment_ids = fields.One2many(
-        'ir.attachment', 'res_id', string='Attachments',
+    assigned_attachment_ids = fields.One2many(
+        'ir.attachment', 'res_id', string='Assigned Attachments',
         domain=lambda self: [('res_model', '=', self._name)], auto_join=True
     )

--- a/autovacuum_message_attachment/models/ir_attachment.py
+++ b/autovacuum_message_attachment/models/ir_attachment.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 class IrAttachment(models.Model):
     _name = "ir.attachment"
     _inherit = ["ir.attachment", "autovacuum.mixin"]
-    _autovacuum_relation = 'attachment_ids'
+    _autovacuum_relation = 'assigned_attachment_ids'
 
     def _get_autovacuum_domain(self, rule):
         domain = super()._get_autovacuum_domain(rule)


### PR DESCRIPTION
The field name used should be forbidden. With the existent code on OCA, messages are sent without attachments, as the inherits are being lost. For example, the following one:

https://github.com/odoo/odoo/blob/12.0/addons/mail/models/mail_mail.py#L27

@florian-dacosta @jarroyomorales 