### PR TITLE
base_view_inheritance_extension: fix pyyaml dependency

### DIFF
--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -9,5 +9,6 @@
     "category": "Hidden/Dependency",
     "summary": "Adds more operators for view inheritance",
     "depends": ["base"],
+    "external_dependencies": {"python": ["pyyaml"]},
     "demo": ["demo/ir_ui_view.xml"],
 }


### PR DESCRIPTION
This is not an issue w/ MQT=OCA because MQT by luck has pyyaml in its requirements
and get installed here https://github.com/OCA/maintainer-quality-tools/blob/master/travis/travis_install_nightly#L106.
When using MQT=PIP or in any case when pip installing this module it will fail.