### PR TITLE
[IMP][8.0] auto_backup: Delete incomplete backups to avoid filling up disk

### DIFF
--- a/auto_backup/README.rst
+++ b/auto_backup/README.rst
@@ -89,6 +89,7 @@ Contributors
 * Yenthe Van Ginneken <yenthe.vanginneken@vanroey.be>
 * Alessio Gerace <alessio.gerace@agilebg.com>
 * Jairo Llopis <yajo.sk8@gmail.com>
+* Tom Blauwendraat <tom@sunflowerweb.nl>
 
 Maintainer
 ----------

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -161,7 +161,12 @@ class DbBackup(models.Model):
                     # Generate new backup
                     else:
                         with rec.custom_tempdir():
-                            db.dump_db(self.env.cr.dbname, destiny)
+                            try:
+                                db.dump_db(self.env.cr.dbname, destiny)
+                            except:  # noqa
+                                # Avoid filling up disk with failed backups
+                                os.remove(destiny)
+                                raise
                         backup = backup or destiny.name
                 successful |= rec
 


### PR DESCRIPTION
Depends on https://github.com/OCA/server-tools/pull/1623

If a backup fails for whatever reason, delete it and dont keep the incomplete file on disk. If incomplete files are kept, the disk will start filling up after some days.