### PR TITLE
[12.0][FIX] Update pygount version info in README INSTALL.rst and requirements.txt

### DIFF
--- a/module_analysis/models/ir_module_module.py
+++ b/module_analysis/models/ir_module_module.py
@@ -146,7 +146,7 @@ class IrModuleModule(models.Model):
 
             for file_path, file_ext in file_list:
                 file_res = SourceAnalysis.from_file(
-                    file_path, '',
+                    file_path, "",
                     encoding=self._get_module_encoding(file_ext))
                 for k, v in analysed_datas.get(file_ext).items():
                     v['value'] += getattr(file_res, k)

--- a/module_analysis/readme/INSTALL.rst
+++ b/module_analysis/readme/INSTALL.rst
@@ -1,3 +1,3 @@
 To use this module, you have to install the ``pygount`` python librairy.
 
-``pip install pygount``
+``pip install pygount>1.2.1``

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ openpyxl
 xlrd
 xlwt
 pysftp
-# version 1.2.0 deprecates the API module_analysis uses
-pygount<1.2.0
+pygount>1.2.1


### PR DESCRIPTION
Hi guys,

Yesterday I did one PR to fix deprecated call to pygount.source_analysis #2036 but @legalsylvain did one PR #1826 (My fault to not find this PR...) As the PR 2302 has been merged, I am making a new PR with #1826 commit made by @legalsylvain to and reviewed by @pedrobaeza

This PR replaces #1826