### PR TITLE
 [IMP] sql_export : add preview button

### DIFF
--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -8,6 +8,7 @@
                 <header>
                     <button name="button_validate_sql_expression" type="object" states="draft"
                             string="Validate SQL Expression" class="oe_highlight"/>
+                    <button name="button_preview_sql_expression" type="object" states="draft" string="Preview Results" attrs="{'invisible': [('field_ids', '!=', False)]}"/>
                     <button name="button_set_draft" type="object" states="sql_valid"
                             string="Set to Draft" groups="sql_request_abstract.group_sql_request_manager"/>
                     <button name="export_sql_query" string="Execute Query" states="sql_valid" type="object" class="oe_highlight"

--- a/sql_request_abstract/models/sql_request_mixin.py
+++ b/sql_request_abstract/models/sql_request_mixin.py
@@ -270,3 +270,9 @@ class SQLRequestMixin(models.AbstractModel):
         """
         self.ensure_one()
         return False
+
+    @api.multi
+    def button_preview_sql_expression(self):
+        self.button_validate_sql_expression()
+        res = self._execute_sql_request()
+        raise UserError('\n'.join(map(lambda x: str(x), res[:100])))


### PR DESCRIPTION
Add a preview button.

![image](https://user-images.githubusercontent.com/3407482/113444373-0cbdca00-93f4-11eb-99d1-be4ae6ddc7df.png)

When clicking, you'll have a quick preview of your request.


![image](https://user-images.githubusercontent.com/3407482/113444505-50b0cf00-93f4-11eb-99fe-ba750f73c317.png)



CC : original commiters : @florian-dacosta , @bealdav, @bguillot 
CC : @quentinDupont