### PR TITLE
 [FIX+IMP] module_analysis : fix analysis during update and make update faster

### DIFF
--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -10,6 +10,7 @@
     'author': 'GRAP, Odoo Community Association (OCA)',
     'website': "https://github.com/OCA/server-tools",
     'version': '12.0.1.0.4',
+    'maintainers': ['legalsylvain'],
     'license': 'AGPL-3',
     'depends': [
         'base',

--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -22,6 +22,7 @@
         'views/view_ir_module_type.xml',
         'views/view_ir_module_type_rule.xml',
         'views/view_ir_module_module.xml',
+        'data/ir_cron.xml',
         'data/ir_config_parameter.xml',
         'data/ir_module_type.xml',
         'data/ir_module_type_rule.xml',

--- a/module_analysis/data/ir_cron.xml
+++ b/module_analysis/data/ir_cron.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2021-Today: GRAP (<http://www.grap.coop/>)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ -->
+
+<odoo noupdate="1">
+    <record id="cron_module_analysis" model="ir.cron">
+        <field name="name">Update Module Analysis</field>
+        <field name="active" eval="True"/>
+        <field name="model_id" ref="base.model_ir_module_module"/>
+        <field name="state">code</field>
+        <field name="code">model.cron_analyse_code()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="nextcall" eval="(DateTime.today()).strftime('%Y-%m-%d')"/>
+        <field name="numbercall">-1</field>
+        <field name="user_id" ref="base.user_root"/>
+    </record>
+</odoo>

--- a/module_analysis/post_init_hook.py
+++ b/module_analysis/post_init_hook.py
@@ -8,6 +8,7 @@ from odoo import api, SUPERUSER_ID
 def analyse_installed_modules(cr, registry):
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})
-        installed_modules = env['ir.module.module'].search(
-            [('state', '=', 'installed')])
+        installed_modules = env['ir.module.module'].search([
+            '|', ('state', '=', 'installed'), ('name', '=', 'module_analysis')
+        ])
         installed_modules.button_analyse_code()

--- a/module_analysis/readme/CONFIGURE.rst
+++ b/module_analysis/readme/CONFIGURE.rst
@@ -14,7 +14,7 @@ developped for exemple,
     .. image:: ../static/description/add_module_type_rules.png
 
 
-to update the data, you have to :
+to update the data manually, you have to :
 
 * Go to 'Apps' / 'Update Apps List'
 
@@ -23,6 +23,12 @@ to update the data, you have to :
     .. image:: ../static/description/base_module_update.png
 
 This will update analysis of your installed modules.
+
+to update the data automatically, you have to :
+
+* Go to 'Settings' / 'Technical' / 'Scheduled Actions'
+
+* Configure the action 'Update Module Analysis'. (By default, the analysis will be done nightly)
 
 
 Adding Extra data

--- a/module_analysis/tests/test_module.py
+++ b/module_analysis/tests/test_module.py
@@ -3,9 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.modules.module import get_module_path
-from odoo.tests.common import TransactionCase, post_install
+from odoo.tests.common import TransactionCase, at_install, post_install
 
 
+@at_install(False)
 @post_install(True)
 class TestModule(TransactionCase):
 


### PR DESCRIPTION
**Rational**

for the time being (before this patch), the update of the analysis is done manually (by Update module List) AND when an update of modules is done (update all, or partial update).
The second analysis is not OK : 
- It is incorrect, because it is partial : module loaded before ``module_analysis`` module are not correctly analysed, due to Odoo design. So for exemple, ``base`` module is never analysed that way.
- It makes the update process slower.

**Description of the PR**
- Remove analysis when updating modules, 

- Add instead a cron task that is executed nightly to update analysis automatically and fully.

thanks for your review