### PR TITLE
[14.0][IMP] upgrade_analysis: make us of odoorpc/openupgradelib master

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+odoorpc @ git+https://github.com/OCA/odoorpc.git@master
+openupgradelib @ git+https://github.com/OCA/openupgradelib.git@master

--- a/upgrade_analysis/blacklist.py
+++ b/upgrade_analysis/blacklist.py
@@ -2,7 +2,7 @@ BLACKLIST_MODULES = []
 
 # the hw_* modules are not affected by a migration as they don't
 # contain any ORM functionality, but they do start up threads that
-# delay the process and spit out annoying log messages continously.
+# delay the process and spit out annoying log messages continuously.
 
 # We also don't want to analyze tests modules
 BLACKLIST_MODULES_STARTS_WITH = ["hw_", "test_"]

--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -14,14 +14,14 @@ import copy
 try:
     from odoo.addons.openupgrade_scripts import apriori
 except ImportError:
-    from dataclasses import dataclass, field
+    from dataclasses import dataclass, field as dc_field
 
     @dataclass
     class NullApriori:
-        renamed_modules: dict = field(default_factory=dict)
-        merged_modules: dict = field(default_factory=dict)
-        renamed_models: dict = field(default_factory=dict)
-        merged_models: dict = field(default_factory=dict)
+        renamed_modules: dict = dc_field(default_factory=dict)
+        merged_modules: dict = dc_field(default_factory=dict)
+        renamed_models: dict = dc_field(default_factory=dict)
+        merged_models: dict = dc_field(default_factory=dict)
 
     apriori = NullApriori()
 

--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -430,7 +430,7 @@ class UpgradeAnalysis(models.Model):
                 raise ValidationError(
                     _(
                         "Unexpected root Element: %s in file: %s"
-                        % (tree.getroot(), xml_file)
+                        % (root_node.getroot(), xml_file)
                     )
                 )
             for node in root_node:

--- a/upgrade_analysis/odoo_patch/odoo_patch.py
+++ b/upgrade_analysis/odoo_patch/odoo_patch.py
@@ -54,7 +54,7 @@ class OdooPatch(object):
                 if hasattr(method, "_original_method"):
                     setattr(cls.target, method_name, method._original_method)
                 else:
-                    _logger.warn(
+                    _logger.warning(
                         "_original_method not found on method %s of class %s",
                         method_name,
                         cls.target,

--- a/upgrade_analysis/wizards/upgrade_install_wizard.py
+++ b/upgrade_analysis/wizards/upgrade_install_wizard.py
@@ -17,10 +17,6 @@ class UpgradeInstallWizard(models.TransientModel):
     _name = "upgrade.install.wizard"
     _description = "Upgrade Install Wizard"
 
-    name = fields.Char(
-        default=_description,
-        help="Workaround for https://github.com/OCA/odoorpc/issues/57",
-    )
     state = fields.Selection(
         [("draft", "Draft"), ("done", "Done")], readonly=True, default="draft"
     )
@@ -109,7 +105,6 @@ class UpgradeInstallWizard(models.TransientModel):
             "type": "ir.actions.act_window",
             "res_model": "upgrade.install.wizard",
             "view_mode": "form",
-            "view_type": "form",
             "res_id": self.id,
             "views": [(False, "form")],
             "target": "new",


### PR DESCRIPTION
It is always a good practice to use the last version (`master`) of OCA libraries, which are contin**u**ously maintained and thus not depend of pypi outdated versions.

Includes minor fixes.