### PR TITLE
[10.0][FIX] auth_admin_passkey: issue with 'bool' object has no attribute 'strip' after login

### DIFF
--- a/auth_admin_passkey/__manifest__.py
+++ b/auth_admin_passkey/__manifest__.py
@@ -4,26 +4,13 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 {
-    'name': 'Authentification - Admin Passkey',
-    'version': '10.0.1.0.2',
-    'category': 'base',
-    'author': "GRAP,Odoo Community Association (OCA)",
-    'website': 'http://www.grap.coop',
-    'license': 'AGPL-3',
-    'depends': [
-        'mail',
-    ],
-    'data': [
-        'data/ir_config_parameter.xml',
-        'views/res_config_view.xml',
-    ],
-    'demo': [],
-    'js': [],
-    'css': [],
-    'qweb': [],
-    'images': [],
-    'post_load': '',
-    'application': False,
-    'installable': True,
-    'auto_install': False,
+    "name": "Authentification - Admin Passkey",
+    "version": "10.0.1.0.2",
+    "category": "base",
+    "author": "GRAP,Odoo Community Association (OCA)",
+    "website": "http://www.grap.coop",
+    "license": "AGPL-3",
+    "depends": ["mail"],
+    "data": ["data/ir_config_parameter.xml", "views/res_config_view.xml"],
+    "installable": True,
 }

--- a/auth_admin_passkey/models/__init__.py
+++ b/auth_admin_passkey/models/__init__.py
@@ -3,7 +3,4 @@
 # @author Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from . import (
-    res_config,
-    res_users,
-    )
+from . import res_config, res_users

--- a/auth_admin_passkey/models/res_config.py
+++ b/auth_admin_passkey/models/res_config.py
@@ -7,47 +7,51 @@ from odoo import api, fields, models
 
 
 class BaseConfigSettings(models.TransientModel):
-    _inherit = 'base.config.settings'
+    _inherit = "base.config.settings"
 
     # Getter / Setter Section
     @api.model
     def get_default_auth_admin_passkey_send_to_admin(self, fields):
         return {
-            'auth_admin_passkey_send_to_admin':
-            self.env["ir.config_parameter"].get_param(
-                "auth_admin_passkey.send_to_admin")
+            "auth_admin_passkey_send_to_admin": self.env[
+                "ir.config_parameter"
+            ].get_param("auth_admin_passkey.send_to_admin")
         }
 
     @api.multi
     def set_auth_admin_passkey_send_to_admin(self):
         for config in self:
-            self.env['ir.config_parameter'].set_param(
+            self.env["ir.config_parameter"].set_param(
                 "auth_admin_passkey.send_to_admin",
-                config.auth_admin_passkey_send_to_admin or '')
+                config.auth_admin_passkey_send_to_admin or "",
+            )
 
     @api.model
     def get_default_auth_admin_passkey_send_to_user(self, fields):
         return {
-            'auth_admin_passkey_send_to_user':
-            self.env["ir.config_parameter"].get_param(
-                "auth_admin_passkey.send_to_user")
+            "auth_admin_passkey_send_to_user": self.env[
+                "ir.config_parameter"
+            ].get_param("auth_admin_passkey.send_to_user")
         }
 
     @api.multi
     def set_auth_admin_passkey_send_to_user(self):
         for config in self:
-            self.env['ir.config_parameter'].set_param(
+            self.env["ir.config_parameter"].set_param(
                 "auth_admin_passkey.send_to_user",
-                config.auth_admin_passkey_send_to_user or '')
+                config.auth_admin_passkey_send_to_user or "",
+            )
 
     auth_admin_passkey_send_to_admin = fields.Boolean(
-        string='Send email to admin user.',
-        help='When the administrator use his password to login in '
-             'with a different account, Odoo will send an email '
-             'to the admin user.')
+        string="Send email to admin user.",
+        help="When the administrator use his password to login in "
+        "with a different account, Odoo will send an email "
+        "to the admin user.",
+    )
 
     auth_admin_passkey_send_to_user = fields.Boolean(
-        string='Send email to user.',
-        help='When the administrator use his password to login in '
-             'with a different account, Odoo will send an email '
-             'to the account user.')
+        string="Send email to user.",
+        help="When the administrator use his password to login in "
+        "with a different account, Odoo will send an email "
+        "to the account user.",
+    )

--- a/auth_admin_passkey/models/res_config.py
+++ b/auth_admin_passkey/models/res_config.py
@@ -4,6 +4,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import api, fields, models
+from odoo.tools.safe_eval import safe_eval
 
 
 class BaseConfigSettings(models.TransientModel):
@@ -13,9 +14,12 @@ class BaseConfigSettings(models.TransientModel):
     @api.model
     def get_default_auth_admin_passkey_send_to_admin(self, fields):
         return {
-            "auth_admin_passkey_send_to_admin": self.env[
-                "ir.config_parameter"
-            ].get_param("auth_admin_passkey.send_to_admin")
+            "auth_admin_passkey_send_to_admin": safe_eval(
+                self.env["ir.config_parameter"].get_param(
+                    "auth_admin_passkey.send_to_admin"
+                )
+                or "False"
+            )
         }
 
     @api.multi
@@ -23,15 +27,18 @@ class BaseConfigSettings(models.TransientModel):
         for config in self:
             self.env["ir.config_parameter"].set_param(
                 "auth_admin_passkey.send_to_admin",
-                config.auth_admin_passkey_send_to_admin or "",
+                str(config.auth_admin_passkey_send_to_admin),
             )
 
     @api.model
     def get_default_auth_admin_passkey_send_to_user(self, fields):
         return {
-            "auth_admin_passkey_send_to_user": self.env[
-                "ir.config_parameter"
-            ].get_param("auth_admin_passkey.send_to_user")
+            "auth_admin_passkey_send_to_user": safe_eval(
+                self.env["ir.config_parameter"].get_param(
+                    "auth_admin_passkey.send_to_user"
+                )
+                or "False"
+            )
         }
 
     @api.multi
@@ -39,7 +46,7 @@ class BaseConfigSettings(models.TransientModel):
         for config in self:
             self.env["ir.config_parameter"].set_param(
                 "auth_admin_passkey.send_to_user",
-                config.auth_admin_passkey_send_to_user or "",
+                str(config.auth_admin_passkey_send_to_user),
             )
 
     auth_admin_passkey_send_to_admin = fields.Boolean(

--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -16,54 +16,58 @@ class ResUsers(models.Model):
     def _send_email_passkey(self, user_id):
         """ Send a email to the admin of the system and / or the user
             to inform passkey use."""
-        mail_obj = self.env['mail.mail'].sudo()
-        icp_obj = self.env['ir.config_parameter']
+        mail_obj = self.env["mail.mail"].sudo()
+        icp_obj = self.env["ir.config_parameter"]
 
         admin_user = self.sudo().browse(SUPERUSER_ID)
         login_user = self.browse(user_id)
 
-        send_to_admin = safe_eval(
-            icp_obj.get_param('auth_admin_passkey.send_to_admin')
-        )
-        send_to_user = safe_eval(
-            icp_obj.get_param('auth_admin_passkey.send_to_user')
-        )
+        send_to_admin = safe_eval(icp_obj.get_param("auth_admin_passkey.send_to_admin"))
+        send_to_user = safe_eval(icp_obj.get_param("auth_admin_passkey.send_to_user"))
 
         mails = []
         if send_to_admin and admin_user.email:
-            mails.append({'email': admin_user.email, 'lang': admin_user.lang})
+            mails.append({"email": admin_user.email, "lang": admin_user.lang})
         if send_to_user and login_user.email:
-            mails.append({'email': login_user.email, 'lang': login_user.lang})
+            mails.append({"email": login_user.email, "lang": login_user.lang})
         for mail in mails:
-            subject = _('Passkey used')
+            subject = _("Passkey used")
             body = _(
                 "Admin user used his passkey to login with '%s'.\n\n"
                 "\n\nTechnicals informations belows : \n\n"
                 "- Login date : %s\n\n"
-            ) % (login_user.login,
-                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+            ) % (
+                login_user.login,
+                datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            )
 
-            mail_obj.create({
-                'email_to': mail['email'],
-                'subject': subject,
-                'body_html': '<pre>%s</pre>' % body
-            })
+            mail_obj.create(
+                {
+                    "email_to": mail["email"],
+                    "subject": subject,
+                    "body_html": "<pre>%s</pre>" % body,
+                }
+            )
 
     @api.model
     def _send_email_same_password(self, login):
         """ Send an email to the admin user to inform that
             another user has the same password as him."""
-        mail_obj = self.env['mail.mail'].sudo()
+        mail_obj = self.env["mail.mail"].sudo()
         admin_user = self.sudo().browse(SUPERUSER_ID)
 
         if admin_user.email:
-            mail_obj.create({
-                'email_to': admin_user.email,
-                'subject': _('[WARNING] Odoo Security Risk'),
-                'body_html':
-                    _("<pre>User with login '%s' has the same "
-                      "password as you.</pre>") % (login),
-            })
+            mail_obj.create(
+                {
+                    "email_to": admin_user.email,
+                    "subject": _("[WARNING] Odoo Security Risk"),
+                    "body_html": _(
+                        "<pre>User with login '%s' has the same "
+                        "password as you.</pre>"
+                    )
+                    % (login),
+                }
+            )
 
     @api.model
     def check_credentials(self, password):
@@ -86,7 +90,7 @@ class ResUsers(models.Model):
                 raise
 
             # Just be sure that parent methods aren't wrong
-            user = self.sudo().search([('id', '=', self._uid)])
+            user = self.sudo().search([("id", "=", self._uid)])
             if not user:
                 raise
 

--- a/auth_admin_passkey/models/res_users.py
+++ b/auth_admin_passkey/models/res_users.py
@@ -22,8 +22,12 @@ class ResUsers(models.Model):
         admin_user = self.sudo().browse(SUPERUSER_ID)
         login_user = self.browse(user_id)
 
-        send_to_admin = safe_eval(icp_obj.get_param("auth_admin_passkey.send_to_admin"))
-        send_to_user = safe_eval(icp_obj.get_param("auth_admin_passkey.send_to_user"))
+        send_to_admin = safe_eval(
+            icp_obj.get_param("auth_admin_passkey.send_to_admin") or "False"
+        )
+        send_to_user = safe_eval(
+            icp_obj.get_param("auth_admin_passkey.send_to_user") or "False"
+        )
 
         mails = []
         if send_to_admin and admin_user.email:

--- a/auth_admin_passkey/tests/test_auth_admin_passkey.py
+++ b/auth_admin_passkey/tests/test_auth_admin_passkey.py
@@ -14,24 +14,22 @@ class TestAuthAdminPasskey(common.TransactionCase):
     def setUp(self):
         super(TestAuthAdminPasskey, self).setUp()
 
-        self.ru_obj = self.env['res.users']
+        self.ru_obj = self.env["res.users"]
 
         self.db = self.env.cr.dbname
 
-        self.admin_user = self.ru_obj.search([('id', '=', SUPERUSER_ID)])
-        self.passkey_user = self.ru_obj.create({
-            'login': 'passkey',
-            'password': 'PasskeyPa$$w0rd',
-            'name': 'passkey'
-        })
+        self.admin_user = self.ru_obj.search([("id", "=", SUPERUSER_ID)])
+        self.passkey_user = self.ru_obj.create(
+            {"login": "passkey", "password": "PasskeyPa$$w0rd", "name": "passkey"}
+        )
 
     def test_01_normal_login_admin_succeed(self):
         # NOTE: Can fail if admin password changed
-        self.admin_user.check_credentials('admin')
+        self.admin_user.check_credentials("admin")
 
     def test_02_normal_login_admin_fail(self):
         with self.assertRaises(exceptions.AccessDenied):
-            self.admin_user.check_credentials('bad_password')
+            self.admin_user.check_credentials("bad_password")
 
     def test_03_normal_login_passkey_succeed(self):
         """ This test cannot pass because in some way the the _uid of
@@ -39,7 +37,7 @@ class TestAuthAdminPasskey(common.TransactionCase):
             original check_credentials() method, it raises an exception
             """
         try:
-            self.passkey_user.check_credentials('passkey')
+            self.passkey_user.check_credentials("passkey")
         except exceptions.AccessDenied:
             # This exception is raised from the origin check_credentials()
             # method and its an expected behaviour as we catch this in our
@@ -48,14 +46,14 @@ class TestAuthAdminPasskey(common.TransactionCase):
 
     def test_04_normal_login_passkey_fail(self):
         with self.assertRaises(exceptions.AccessDenied):
-            self.passkey_user.check_credentials('bad_password')
+            self.passkey_user.check_credentials("bad_password")
 
     def test_05_passkey_login_passkey_with_admin_password_succeed(self):
         # NOTE: Can fail if admin password changed
-        self.passkey_user.check_credentials('admin')
+        self.passkey_user.check_credentials("admin")
 
     def test_06_passkey_login_passkey_succeed(self):
         """[Bug #1319391]
         Test the correct behaviour of login with 'bad_login' / 'admin'"""
-        res = self.ru_obj.authenticate(self.db, 'bad_login', 'admin', {})
+        res = self.ru_obj.authenticate(self.db, "bad_login", "admin", {})
         self.assertFalse(res)

--- a/auth_admin_passkey/tests/test_config.py
+++ b/auth_admin_passkey/tests/test_config.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019 Therp BV (https://therp.nl)
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+import logging
 
 from odoo.tests import common
+
+_logger = logging.getLogger(__name__)
 
 
 @common.post_install(True)
@@ -19,17 +22,17 @@ class TestConfig(common.TransactionCase):
         # Set email admin and user to False (and back again).
         config.set_auth_admin_passkey_send_to_admin()
         config.set_auth_admin_passkey_send_to_user()
-        self.assertEqual(
-            False,
+        self.assertFalse(config.auth_admin_passkey_send_to_admin)
+        self.assertFalse(config.auth_admin_passkey_send_to_user)
+        self.assertFalse(
             config_model.get_default_auth_admin_passkey_send_to_admin([])[
                 "auth_admin_passkey_send_to_admin"
-            ],
+            ]
         )
-        self.assertEqual(
-            False,
+        self.assertFalse(
             config_model.get_default_auth_admin_passkey_send_to_user([])[
                 "auth_admin_passkey_send_to_user"
-            ],
+            ]
         )
         config.write(
             {
@@ -39,15 +42,34 @@ class TestConfig(common.TransactionCase):
         )
         config.set_auth_admin_passkey_send_to_admin()
         config.set_auth_admin_passkey_send_to_user()
-        self.assertEqual(
-            u"True",
+        self.assertTrue(config.auth_admin_passkey_send_to_admin)
+        self.assertTrue(config.auth_admin_passkey_send_to_user)
+        self.assertTrue(
             config_model.get_default_auth_admin_passkey_send_to_admin([])[
                 "auth_admin_passkey_send_to_admin"
-            ],
+            ]
         )
-        self.assertEqual(
-            u"True",
+        self.assertTrue(
             config_model.get_default_auth_admin_passkey_send_to_user([])[
                 "auth_admin_passkey_send_to_user"
-            ],
+            ]
         )
+
+    def test_read_legacy_config_values(self):
+        """ Make sure that any falsy or truthy value formats that were
+            used in past, are still interpreted as such """
+        config_model = self.env["base.config.settings"]
+        param_model = self.env["ir.config_parameter"]
+
+        values = {False: ["False", "0", "", "None", None], True: ["True", "1"]}
+
+        for boolean_value, char_values in values.iteritems():
+            for char_value in char_values:
+                _logger.info(
+                    "Testing for value %s, type %s", char_value, type(char_value)
+                )
+                param_model.set_param("auth_admin_passkey.send_to_admin", char_value)
+                param_model.set_param("auth_admin_passkey.send_to_user", char_value)
+                config = config_model.create({})
+                self.assertEqual(boolean_value, config.auth_admin_passkey_send_to_admin)
+                self.assertEqual(boolean_value, config.auth_admin_passkey_send_to_user)

--- a/auth_admin_passkey/tests/test_config.py
+++ b/auth_admin_passkey/tests/test_config.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019 Therp BV (https://therp.nl)
 # License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0.html
+
 from odoo.tests import common
 
 
@@ -39,13 +40,13 @@ class TestConfig(common.TransactionCase):
         config.set_auth_admin_passkey_send_to_admin()
         config.set_auth_admin_passkey_send_to_user()
         self.assertEqual(
-            u'True',
+            u"True",
             config_model.get_default_auth_admin_passkey_send_to_admin([])[
                 "auth_admin_passkey_send_to_admin"
             ],
         )
         self.assertEqual(
-            u'True',
+            u"True",
             config_model.get_default_auth_admin_passkey_send_to_user([])[
                 "auth_admin_passkey_send_to_user"
             ],

--- a/auth_admin_passkey/tests/test_ui.py
+++ b/auth_admin_passkey/tests/test_ui.py
@@ -4,37 +4,37 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from lxml import html
-
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
-from odoo.tests import common
 from odoo.service import wsgi_server
+from odoo.tests import common
 
 
 @common.post_install(True)
 class TestUI(common.HttpCase):
-
     def setUp(self):
         super(TestUI, self).setUp()
 
         with self.registry.cursor() as test_cursor:
             env = self.env(test_cursor)
 
-            self.admin_password = 'AdminPa$$w0rd'
-            env.ref('base.user_root').password = self.admin_password
-            self.passkey_password = 'PasskeyPa$$w0rd'
-            self.passkey_user = env['res.users'].create({
-                'name': 'passkey',
-                'login': 'passkey',
-                'email': 'passkey',
-                'password': self.passkey_password
-            })
+            self.admin_password = "AdminPa$$w0rd"
+            env.ref("base.user_root").password = self.admin_password
+            self.passkey_password = "PasskeyPa$$w0rd"
+            self.passkey_user = env["res.users"].create(
+                {
+                    "name": "passkey",
+                    "login": "passkey",
+                    "email": "passkey",
+                    "password": self.passkey_password,
+                }
+            )
             self.dbname = env.cr.dbname
 
-        self.werkzeug_environ = {'REMOTE_ADDR': '127.0.0.1'}
+        self.werkzeug_environ = {"REMOTE_ADDR": "127.0.0.1"}
         self.test_client = Client(wsgi_server.application, BaseResponse)
-        self.test_client.get('/web/session/logout')
+        self.test_client.get("/web/session/logout")
 
     def html_doc(self, response):
         """Get an HTML LXML document."""
@@ -43,129 +43,128 @@ class TestUI(common.HttpCase):
     def csrf_token(self, response):
         """Get a valid CSRF token."""
         doc = self.html_doc(response)
-        return doc.xpath("//input[@name='csrf_token']")[0].get('value')
+        return doc.xpath("//input[@name='csrf_token']")[0].get("value")
 
     def get_request(self, url, data=None):
-        return self.test_client.get(
-            url, query_string=data, follow_redirects=True)
+        return self.test_client.get(url, query_string=data, follow_redirects=True)
 
     def post_request(self, url, data=None):
         return self.test_client.post(
-            url, data=data, follow_redirects=True,
-            environ_base=self.werkzeug_environ)
+            url, data=data, follow_redirects=True, environ_base=self.werkzeug_environ
+        )
 
     def test_01_normal_login_admin_succeed(self):
         # Our admin user wants to go to backoffice part of Odoo
-        response = self.get_request('/web/', data={'db': self.dbname})
+        response = self.get_request("/web/", data={"db": self.dbname})
 
         # He notices that his redirected to login page as not authenticated
-        self.assertIn('oe_login_form', response.data)
+        self.assertIn("oe_login_form", response.data)
 
         # He needs to enters his credentials and submit the form
         data = {
-            'login': 'admin',
-            'password': self.admin_password,
-            'csrf_token': self.csrf_token(response),
-            'db': self.dbname
+            "login": "admin",
+            "password": self.admin_password,
+            "csrf_token": self.csrf_token(response),
+            "db": self.dbname,
         }
-        response = self.post_request('/web/login/', data=data)
+        response = self.post_request("/web/login/", data=data)
 
         # He notices that his redirected to backoffice
-        self.assertNotIn('oe_login_form', response.data)
+        self.assertNotIn("oe_login_form", response.data)
 
     def test_02_normal_login_admin_fail(self):
         # Our admin user wants to go to backoffice part of Odoo
-        response = self.get_request('/web/', data={'db': self.dbname})
+        response = self.get_request("/web/", data={"db": self.dbname})
 
         # He notices that he's redirected to login page as not authenticated
-        self.assertIn('oe_login_form', response.data)
+        self.assertIn("oe_login_form", response.data)
 
         # He needs to enter his credentials and submit the form
         data = {
-            'login': 'admin',
-            'password': 'password',
-            'csrf_token': self.csrf_token(response),
-            'db': self.dbname
+            "login": "admin",
+            "password": "password",
+            "csrf_token": self.csrf_token(response),
+            "db": self.dbname,
         }
-        response = self.post_request('/web/login/', data=data)
+        response = self.post_request("/web/login/", data=data)
 
         # He mistyped his password so he's redirected to login page again
-        self.assertIn('Wrong login/password', response.data)
+        self.assertIn("Wrong login/password", response.data)
 
     def test_03_normal_login_passkey_succeed(self):
         # Our passkey user wants to go to backoffice part of Odoo
-        response = self.get_request('/web/', data={'db': self.dbname})
+        response = self.get_request("/web/", data={"db": self.dbname})
 
         # He notices that he's redirected to login page as not authenticated
-        self.assertIn('oe_login_form', response.data)
+        self.assertIn("oe_login_form", response.data)
 
         # He needs to enter his credentials and submit the form
         data = {
-            'login': self.passkey_user.login,
-            'password': self.passkey_password,
-            'csrf_token': self.csrf_token(response),
-            'db': self.dbname
+            "login": self.passkey_user.login,
+            "password": self.passkey_password,
+            "csrf_token": self.csrf_token(response),
+            "db": self.dbname,
         }
-        response = self.post_request('/web/login/', data=data)
+        response = self.post_request("/web/login/", data=data)
 
         # He notices that his redirected to backoffice
-        self.assertNotIn('oe_login_form', response.data)
+        self.assertNotIn("oe_login_form", response.data)
 
     def test_04_normal_login_passkey_fail(self):
         # Our passkey user wants to go to backoffice part of Odoo
-        response = self.get_request('/web/', data={'db': self.dbname})
+        response = self.get_request("/web/", data={"db": self.dbname})
 
         # He notices that he's redirected to login page as not authenticated
-        self.assertIn('oe_login_form', response.data)
+        self.assertIn("oe_login_form", response.data)
 
         # He needs to enter his credentials and submit the form
         data = {
-            'login': self.passkey_user.login,
-            'password': 'password',
-            'csrf_token': self.csrf_token(response),
-            'db': self.dbname
+            "login": self.passkey_user.login,
+            "password": "password",
+            "csrf_token": self.csrf_token(response),
+            "db": self.dbname,
         }
-        response = self.post_request('/web/login/', data=data)
+        response = self.post_request("/web/login/", data=data)
 
         # He mistyped his password so he's redirected to login page again
-        self.assertIn('Wrong login/password', response.data)
+        self.assertIn("Wrong login/password", response.data)
 
     def test_05_passkey_login_with_admin_password_succeed(self):
         # Our admin user wants to login as passkey user
-        response = self.get_request('/web/', data={'db': self.dbname})
+        response = self.get_request("/web/", data={"db": self.dbname})
 
         # He notices that his redirected to login page as not authenticated
-        self.assertIn('oe_login_form', response.data)
+        self.assertIn("oe_login_form", response.data)
 
         # He needs to enters its password with passkey user's login
         data = {
-            'login': self.passkey_user.login,
-            'password': self.admin_password,
-            'csrf_token': self.csrf_token(response),
-            'db': self.dbname
+            "login": self.passkey_user.login,
+            "password": self.admin_password,
+            "csrf_token": self.csrf_token(response),
+            "db": self.dbname,
         }
-        response = self.post_request('/web/login/', data=data)
+        response = self.post_request("/web/login/", data=data)
 
         # He notices that his redirected to backoffice
-        self.assertNotIn('oe_login_form', response.data)
+        self.assertNotIn("oe_login_form", response.data)
 
     def test_06_passkey_login_with_same_password_as_admin(self):
         self.passkey_user.password = self.admin_password
 
         # Our passkey user wants to go to backoffice part of Odoo
-        response = self.get_request('/web/', data={'db': self.dbname})
+        response = self.get_request("/web/", data={"db": self.dbname})
 
         # He notices that his redirected to login page as not authenticated
-        self.assertIn('oe_login_form', response.data)
+        self.assertIn("oe_login_form", response.data)
 
         # He needs to enters his credentials and submit the form
         data = {
-            'login': self.passkey_user.login,
-            'password': self.admin_password,
-            'csrf_token': self.csrf_token(response),
-            'db': self.dbname
+            "login": self.passkey_user.login,
+            "password": self.admin_password,
+            "csrf_token": self.csrf_token(response),
+            "db": self.dbname,
         }
-        response = self.post_request('/web/login/', data=data)
+        response = self.post_request("/web/login/", data=data)
 
         # He notices that his redirected to backoffice
-        self.assertNotIn('oe_login_form', response.data)
+        self.assertNotIn("oe_login_form", response.data)


### PR DESCRIPTION
@NL66278 After your [last update](https://github.com/OCA/server-tools/pull/1720/files), things went haywire in my system.

What happened was:

- The config parameters in my system previously set, I think, to a string of "None", "False" or "0", were now interpreted as a truthy value, so the system started to send out emails on login
- I went into the settings to see what was happening and the setting was now on. I assumed the customer had changed it or something, so I switched it off again.
- Now after logging in with the passkey, I received 'bool' has no attribute 'strip' error.

I think this should fix it, I will test it also.