### PR TITLE
[14.0][FIX] upgrade_analysis: fix methods related to noupdate data

### DIFF
--- a/upgrade_analysis/__manifest__.py
+++ b/upgrade_analysis/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Upgrade Analysis",
-    "summary": "performs a difference analysis between modules"
+    "summary": "Performs a difference analysis between modules"
     " installed on two different Odoo instances",
     "version": "14.0.2.0.1",
     "category": "Migration",
@@ -19,6 +19,7 @@
         "wizards/view_upgrade_install_wizard.xml",
     ],
     "installable": True,
+    "depends": ["base"],
     "external_dependencies": {
         "python": ["dataclasses", "odoorpc", "openupgradelib"],
     },

--- a/upgrade_analysis/models/upgrade_record.py
+++ b/upgrade_analysis/models/upgrade_record.py
@@ -1,6 +1,6 @@
 # Copyright 2011-2015 Therp BV <https://therp.nl>
 # Copyright 2016-2020 Opener B.V. <https://opener.am>
-# Copyright 2019 Eficent <https://eficent.com>
+# Copyright 2019 ForgeFlow <https://forgeflow.com>
 # Copyright 2020 GRAP <https://grap.coop>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -159,7 +159,7 @@ class UpgradeRecord(models.Model):
         # The order of the keys are important.
         # Load files in the same order as in
         # module/loading.py:load_module_graph
-        files = []
+        paths = []
         for key in ["init_xml", "update_xml", "data"]:
             if not manifest.get(key):
                 continue
@@ -167,6 +167,5 @@ class UpgradeRecord(models.Model):
                 if not xml_file.lower().endswith(".xml"):
                     continue
                 parts = xml_file.split("/")
-                with open(os.path.join(addon_dir, *parts), "r") as xml_handle:
-                    files.append(xml_handle.read())
-        return files
+                paths.append(os.path.join(addon_dir, *parts))
+        return paths

--- a/upgrade_analysis/readme/CONTRIBUTORS.rst
+++ b/upgrade_analysis/readme/CONTRIBUTORS.rst
@@ -3,5 +3,5 @@
 * Pedro M. Baeza <pedro.baeza@gmail.com>
 * Ferdinand Gassauer <gass@cc-l-12.chircar.at>
 * Florent Xicluna <florent.xicluna@gmail.com>
-* Miquel Raïch <miquel.raich@eficent.com>
+* Miquel Raïch <miquel.raich@forgeflow.com>
 * Sylvain LE GAL <https://twitter.com/legalsylvain>

--- a/upgrade_analysis/static/description/index.html
+++ b/upgrade_analysis/static/description/index.html
@@ -416,7 +416,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;gmail.com">pedro.baeza&#64;gmail.com</a>&gt;</li>
 <li>Ferdinand Gassauer &lt;<a class="reference external" href="mailto:gass&#64;cc-l-12.chircar.at">gass&#64;cc-l-12.chircar.at</a>&gt;</li>
 <li>Florent Xicluna &lt;<a class="reference external" href="mailto:florent.xicluna&#64;gmail.com">florent.xicluna&#64;gmail.com</a>&gt;</li>
-<li>Miquel Raïch &lt;<a class="reference external" href="mailto:miquel.raich&#64;eficent.com">miquel.raich&#64;eficent.com</a>&gt;</li>
+<li>Miquel Raïch &lt;<a class="reference external" href="mailto:miquel.raich&#64;forgeflow.com">miquel.raich&#64;forgeflow.com</a>&gt;</li>
 <li>Sylvain LE GAL &lt;<a class="reference external" href="https://twitter.com/legalsylvain">https://twitter.com/legalsylvain</a>&gt;</li>
 </ul>
 </div>

--- a/upgrade_analysis/wizards/upgrade_generate_record_wizard.py
+++ b/upgrade_analysis/wizards/upgrade_generate_record_wizard.py
@@ -25,6 +25,9 @@ class GenerateWizard(models.TransientModel):
 
         TODO: update module list and versions, then update all modules?"""
 
+        # Truncate the records table
+        self.env.cr.execute("TRUNCATE upgrade_attribute, upgrade_record;")
+
         # Check of all the modules are correctly installed
         modules = self.env["ir.module.module"].search(
             [("state", "in", ["to install", "to upgrade"])]


### PR DESCRIPTION
Last time I did the analysis I detected that the noupdate data code was broken and thus, not updated. The break of that is silenced, so I didn't see it. But with more time, I have been fixing that to make it works. It will also be needed https://github.com/OCA/OpenUpgrade/pull/2632 compatibility to make it work. The result is https://github.com/OCA/OpenUpgrade/pull/2631.

Errors fixed:
- ~~Method `list_modules` was returning a list of lists, which was wrong.~~
- Method `get_xml_records` was reading the files to get parsed later with `_parse_files`. That breaks when the xml file uses a different enconding than `utf-8`, like `data/account_chart_template_data.xml` in `l10n_ma`. In fact, the reading step proves to be unnecessary, as it can be parsed directly, that's what it does now (and what it was already doing in the script of v13).
- Also merged_modules of apriori was not being considered.

And then, I update my company name :P

~~Note: I also added the analysis.txt to justify the migration scripts haha~~