### PR TITLE
[FIX][8.0] base_suspend_security x TransientModel

### DIFF
--- a/base_suspend_security/tests/test_base_suspend_security.py
+++ b/base_suspend_security/tests/test_base_suspend_security.py
@@ -66,6 +66,11 @@ class TestBaseSuspendSecurity(TransactionCase):
         self.assertEqual(
             BaseSuspendSecurityUid(42), BaseSuspendSecurityUid(42),
         )
+        # Test transient model access
+        wiz = self.env(user=user_id)[
+            'base.language.install'].suspend_security().create(
+                {'lang': 'en_US'})
+        wiz.lang = 'nl_NL'
 
     def test_changing_access_right(self):
         env = self.env(user=self.user.id)


### PR DESCRIPTION
Grant access on transient models in the case of suspended security.
Otherwise, the ORM will try to compare the suspended security uid with
the integer create_uids from the records in the database