### PR TITLE
[8.0][IMP] auditlog: Add indexes for autovacuum speed

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -19,7 +19,7 @@ class AuditlogHTTPRequest(models.Model):
     user_id = fields.Many2one(
         'res.users', string=u"User")
     http_session_id = fields.Many2one(
-        'auditlog.http.session', string=u"Session")
+        'auditlog.http.session', string=u"Session", index=True)
     user_context = fields.Char(u"Context")
     log_ids = fields.One2many(
         'auditlog.log', 'http_request_id', string=u"Logs")

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -23,9 +23,9 @@ class AuditlogLog(models.Model):
     line_ids = fields.One2many(
         'auditlog.log.line', 'log_id', string=u"Fields updated")
     http_session_id = fields.Many2one(
-        'auditlog.http.session', string=u"Session")
+        'auditlog.http.session', index=True, string=u"Session")
     http_request_id = fields.Many2one(
-        'auditlog.http.request', string=u"HTTP Request")
+        'auditlog.http.request', index=True, string=u"HTTP Request")
     log_type = fields.Selection(
         [('full', u"Full log"),
          ('fast', u"Fast log"),


### PR DESCRIPTION
So that autovacuum of HTTP requests and sessions does not require table-scanning a huge auditlog.log file

https://stackoverflow.com/questions/48793071/does-a-postgres-foreign-key-imply-an-index