### PR TITLE
[14.0][OU-MIG] upgrade_analysis: add migration scripts

### DIFF
--- a/upgrade_analysis/migrations/14.0.1.0.0/pre-migrate.py
+++ b/upgrade_analysis/migrations/14.0.1.0.0/pre-migrate.py
@@ -1,0 +1,27 @@
+# Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+_model_renames = [
+    ("openupgrade.analysis.wizard", "upgrade.analysis"),
+    ("openupgrade.attribute", "upgrade.attribute"),
+    ("openupgrade.comparison.config", "upgrade.comparison.config"),
+    ("openupgrade.record", "upgrade.record"),
+    ("openupgrade.generate.records.wizard", "upgrade.generate.record.wizard"),
+    ("openupgrade.install.all.wizard", "upgrade.install.wizard"),
+]
+
+_table_renames = [
+    ("openupgrade_analysis_wizard", "upgrade_analysis"),
+    ("openupgrade_attribute", "upgrade_attribute"),
+    ("openupgrade_comparison_config", "upgrade_comparison_config"),
+    ("openupgrade_record", "upgrade_record"),
+    ("openupgrade_generate_records_wizard", "upgrade_generate_record_wizard"),
+    ("openupgrade_install_all_wizard", "upgrade_install_wizard"),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_models(env.cr, _model_renames)
+    openupgrade.rename_tables(env.cr, _table_renames)

--- a/upgrade_analysis/readme/DESCRIPTION.rst
+++ b/upgrade_analysis/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
 This module provides the tool to generate the database analysis files that indicate how the Odoo data model and module data have changed between two versions of Odoo. Database analysis files for the core modules are included in the OpenUpgrade distribution so as a migration script developer you will not usually need to use this tool yourself. If you do need to run your analysis of a custom set of modules, please refer to the documentation here: https://doc.therp.nl/openupgrade/analysis.html
+
+This module is just a tool, a continuation of the old openupgrade_records in OpenUpgrade in previous versions. It's not recommended to have this module in a production database.


### PR DESCRIPTION
Just in case.

The module rename is added in https://github.com/OCA/OpenUpgrade/pull/2629.