### PR TITLE
[12.0][FIX] excel_import_export, Change color in bold_red style

### DIFF
--- a/excel_import_export/__manifest__.py
+++ b/excel_import_export/__manifest__.py
@@ -25,6 +25,6 @@
              'views/webclient_templates.xml',
              ],
     'installable': True,
-    'development_status': 'beta',
+    'development_status': 'Beta',
     'maintainers': ['kittiu'],
 }

--- a/excel_import_export/models/styles.py
+++ b/excel_import_export/models/styles.py
@@ -7,7 +7,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 try:
-    from openpyxl.styles import colors, PatternFill, Alignment, Font
+    from openpyxl.styles import PatternFill, Alignment, Font
 except ImportError:
     _logger.debug(
         'Cannot import "openpyxl". Please make sure it is installed.')
@@ -24,7 +24,7 @@ class XLSXStyles(models.AbstractModel):
             'font': {
                 'bold': Font(name="Arial", size=10, bold=True),
                 'bold_red': Font(name="Arial", size=10,
-                                 color=colors.RED, bold=True),
+                                 color="FF0000", bold=True),
             },
             'fill': {
                 'red': PatternFill("solid", fgColor="FF0000"),

--- a/excel_import_export_demo/__manifest__.py
+++ b/excel_import_export_demo/__manifest__.py
@@ -23,6 +23,6 @@
           'report_action/partner_list/report_partner_list.xml',
           ],
  'installable': True,
- 'development_status': 'alpha',
+ 'development_status': 'Alpha',
  'maintainers': ['kittiu'],
  }


### PR DESCRIPTION
openpyxl after v.3.0.3 is not supported `colors.RED`, I change color to "FF0000"
https://foss.heptapod.net/openpyxl/openpyxl/-/blob/3.0.4/openpyxl/styles/colors.py#L36

cc: @kittiu 