### PR TITLE
[IMP] base_custom_info enable to easily import custom info values

### DIFF
--- a/base_custom_info/models/custom_info_value.py
+++ b/base_custom_info/models/custom_info_value.py
@@ -61,6 +61,7 @@ class CustomInfoValue(models.Model):
     required = fields.Boolean(related="property_id.required")
     value = fields.Char(
         compute="_compute_value",
+        inverse="_inverse_value",
         search="_search_value",
         help="Value, always converted to/from the typed field.",
     )


### PR DESCRIPTION
I use base_custom_info module a bit differently than its original plan. I combine properties from multiple templates to form product custom information like technical specs, params, ...  The values come from externals sources - I import them mostly. However as it stands now I'd need to write specific field depending on type (i.e. value_str, value_int, ...).
This simple change should allow for just writing into value field using already present _inverse_value function. I haven't found any side effects so far.