### PR TITLE
[WIP][ADD] safe translations

### DIFF
--- a/base_safe_translations/__init__.py
+++ b/base_safe_translations/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/base_safe_translations/__manifest__.py
+++ b/base_safe_translations/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Safe Translations",
+    "description": """Minimize the risks to break things while translating.""",
+    "version": "12.0.1.0.0",
+    "depends": ["base"],
+    "author": "ACSONE SA/NV",
+    "website": "http://www.acsone.eu",
+    "license": "AGPL-3",
+    "category": "Localization",
+    "data": ["views/ir_translation_views.xml"],
+    "demo": [],
+    "installable": True,
+}

--- a/base_safe_translations/models/__init__.py
+++ b/base_safe_translations/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_translation

--- a/base_safe_translations/models/ir_translation.py
+++ b/base_safe_translations/models/ir_translation.py
@@ -1,0 +1,47 @@
+# Copyright 2021 ACSONE SA/NV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import re
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class IrTranslation(models.Model):
+    _inherit = "ir.translation"
+
+    @api.constrains("source", "value")
+    def _constrains_value(self):
+        """In general we allow to have different html structure... TODO"""
+        if not self.env.context.get("skip_translations_checks"):
+            for term in self:
+                if term.value:
+                    term._check_new_formatting()
+                    term._check_old_formatting()
+                    term._check_html()
+
+    def _check_html(self):
+        regex = re.compile(r"<.+?>")
+        msg = _("There is a discrepancy in html tags.")
+        self._check_regex_matches(regex, msg)
+
+    def _check_new_formatting(self):
+        regex = re.compile(r"{.*?}")
+        msg = _("There is a discrepancy in new format string variables.")
+        self._check_regex_matches(regex, msg)
+
+    def _check_old_formatting(self):
+        regex = re.compile(r"%(?:\(\w+\))?[dsr]", re.ASCII)
+        msg = _("There is a discrepancy in old format string variables.")
+        self._check_regex_matches(regex, msg)
+
+    def _check_regex_matches(self, regex, msg):
+        self.ensure_one()
+        src_matches = regex.findall(self.src)
+        dst_matches = regex.findall(self.value)
+        correct = len(src_matches) == len(dst_matches)
+        correct &= all(s == d for s, d in zip(src_matches, dst_matches))
+        if not correct:
+            msg_source = _("Source: %s") % self.src
+            msg_value = _("Value: %s") % self.value
+            raise ValidationError("\n".join([msg, msg_source, msg_value]))

--- a/base_safe_translations/tests/__init__.py
+++ b/base_safe_translations/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_translate

--- a/base_safe_translations/tests/common.py
+++ b/base_safe_translations/tests/common.py
@@ -1,0 +1,30 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import SavepointCase
+
+
+class TestTranslations(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestTranslations, cls).setUpClass()
+        domain_fr = [("code", "=", "fr_FR")]
+        cls.lang = cls.env["res.lang"].with_context(active_test=False).search(domain_fr)
+        cls.lang.active = True
+        cls.env["ir.translation"].load_module_terms(["base"], [cls.lang.code])
+
+        def _irt(src, value, **params):
+            model = cls.env["ir.translation"]
+            if "context" in params:
+                model = model.with_context(params.pop("context"))
+            vals_base = {
+                "type": "code",
+                "name": "res.partner,signature",
+                "module": "base_safe_translations_check",
+                "lang": cls.lang.code,
+                "state": "translated",
+            }
+            vals = {**vals_base, "src": src, "value": value, **params}
+            return model.create(vals)
+
+        cls._create_ir_translation = lambda self, *args, **kwargs: _irt(*args, **kwargs)

--- a/base_safe_translations/tests/test_translate.py
+++ b/base_safe_translations/tests/test_translate.py
@@ -1,0 +1,63 @@
+# Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+
+from .common import TestTranslations
+
+
+class TestConstraints(TestTranslations):
+    def test_nothing(self):
+        # there is nothing, it should not cause any issue anyway
+        self._create_ir_translation("Text.", "Texte.")
+
+    def test_new_style_formatting(self):
+        # modified internal formatting
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text {:0f}.", "Texte { :0f}.")
+        # extraneous formatting argument
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text.", "Texte {:0f}.")
+        # missing formatting argument
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text {}.", "Texte.")
+        # inverted formatting arguments
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text {:0f} {}.", "Texte {} .{:0f}")
+
+        # This works.
+        self._create_ir_translation("Text {:2f} and {}.", "Texte {:2f} et {}.")
+
+    def test_old_style_formatting(self):
+        # modified internal formatting
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text %s.", "Texte %d.")
+        # extraneous formatting argument
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text.", "Texte %s.")
+        # missing formatting argument
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text %d.", "Texte.")
+        # inverted formatting arguments
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text %s %d.", "Texte %d %s")
+
+        # This works.
+        self._create_ir_translation("Text %d and %s.", "Texte %d et %s.")
+
+    def test_html_tags(self):
+        # modified internal formatting
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("<i>Text</i>.", "<b>Texte<b>.")
+        # extraneous formatting argument
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("Text.", "<i>Text</i>.")
+        # missing formatting argument
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("<b>Text</b>.", "Texte.")
+        # inverted formatting arguments
+        with self.assertRaises(ValidationError):
+            self._create_ir_translation("<b><i>Text</i></b>.", "<i><b>Text</b></i>")
+
+        # This works.
+        self._create_ir_translation("<i><b>Text</b></i>", "<i><b>Texte</b></i>")

--- a/base_safe_translations/views/ir_translation_views.xml
+++ b/base_safe_translations/views/ir_translation_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 ACSONE SA/NV.
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="action_translation_unsafe" model="ir.actions.act_window">
+        <field name="name">Translated Terms (Unsafe)</field>
+        <field name="res_model">ir.translation</field>
+        <field name="view_type">form</field>
+        <field name="view_id" ref="base.view_translation_tree" />
+        <field name="context">{'skip_translations_checks': True}</field>
+    </record>
+
+    <menuitem
+    action="action_translation_unsafe"
+    id="menu_action_translation_unsafe"
+    parent="base.menu_translation_app"
+  />
+</odoo>

--- a/base_safe_translations_check/__init__.py
+++ b/base_safe_translations_check/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/base_safe_translations_check/__manifest__.py
+++ b/base_safe_translations_check/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Safe Translations Check",
+    "description": """Check all database translations for errors.""",
+    "version": "12.0.1.0.0",
+    "depends": ["base_safe_translations", "queue_job"],
+    "author": "ACSONE SA/NV",
+    "website": "http://www.acsone.eu",
+    "license": "AGPL-3",
+    "category": "Localization",
+    "data": ["wizard/ir_translation_safe_wizard.xml"],
+    "demo": [],
+    "installable": True,
+}

--- a/base_safe_translations_check/models/__init__.py
+++ b/base_safe_translations_check/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_translation

--- a/base_safe_translations_check/models/ir_translation.py
+++ b/base_safe_translations_check/models/ir_translation.py
@@ -1,0 +1,23 @@
+# Copyright 2021 ACSONE SA/NV.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+from odoo.exceptions import ValidationError
+
+from odoo.addons.queue_job.job import job
+
+
+class IrTranslation(models.Model):
+    _inherit = "ir.translation"
+
+    @job(default_channel="root.check_translations")
+    def jobify_check_constraints(self):
+        """Process translations one by one, to make it easy to process."""
+        if len(self) > 1:
+            try:
+                self[0].jobify_check_constraints()
+            except ValidationError:  # if that failed, create a job to get it checked.
+                self[0].with_delay().jobify_check_constraints()
+            self[1:].with_delay().jobify_check_constraints()
+        else:
+            self._validate_fields(self._fields)

--- a/base_safe_translations_check/tests/__init__.py
+++ b/base_safe_translations_check/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_wizard

--- a/base_safe_translations_check/tests/common.py
+++ b/base_safe_translations_check/tests/common.py
@@ -1,0 +1,17 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.base_safe_translations.tests.common import TestTranslations
+
+
+class TestTranslationsWizard(TestTranslations):
+    @classmethod
+    def setUpClass(cls):
+        super(TestTranslationsWizard, cls).setUpClass()
+        cls.translated_term = cls._create_ir_translation(
+            False, "Oh {}", "Ho {}", module="base_safe_translations_check"
+        )
+        # we force a wrong translation in database
+        query = 'UPDATE ir_translation SET "value"=%s WHERE id = %s'
+        params = ("Ho non", cls.translated_term.id)
+        cls.env.cr.execute(query, params)

--- a/base_safe_translations_check/tests/test_wizard.py
+++ b/base_safe_translations_check/tests/test_wizard.py
@@ -1,0 +1,30 @@
+# Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tools import mute_logger
+
+from .common import TestTranslationsWizard
+
+
+class TestTranslationsWizardFlow(TestTranslationsWizard):
+    @mute_logger("odoo.addons.queue_job.models.base")
+    def test_faulty_translation(self):
+        lang = self.env.ref("base.lang_fr")
+        vals = {"module": "base_safe_translations_check", "lang_id": lang.id}
+        wizard = self.env["ir.translation.safe.wizard"].create(vals)
+
+        with self.assertRaises(ValidationError):
+            wizard.with_context(test_queue_job_no_delay=True)._execute()
+
+    @mute_logger("odoo.addons.queue_job.models.base")
+    def test_all_right(self):
+        module = "module"
+        module_name = "base_safe_translations"
+        domain = [("value", "not in", [False, ""]), (module, "=", module_name)]
+        translations_nmbr = self.env["ir.translation"].search_count(domain)
+        wizard = self.env["ir.translation.safe.wizard"].create({module: module_name})
+
+        res = wizard.with_context(test_queue_job_no_delay=True)._execute()
+
+        self.assertEqual(len(res), translations_nmbr)

--- a/base_safe_translations_check/wizard/__init__.py
+++ b/base_safe_translations_check/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_translation_safe_wizard

--- a/base_safe_translations_check/wizard/ir_translation_safe_wizard.py
+++ b/base_safe_translations_check/wizard/ir_translation_safe_wizard.py
@@ -1,0 +1,37 @@
+# Copyright 2021 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class IrTranslationSafeWizard(models.TransientModel):
+
+    _name = "ir.translation.safe.wizard"
+    _description = "Wizard to check existing translations."
+
+    @api.model
+    def _compute_module_selection(self):
+        modules = self.env["ir.module.module"].search([])
+        return modules.mapped(lambda m: (m.name, m.shortdesc))
+
+    module = fields.Selection(selection=_compute_module_selection)
+    lang_id = fields.Many2one(
+        string="lang",
+        comodel_name="res.lang",
+        help="If set, only checks translation in that language",
+    )
+
+    def execute(self):
+        self._execute()
+
+    def _execute(self):
+        self.ensure_one()
+        domain = [("value", "not in", [False, ""])]
+        if self.module:
+            domain.append(("module", "=", self.module))
+        if self.lang_id:
+            domain.append(("lang", "=", self.lang_id.code))
+        translations = self.env["ir.translation"].search(domain)
+        # for translation in translations:
+        translations.with_delay().jobify_check_constraints()
+        return translations

--- a/base_safe_translations_check/wizard/ir_translation_safe_wizard.xml
+++ b/base_safe_translations_check/wizard/ir_translation_safe_wizard.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="ir_translation_safe_wizard_form_view">
+        <field name="name">ir.translation.safe.wizard.form</field>
+        <field name="model">ir.translation.safe.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Preinvoice Contract">
+                <group>
+                    <field name="lang_id" />
+                    <field name="module" />
+                </group>
+                <footer>
+                    <button
+            name="execute"
+            class="btn btn-primary"
+            type="object"
+            string="Check Translations"
+          />
+                    <button special="cancel" string="Cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="ir_translation_safe_wizard_act_window">
+        <field name="name">Check Existing Translations</field>
+        <field name="res_model">ir.translation.safe.wizard</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+    <menuitem
+    name="Check Existing Translations"
+    action="ir_translation_safe_wizard_act_window"
+    id="ir_check_translations_menu"
+    parent="base.menu_translation"
+    sequence="90"
+  />
+</odoo>


### PR DESCRIPTION
Translations can break business flows if there are mistakes in formatting arguments. Moreover, they can be broken because of invisible symbols, and the flows need to be checked in all relevant languages, making it these issues hard to detect before then are actually break something. 
These two modules add the following:
- check that formatting arguments are the same in source and translation
- add a view to bypass the constraint, for correct translations known to be caught by the strict heuristic
- add a wizard to check existing translations (using queue_job)

The heuristic is extremely simple: for each of old formatting (`%s`), new formatting (`{:0f}`) and html tags, we check that we have exactly the same matches on the left and on the right.

This creates a lot more false-positives for the html tags, although it finds some real errors. It should probably be an optional parameter for the wizard only, or removed entirely. The check should be that the tree structures are isomorphic (excepting string attributes) but it does not seem worth the trade-off in reward/complexity.