### PR TITLE
 [FIX] sql_export_excel: add missing dependency to python lib openpyxl

### DIFF
--- a/sql_export_excel/__manifest__.py
+++ b/sql_export_excel/__manifest__.py
@@ -12,6 +12,11 @@
     'depends': [
         'sql_export',
     ],
+    'external_dependencies': {
+        'python': [
+            'openpyxl',
+        ],
+    },
     'data': [
         'views/sql_export_view.xml',
     ],


### PR DESCRIPTION
trivial PR to add dependency to required python lib.

CC : @florian-dacosta, @quentinDupont 

GRAP : apps/deck/#/board/144/card/1376