### PR TITLE
[13.0][FIX] base_exception: import correctly osv.expression

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -7,8 +7,9 @@
 import html
 import time
 
-from odoo import _, api, fields, models, osv
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -115,7 +116,7 @@ class BaseExceptionMethod(models.AbstractModel):
         # Cumulate all the records to attach to the rule
         # before linking. We don't want to call "rule.write()"
         # which would:
-        # * write on write_date so lock the expection.rule
+        # * write on write_date so lock the exception.rule
         # * trigger the recomputation of "main_exception_id" on
         #   all the sale orders related to the rule, locking them all
         #   and preventing concurrent writes
@@ -141,7 +142,7 @@ class BaseExceptionMethod(models.AbstractModel):
             "object": rec,
             "obj": rec,
             # copy context to prevent side-effects of eval
-            # should be deprecated too, accesible through self.
+            # should be deprecated too, accessible through self.
             "context": self.env.context.copy(),
         }
 
@@ -155,7 +156,7 @@ class BaseExceptionMethod(models.AbstractModel):
             )  # nocopy allows to return 'result'
         except Exception as e:
             raise UserError(
-                _("Error when evaluating the exception.rule " "rule:\n %s \n(%s)")
+                _("Error when evaluating the exception.rule rule:\n %s \n(%s)")
                 % (rule.name, e)
             )
         return space.get("failed", False)
@@ -187,7 +188,7 @@ class BaseExceptionMethod(models.AbstractModel):
         """
         base_domain = self._get_base_domain()
         rule_domain = rule._get_domain()
-        domain = osv.expression.AND([base_domain, rule_domain])
+        domain = expression.AND([base_domain, rule_domain])
         return self.search(domain)
 
 


### PR DESCRIPTION
When doing `osv.expression`, python assumes that the `__init__.py` file in the `odoo/osv` folder contains a `from . import expression` call, but this is not the case. Thus, the correct way is importing the `expression` instead of the `osv` (also because `import osv` leads to confusion, there is an `osv.py` in the `odoo/osv` folder).