### PR TITLE
[IMP] override dbfilter instead of superposing it

### DIFF
--- a/dbfilter_from_header/override.py
+++ b/dbfilter_from_header/override.py
@@ -12,11 +12,12 @@ db_filter_org = http.db_filter
 
 
 def db_filter(dbs, httprequest=None):
-    dbs = db_filter_org(dbs, httprequest)
     httprequest = httprequest or http.request.httprequest
     db_filter_hdr = httprequest.environ.get('HTTP_X_ODOO_DBFILTER')
     if db_filter_hdr:
         dbs = [db for db in dbs if re.match(db_filter_hdr, db)]
+    else:
+        dbs = db_filter_org(dbs, httprequest)
     return dbs
 
 


### PR DESCRIPTION
The current behavior does not correspond to the description of the module: If there is already a dbfilter defined in the config file or as a parameter, this module will add the new dbfilter to the old one hence further filtering out the databases.

This proposed changes will instead completely override the old dbfilter with the new one, giving more flexibility to its use.