### PR TITLE
[12.0][FIX]database_cleanup: Don't purge by default

### DIFF
--- a/database_cleanup/models/purge_modules.py
+++ b/database_cleanup/models/purge_modules.py
@@ -89,8 +89,6 @@ class CleanupPurgeWizardModule(models.TransientModel):
                 continue
             res.append((0, 0, {'name': module.name}))
 
-        purge_lines.purge()
-
         if not res:
             raise UserError(_('No modules found to purge'))
         return res


### PR DESCRIPTION
Modules should not be purged when completing scan without
explicit user consent. Instead select modules to purge from results.

After applied fixed an issue similar to #1534 