### PR TITLE
[IMP] database_cleanup : delete also obsolete database views

### DIFF
--- a/database_cleanup/models/purge_tables.py
+++ b/database_cleanup/models/purge_tables.py
@@ -4,6 +4,13 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from ..identifier_adapter import IdentifierAdapter
+from psycopg2.extensions import AsIs
+
+
+_TABLE_TYPE_SELECTION = [
+    ('base', 'SQL Table'),
+    ('view', 'SQL View'),
+]
 
 
 class CleanupPurgeLineTable(models.TransientModel):
@@ -13,6 +20,10 @@ class CleanupPurgeLineTable(models.TransientModel):
 
     wizard_id = fields.Many2one(
         'cleanup.purge.wizard.table', 'Purge Wizard', readonly=True)
+
+    table_type = fields.Selection(
+        string='Table Type', selection=_TABLE_TYPE_SELECTION
+    )
 
     @api.multi
     def purge(self):
@@ -63,10 +74,17 @@ class CleanupPurgeLineTable(models.TransientModel):
                             IdentifierAdapter(constraint[0])
                         ))
 
+            if line.table_type == 'base':
+                _sql_type = "TABLE"
+            elif line.table_type == 'view':
+                _sql_type = "VIEW"
             self.logger.info(
-                'Dropping table %s', line.name)
+                'Dropping %s %s', (_sql_type, line.name))
             self.env.cr.execute(
-                "DROP TABLE %s", (IdentifierAdapter(line.name),))
+                "DROP %s %s", (
+                    AsIs(_sql_type),
+                    IdentifierAdapter(line.name),)
+            )
             line.write({'purged': True})
         return True
 
@@ -79,8 +97,7 @@ class CleanupPurgeWizardTable(models.TransientModel):
     @api.model
     def find(self):
         """
-        Search for tables that cannot be instantiated.
-        Ignore views for now.
+        Search for tables and views that cannot be instantiated.
         """
         known_tables = []
         for model in self.env['ir.model'].search([]):
@@ -98,11 +115,15 @@ class CleanupPurgeWizardTable(models.TransientModel):
 
         self.env.cr.execute(
             """
-            SELECT table_name FROM information_schema.tables
-            WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+            SELECT table_name, table_type FROM information_schema.tables
+            WHERE table_schema = 'public'
+            AND table_type in ('BASE TABLE', 'VIEW')
             AND table_name NOT IN %s""", (tuple(known_tables),))
 
-        res = [(0, 0, {'name': row[0]}) for row in self.env.cr.fetchall()]
+        res = [(0, 0, {
+            'name': row[0],
+            'table_type': "base" if row[1] == "BASE TABLE" else "view"
+        }) for row in self.env.cr.fetchall()]
         if not res:
             raise UserError(_('No orphaned tables found'))
         return res

--- a/database_cleanup/views/purge_tables.xml
+++ b/database_cleanup/views/purge_tables.xml
@@ -24,7 +24,9 @@
         <field name="inherit_id" ref="tree_purge_line" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <data />
+            <field name="name" position="after">
+                <field name="table_type"/>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
**Context**

- database migrated with openupgrade from 8.0 to 12.0.
when trying to cleanup the database, some tables are not dropable, for exemple ``stock_quant_move_rel`` with the following errors : 

```cannot drop table stock_quant_move_rel because other objects depend on it
DETAIL:  view stock_history depends on table stock_quant_move_rel
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
```

this PR improve the concept purge tables to also purges obsoletes views.

**sample**

![image](https://user-images.githubusercontent.com/3407482/120396634-34b7a400-c337-11eb-9e68-2407b5780a65.png)

**Note**

Materialized views are still not handled.
