### PR TITLE
[11.0][IMP] profiler: 'Per HTTP request' mode

### DIFF
--- a/profiler/README.rst
+++ b/profiler/README.rst
@@ -9,6 +9,31 @@ Odoo Profiler
 Integration of python cprofile and postgresql logging collector for Odoo
 Check the Profiler menu in admin menu
 
+Installation
+============
+
+To make use of the Postgres capabilities, enable Postgres logging and install PGbadger.
+
+Python profiling will work out of the box.
+
+Usage
+=====
+
+For Python profiling we have two methods:
+
+**Full profiling**: Profile anything that happens between A and B. For this method, start Odoo
+with workers=0, create a profile record and select Python method 'All activity'. Enable
+the profiler, do actions in Odoo, and disable again. Under 'Attachments' you can download the
+cProfile stats file.
+
+**Profile current session per HTTP request**: Profile HTTP requests in the active user session.
+This method also works in multi-worker mode. Create a profile record and select Python method
+'Per HTTP request'. Enable the profiler, do actions in Odoo, and see the list filling up with
+requests. After some time, disable. You can find your slow HTTP requests by sorting
+on the 'Total time' column, and download the cProfile stats file for further analysis.
+
+Stats files can be analyzed visually for example with Snakeviz or Tuna.
+
 Credits
 =======
 
@@ -16,6 +41,7 @@ Contributors
 ------------
 
 * Moisés López <moylop260@vauxoo.com>
+* Tom Blauwendraat <tom@sunflowerweb.nl>
 
 Maintainer
 ----------

--- a/profiler/__manifest__.py
+++ b/profiler/__manifest__.py
@@ -1,14 +1,15 @@
 {
     'name': "profiler",
-    'author': "Vauxoo, Odoo Community Association (OCA)",
+    'author': "Vauxoo, Sunflower IT, Odoo Community Association (OCA)",
     'website': "https://github.com/OCA/server-tools/tree/12.0/profiler",
     'category': 'Tests',
     'version': '11.0.1.0.0',
     'license': 'AGPL-3',
-    'depends': ["document"],
+    'depends': ["document", "web_tour"],
     'data': [
         'security/ir.model.access.csv',
         'views/profiler_profile_view.xml',
+        'views/assets.xml',
     ],
     'post_load': 'post_load',
     'installable': True,

--- a/profiler/models/__init__.py
+++ b/profiler/models/__init__.py
@@ -1,2 +1,2 @@
-
+from . import ir_http
 from . import profiler_profile

--- a/profiler/models/ir_http.py
+++ b/profiler/models/ir_http.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Sunflower IT (http://sunflowerweb.nl)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from timeit import default_timer as timer
+
+from odoo import models
+from odoo.http import request
+
+from .profiler_profile import ProfilerProfile
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _dispatch(cls):
+        if request and request.httprequest and request.httprequest.session \
+                and getattr(request.httprequest.session, 'oca_profiler', False):
+            oca_profiler_id = request.httprequest.session.oca_profiler
+            profiler = request.env['profiler.profile'].browse(oca_profiler_id)
+            ProfilerProfile.enabled = True
+            start = timer()
+            with ProfilerProfile.profiling():
+                ret = super(IrHttp, cls)._dispatch()
+            end = timer()
+            ProfilerProfile.enabled = False
+            request_line = profiler.sudo().create_request_line()
+            request_line.dump_stats()
+            request_line.total_time = (end - start) * 1000.0
+            return ret
+        return super(IrHttp, cls)._dispatch()

--- a/profiler/security/ir.model.access.csv
+++ b/profiler/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_profiler_profile_admin,profiler profile admin,model_profiler_profile,base.group_system,1,1,1,1
 access_profiler_profile_line_admin,profiler profile line admin,model_profiler_profile_python_line,base.group_system,1,1,1,1
+access_profiler_request_line_admin,profiler request line admin,model_profiler_profile_request_line,base.group_system,1,1,1,1

--- a/profiler/static/src/js/tour.js
+++ b/profiler/static/src/js/tour.js
@@ -1,0 +1,72 @@
+odoo.define('profiler.tour', function(require) {
+  "use strict";
+
+  var core = require('web.core');
+  var tour = require('web_tour.tour');
+
+  var _t = core._t;
+
+  tour.register(
+    'profiler_tour',
+    {
+      url: "/web",
+    },
+    [
+      tour.STEPS.MENU_MORE,
+      {
+        content: _t("Analyze your application performance in the Profiler app."),
+        trigger: '.o_app[data-menu-xmlid="profiler.menu_profiler_root"], .oe_menu_toggler[data-menu-xmlid="profiler.menu_profiler_root"]',
+        position: "bottom"
+      },
+      {
+        trigger: '.o_list_view',
+        run: function () {
+          // Hack to wait for 500 ms before entering next step
+          _.delay(function () {
+            $(".o_list_button_add").addClass('ready');
+          }, 500);
+        },
+      },
+
+      {
+        content: _t("Let's create a new profiler session."),
+        trigger: ".o_list_button_add.ready",
+        position: "right",
+      },
+      {
+        content: _t("Give this session a name."),
+        trigger: "h1 input[name='name']",
+        extra_trigger: ".o_form_editable",
+        position: "right",
+      },
+      {
+        content: _t("Select a profiling method."),
+        trigger: "select[name='python_method']",
+        position: "right",
+        run: "text Per HTTP request",
+      },
+      {
+        content: _t("When you are happy, save it."),
+        trigger: ".o_form_button_save",
+        position: "right",
+      },
+      {
+        content: _t("Now enable it to start profiling."),
+        trigger: ".o_statusbar_buttons button:containsExact(Enable)",
+        extra_trigger: ".o_form_readonly",
+        position: "right",
+      },
+      {
+        content: _t("Now disable it to stop profiling."),
+        trigger: ".o_statusbar_buttons button:containsExact(Disable)",
+        extra_trigger: ".o_form_readonly",
+        position: "right",
+      },
+      {
+        content: _t("We now have measurements."),
+        trigger: "tr[class='o_data_row']",
+      },
+    ]
+  );
+
+});

--- a/profiler/tests/__init__.py
+++ b/profiler/tests/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2018 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import test_profiling
+from . import test_profiling_ui

--- a/profiler/tests/test_profiling.py
+++ b/profiler/tests/test_profiling.py
@@ -1,6 +1,7 @@
 
 # Copyright 2018 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from odoo.tests.common import HttpCase
 
 
@@ -9,7 +10,11 @@ class TestProfiling(HttpCase):
     def test_profile_creation(self):
         """We are testing the creation of a profile."""
         prof_obj = self.env['profiler.profile']
-        profile = prof_obj.create({'name': 'this_profiler'})
+        profile = prof_obj.create({
+            'name': 'this_profiler',
+            'enable_python': True,
+            'python_method': 'full',
+        })
         self.assertEqual(0, profile.attachment_count)
         profile.enable()
         self.assertFalse(self.xmlrpc_common.authenticate(
@@ -22,7 +27,9 @@ class TestProfiling(HttpCase):
         prof_obj = self.env['profiler.profile']
         profile = prof_obj.create({
             'name': 'this_profiler',
+            'enable_python': True,
             'use_py_index': True,
+            'python_method': 'full',
         })
         self.assertEqual(0, profile.attachment_count)
         profile.enable()

--- a/profiler/tests/test_profiling_ui.py
+++ b/profiler/tests/test_profiling_ui.py
@@ -1,0 +1,19 @@
+
+# Copyright 2018 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import HttpCase, at_install, post_install
+
+
+@at_install(False)
+@post_install(True)
+class TestProfilingUI(HttpCase):
+
+    def test_profile_creation_by_request(self):
+        """We are testing the creation of a user session profile."""
+        self.phantom_js(
+            "/web",
+            "odoo.__DEBUG__.services['web_tour.tour'].run('profiler_tour')",
+            "odoo.__DEBUG__.services['web_tour.tour'].tours.profiler_tour.ready",
+            login="admin"
+        )

--- a/profiler/views/assets.xml
+++ b/profiler/views/assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <template id="assets_backend" name="profiler assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/profiler/static/src/js/tour.js"></script>
+            </xpath>
+        </template>
+</odoo>

--- a/profiler/views/profiler_profile_view.xml
+++ b/profiler/views/profiler_profile_view.xml
@@ -1,4 +1,5 @@
 <odoo>
+
     <record model="ir.ui.view" id="view_profile_list">
         <field name="name">view profile list</field>
         <field name="model">profiler.profile</field>
@@ -6,11 +7,28 @@
             <tree>
                 <field name="name"/>
                 <field name="enable_python"/>
+                <field name="python_method" attrs="{'invisible': [('enable_python', '=', False)]}"/>
                 <field name="use_py_index"/>
                 <field name="enable_postgresql"/>
                 <field name="date_started"/>
                 <field name="date_finished"/>
                 <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_request_lines">
+        <field name="name">view request_lines</field>
+        <field name="model">profiler.profile.request.line</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="create_date"/>
+                <field name="total_time"/>
+                <field name="root_url"/>
+                <field name="user_id"/>
+                <field name="user_context"/>
+                <field name="attachment_id"/>
             </tree>
         </field>
     </record>
@@ -30,6 +48,7 @@
             </tree>
         </field>
     </record>
+
     <record id="view_profiling_lines_search" model="ir.ui.view">
         <field name="name">view.profiling.lines.search</field>
         <field name="model">profiler.profile.python.line</field>
@@ -40,6 +59,7 @@
             </search>
         </field>
     </record>
+
     <record id="action_view_profiling_lines" model="ir.actions.act_window">
         <field name="name">Profiling lines</field>
         <field name="res_model">profiler.profile.python.line</field>
@@ -71,7 +91,7 @@
                             class="oe_stat_button"
                             icon="fa-share-square-o"
                             context="{'search_default_profile_id': active_id, 'default_profile_id': active_id}"
-                            attrs="{'invisible': ['|', ('enable_python', '=', False), ('date_finished', '=', False)]}">
+                            attrs="{'invisible': ['|', '|', ('enable_python', '=', False), ('python_method', '!=', 'full'), ('date_finished', '=', False)]}">
                         </button>
 
                         <button name="action_view_attachment"
@@ -90,6 +110,7 @@
                     <group>
                         <group>
                             <field name="enable_python" attrs="{'readonly': [('state','=', 'enabled')]}"/>
+                            <field name="python_method" attrs="{'invisible': [('enable_python', '=', False)]}"/>
                             <field name="use_py_index"/>
                         </group>
                         <group>
@@ -115,7 +136,7 @@
                         <page string="PostgreSQL Stats - Most Frequent" attrs="{'invisible': ['|', ('enable_postgresql', '=', False), ('date_finished', '=', False)]}">
                             <field name="pg_stats_most_frequent_html" nolabel="1" colspan="4"/>
                         </page>
-                        <page string="Python Stats - Profiling Lines" attrs="{'invisible': ['|', ('enable_python', '=', False), ('date_finished', '=', False)]}">
+                        <page string="Python Stats - Profiling Lines" attrs="{'invisible': ['|', '|', ('enable_python', '=', False), ('python_method', '!=', 'full'), ('date_finished', '=', False)]}">
                             <field name="py_stats_lines" nolabel="1" colspan="4">
                                 <tree>
                                     <field name="cprof_ncalls"/>
@@ -125,6 +146,16 @@
                                     <field name="cprof_cumtime"/>
                                     <field name="cprof_ctpercall"/>
                                     <field name="cprof_fname"/>
+                                </tree>
+                            </field>
+                        </page>
+                        <page string="Python Stats - Requests" attrs="{'invisible': ['|', '|', ('enable_python', '=', False), ('python_method', '!=', 'request'), ('date_finished', '=', False)]}">
+                            <field name="py_request_lines" nolabel="1" colspan="4">
+                                <tree>
+                                    <field name="name"/>
+                                    <field name="create_date"/>
+                                    <field name="total_time"/>
+                                    <field name="user_id"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Current profiling module only works with `workers=0` so it is not useful in production.

This patch adds a separate Python profiling mode 'Per request', which generates a cProfile stats file for each individual HTTP request of the user session that enabled it. This works in multi-worker mode also, and allows to see profiling data for the slow(est) requests only.

Now profiling can also be used in production with low overhead.

![image](https://user-images.githubusercontent.com/1466356/104036418-a7cb4d00-51d3-11eb-996c-5afc57e92957.png)

@moylop260 @etobella 