### PR TITLE
[11.0][FIX] base_name_search_improved: ensure search with limit as an integer

### DIFF
--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -18,6 +18,7 @@ def _get_rec_names(self):
 
 
 def _extend_name_results(self, domain, results, limit):
+    limit = limit or 100
     result_count = len(results)
     if result_count < limit:
         domain += [('id', 'not in', [x[0] for x in results])]


### PR DESCRIPTION
This error is reproduced when we name_search a Many2many relation. For example in the [module_analysis](https://github.com/OCA/server-tools/pull/1866/files#diff-8cbf9818e2eb28f6100234deea86a3a959b740b390ee1e43e07eddb3b5f2e042R26).

The variable `limit` is `None` as you can see in this [image](https://ibb.co/TtR1TtR) 

This fix was made for backport module analysis to v11  #1866 