### PR TITLE
[14.0][FIX] base_report_auto_create_qweb, conflict test report name

### DIFF
--- a/base_report_auto_create_qweb/tests/test_base_report_auto_create_qweb.py
+++ b/base_report_auto_create_qweb/tests/test_base_report_auto_create_qweb.py
@@ -18,7 +18,7 @@ class TestBaseReportAutoQwebCreate(common.TransactionCase):
                 "name": "Test 1",
                 "model": "res.partner",
                 "report_type": "qweb-html",
-                "report_name": "test1.report_test",
+                "report_name": "test1.auto_qweb_report_test",
             }
         )
         report_html.button_create_qweb()
@@ -37,7 +37,7 @@ class TestBaseReportAutoQwebCreate(common.TransactionCase):
                 "name": "Test 2",
                 "model": "res.partner",
                 "report_type": "qweb-pdf",
-                "report_name": "test2.report_test",
+                "report_name": "test2.auto_qweb_report_test",
             }
         )
         report_pdf.button_create_qweb()


### PR DESCRIPTION
If module `product` is installed, the test will not pass, because keyword "report_test" in https://github.com/odoo/odoo/blob/14.0/addons/product/views/product_templates.xml#L11

Which result in test error,

```
  File "/opt/odoo/auto/addons/base_report_auto_create_qweb/tests/test_base_report_auto_create_qweb.py", line 42, in test_creation_html
    self.assertEqual(view_num, 1, "Only one view must be created.")
AssertionError: 2 != 1 : Only one view must be created.
```

Just ensure that, the report name in test is unique.