### PR TITLE
[14.0][IMP] auditlog: prevent cascading delete of logs when models or fields are unlinked

### DIFF
--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Audit Log",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.1.0",
     "author": "ABF OSIELL,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/server-tools",

--- a/auditlog/migrations/14.0.1.1.0/pre-migration.py
+++ b/auditlog/migrations/14.0.1.1.0/pre-migration.py
@@ -1,0 +1,73 @@
+# © 2018 Pieter Paulussen <pieter_paulussen@me.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    logger = logging.getLogger(__name__)
+    logger.info(
+        "Creating columns: auditlog_log (model_name, model_model) "
+        "and auditlog_log_line (field_name, field_description)."
+    )
+    cr.execute(
+        """
+    ALTER TABLE auditlog_log
+    ADD COLUMN IF NOT EXISTS model_name VARCHAR,
+    ADD COLUMN IF NOT EXISTS model_model VARCHAR;
+    ALTER TABLE auditlog_log_line
+    ADD COLUMN IF NOT EXISTS field_name VARCHAR,
+    ADD COLUMN IF NOT EXISTS field_description VARCHAR;
+    ALTER TABLE auditlog_rule
+    ADD COLUMN IF NOT EXISTS model_name VARCHAR,
+    ADD COLUMN IF NOT EXISTS model_model VARCHAR;
+    """
+    )
+    logger.info(
+        "Creating indexes on auditlog_log column 'model_id' and "
+        "auditlog_log_line column 'field_id'."
+    )
+    cr.execute(
+        """
+        CREATE INDEX IF NOT EXISTS
+        auditlog_log_model_id_index ON auditlog_log (model_id);
+        CREATE INDEX IF NOT EXISTS
+        auditlog_log_line_field_id_index ON auditlog_log_line (field_id);
+    """
+    )
+    logger.info(
+        "Preemptive fill auditlog_log columns: 'model_name' and " "'model_model'."
+    )
+    cr.execute(
+        """
+    UPDATE auditlog_log al
+    SET model_name = im.name, model_model = im.model
+    FROM ir_model im
+    WHERE im.id = al.model_id AND model_name IS NULL
+    """
+    )
+    logger.info(
+        "Preemtive fill of auditlog_log_line columns: 'field_name' and"
+        " 'field_description'."
+    )
+    cr.execute(
+        """
+    UPDATE auditlog_log_line al
+    SET field_name = imf.name, field_description = imf.field_description
+    FROM ir_model_fields imf
+    WHERE imf.id = al.field_id AND field_name IS NULL
+    """
+    )
+    logger.info(
+        "Preemptive fill auditlog_rule columns: 'model_name' and " "'model_model'."
+    )
+    cr.execute(
+        """
+    UPDATE auditlog_rule al
+    SET model_name = im.name, model_model = im.model
+    FROM ir_model im
+    WHERE im.id = al.model_id AND model_name IS NULL
+    """
+    )
+    logger.info("Successfully updated auditlog tables")

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -1,6 +1,7 @@
 # Copyright 2015 ABF OSIELL <https://osiell.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AuditlogLog(models.Model):
@@ -9,7 +10,11 @@ class AuditlogLog(models.Model):
     _order = "create_date desc"
 
     name = fields.Char("Resource Name", size=64)
-    model_id = fields.Many2one("ir.model", string="Model")
+    model_id = fields.Many2one(
+        "ir.model", string="Model", index=True, ondelete="set null"
+    )
+    model_name = fields.Char(readonly=True)
+    model_model = fields.Char(string="Technical Model Name", readonly=True)
     res_id = fields.Integer("Resource ID")
     user_id = fields.Many2one("res.users", string="User")
     method = fields.Char(size=64)
@@ -20,13 +25,33 @@ class AuditlogLog(models.Model):
         [("full", "Full log"), ("fast", "Fast log")], string="Type"
     )
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        """ Insert model_name and model_model field values upon creation. """
+        for vals in vals_list:
+            if not vals.get("model_id"):
+                raise UserError(_("No model defined to create log."))
+            model = self.env["ir.model"].browse(vals["model_id"])
+            vals.update({"model_name": model.name, "model_model": model.model})
+        return super().create(vals_list)
+
+    def write(self, vals):
+        """Update model_name and model_model field values to reflect model_id
+        changes."""
+        if "model_id" in vals:
+            if not vals["model_id"]:
+                raise UserError(_("The field 'model_id' cannot be empty."))
+            model = self.env["ir.model"].browse(vals["model_id"])
+            vals.update({"model_name": model.name, "model_model": model.model})
+        return super().write(vals)
+
 
 class AuditlogLogLine(models.Model):
     _name = "auditlog.log.line"
     _description = "Auditlog - Log details (fields updated)"
 
     field_id = fields.Many2one(
-        "ir.model.fields", ondelete="cascade", string="Field", required=True
+        "ir.model.fields", ondelete="set null", string="Field", index=True
     )
     log_id = fields.Many2one(
         "auditlog.log", string="Log", ondelete="cascade", index=True
@@ -35,5 +60,30 @@ class AuditlogLogLine(models.Model):
     new_value = fields.Text()
     old_value_text = fields.Text("Old value Text")
     new_value_text = fields.Text("New value Text")
-    field_name = fields.Char("Technical name", related="field_id.name")
-    field_description = fields.Char("Description", related="field_id.field_description")
+    field_name = fields.Char("Technical name", readonly=True)
+    field_description = fields.Char("Description", readonly=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Ensure field_id is not empty on creation and store field_name and
+        field_description."""
+        for vals in vals_list:
+            if not vals.get("field_id"):
+                raise UserError(_("No field defined to create line."))
+            field = self.env["ir.model.fields"].browse(vals["field_id"])
+            vals.update(
+                {"field_name": field.name, "field_description": field.field_description}
+            )
+        return super().create(vals_list)
+
+    def write(self, vals):
+        """Ensure field_id is set during write and update field_name and
+        field_description values."""
+        if "field_id" in vals:
+            if not vals["field_id"]:
+                raise UserError(_("The field 'field_id' cannot be empty."))
+            field = self.env["ir.model.fields"].browse(vals["field_id"])
+            vals.update(
+                {"field_name": field.name, "field_description": field.field_description}
+            )
+        return super().write(vals)

--- a/auditlog/readme/CONTRIBUTORS.rst
+++ b/auditlog/readme/CONTRIBUTORS.rst
@@ -2,4 +2,6 @@
 * Holger Brunn <hbrunn@therp.nl>
 * Holden Rehg <holdenrehg@gmail.com>
 * Eric Lembregts <eric@lembregts.eu>
+* Pieter Paulussen <pieter.paulussen@me.com>
 * Alan Ramos <alan.ramos@jarsa.com.mx>
+* Stefan Rijnhart <stefan@opener.amsterdam>

--- a/auditlog/views/auditlog_view.xml
+++ b/auditlog/views/auditlog_view.xml
@@ -128,6 +128,17 @@
                         </group>
                         <group colspan="1">
                             <field name="model_id" readonly="1" />
+                            <field
+                                name="model_name"
+                                attrs="{'invisible': [('model_id', '!=', False)]}"
+                                readonly="1"
+                            />
+                            />
+                            <field
+                                name="model_model"
+                                attrs="{'invisible': [('model_id', '!=', False)]}"
+                                readonly="1"
+                            />
                             <field name="res_id" readonly="1" />
                             <field name="name" readonly="1" />
                         </group>
@@ -141,6 +152,11 @@
                             <form string="Log - Field updated">
                                 <group>
                                     <field name="field_id" readonly="1" />
+                                    <field
+                                        name="field_name"
+                                        attrs="{'invisible': [('field_id', '!=', False)]}"
+                                        readonly="1"
+                                    />
                                 </group>
                                 <group string="Values" col="4">
                                     <field name="old_value" readonly="1" />


### PR DESCRIPTION
When a field or a model is unlinked, keep the related audit logs. Denormalize the field and model info on the logs and log lines so that the information is still available after the deletion of the related data model.

Also, to improve the performance of the deletion of fields and models, add indexes on the log's `model_id` and log line's `field_id`.

Port of https://github.com/OCA/server-tools/pull/1262.
