### PR TITLE
[9.0][FIX] Dont query non-stored related or computed fields on full auditlog

### DIFF
--- a/auditlog/README.rst
+++ b/auditlog/README.rst
@@ -58,6 +58,7 @@ Contributors
 * Sebastien Alix <sebastien.alix@osiell.com>
 * Holger Brunn <hbrunn@therp.nl>
 * Holden Rehg <holdenrehg@gmail.com>
+* Tom Blauwendraat <tom@sunflowerweb.nl>
 
 Images
 ------

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -195,6 +195,19 @@ class AuditlogRule(models.Model):
         self.unsubscribe()
         return super(AuditlogRule, self).unlink()
 
+    @api.model
+    def get_auditlog_fields(self, model):
+        """
+        Get the list of auditlog fields for a model
+        By default it is all stored fields only, but you can
+        override this.
+        """
+        return list(
+            n
+            for n, f in model._fields.iteritems()
+            if (not f.compute and not f.related) or f.store
+        )
+
     @api.multi
     def _make_create(self):
         """Instanciate a create method that log its calls."""
@@ -207,9 +220,10 @@ class AuditlogRule(models.Model):
             self = self.with_context(auditlog_disabled=True)
             rule_model = self.env['auditlog.rule']
             new_record = create_full.origin(self, vals, **kwargs)
+            fields_list = rule_model.get_auditlog_fields(self)
             new_values = dict(
                 (d['id'], d) for d in new_record.sudo()
-                .with_context(prefetch_fields=False).read(list(self._fields)))
+                .with_context(prefetch_fields=False).read(fields_list))
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, new_record.ids,
                 'create', None, new_values, {'log_type': log_type})
@@ -286,13 +300,14 @@ class AuditlogRule(models.Model):
         def write_full(self, vals, **kwargs):
             self = self.with_context(auditlog_disabled=True)
             rule_model = self.env['auditlog.rule']
+            fields_list = rule_model.get_auditlog_fields(self)
             old_values = dict(
                 (d['id'], d) for d in self.sudo()
-                .with_context(prefetch_fields=False).read(list(self._fields)))
+                .with_context(prefetch_fields=False).read(fields_list))
             result = write_full.origin(self, vals, **kwargs)
             new_values = dict(
                 (d['id'], d) for d in self.sudo()
-                .with_context(prefetch_fields=False).read(list(self._fields)))
+                .with_context(prefetch_fields=False).read(fields_list))
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, self.ids,
                 'write', old_values, new_values, {'log_type': log_type})
@@ -327,9 +342,10 @@ class AuditlogRule(models.Model):
         def unlink_full(self, **kwargs):
             self = self.with_context(auditlog_disabled=True)
             rule_model = self.env['auditlog.rule']
+            fields_list = rule_model.get_auditlog_fields(self)
             old_values = dict(
                 (d['id'], d) for d in self.sudo()
-                .with_context(prefetch_fields=False).read(list(self._fields)))
+                .with_context(prefetch_fields=False).read(fields_list))
             rule_model.sudo().create_logs(
                 self.env.uid, self._name, self.ids, 'unlink', old_values, None,
                 {'log_type': log_type})


### PR DESCRIPTION
Fixes #1249, forward port of https://github.com/OCA/server-tools/pull/1964