### PR TITLE
[12.0] Replaced Pygount source analysis deprecation method

### DIFF
--- a/module_analysis/models/ir_module_module.py
+++ b/module_analysis/models/ir_module_module.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import os
-import pygount
+from pygount import SourceAnalysis
 from pathlib import Path
 import logging
 
@@ -145,7 +145,7 @@ class IrModuleModule(models.Model):
                 exclude_files)
 
             for file_path, file_ext in file_list:
-                file_res = pygount.source_analysis(
+                file_res = SourceAnalysis.from_file(
                     file_path, '',
                     encoding=self._get_module_encoding(file_ext))
                 for k, v in analysed_datas.get(file_ext).items():


### PR DESCRIPTION
Today module_analysis uses pygount deprecation method **source_analysis** and it creates log warring records:

![image](https://user-images.githubusercontent.com/211005/110677865-6b58a500-81b4-11eb-8898-bcb01cc73275.png)
