### PR TITLE
[12.0][FIX] sql_export: fix warning two fields have same label

### DIFF
--- a/sql_export/demo/sql_export.xml
+++ b/sql_export/demo/sql_export.xml
@@ -18,7 +18,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
     <record id="integer_field_variable_sql" model="ir.model.fields">
         <field name="name">x_id</field>
-        <field name="field_description">ID</field>
+        <field name="field_description">x_ID</field>
         <field name="ttype">integer</field>
         <field name="model_id" ref="sql_export.model_sql_file_wizard"/>
         <field name="model">sql.file.wizard</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, runbot marks a warning about sql.file.wizard model in demo data with two fields with same label (ID).

Current behavior before PR: runbot warns about sql.file.wizard model in demo data with two fields with same label (ID).

Desired behavior after PR is merged: runbot pass in green without warnings.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
