### PR TITLE
[14.0][IMP] auditlog, add auditlog.report view

### DIFF
--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -15,6 +15,7 @@
         "views/auditlog_view.xml",
         "views/http_session_view.xml",
         "views/http_request_view.xml",
+        "report/auditlog_report.xml",
     ],
     "application": True,
     "installable": True,

--- a/auditlog/readme/CONTRIBUTORS.rst
+++ b/auditlog/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Stefan Rijnhart <stefan@opener.amsterdam>
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * Hardik Suthar <hsuthar@opensourceintegrators.com>
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/auditlog/report/__init__.py
+++ b/auditlog/report/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import report
+from . import auditlog_report

--- a/auditlog/report/auditlog_report.py
+++ b/auditlog/report/auditlog_report.py
@@ -1,0 +1,63 @@
+# Copyright 2021 Ecosoft Co., Ltd. <http://ecosoft.co.th>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AuditlogReport(models.Model):
+    _name = "auditlog.report"
+    _description = "Audit Log Report"
+    _auto = False
+    _order = "id desc"
+
+    # Logs
+    create_date = fields.Datetime()
+    name = fields.Char(string="Resource Name")
+    model_id = fields.Many2one(
+        comodel_name="ir.model",
+        string="Model",
+        readonly=True,
+    )
+    model_name = fields.Char(readonly=True)
+    model_model = fields.Char(string="Technical Model Name", readonly=True)
+    res_id = fields.Integer(string="Resource ID", readonly=True)
+    user_id = fields.Many2one(comodel_name="res.users", string="User", readonly=True)
+    method = fields.Char(readonly=True)
+    http_session_id = fields.Many2one("auditlog.http.session", string="Session")
+    http_request_id = fields.Many2one("auditlog.http.request", string="HTTP Request")
+    log_type = fields.Selection(
+        selection=[("full", "Full log"), ("fast", "Fast log")],
+        string="Type",
+        readonly=True,
+    )
+    # Lines
+    field_id = fields.Many2one(
+        comodel_name="ir.model.fields",
+        string="Field",
+        readonly=True,
+    )
+    old_value = fields.Text(
+        readonly=True,
+    )
+    new_value = fields.Text(
+        readonly=True,
+    )
+    old_value_text = fields.Text(string="Change From", readonly=True)
+    new_value_text = fields.Text(string="Change To", readonly=True)
+    field_name = fields.Char(string="Technical Field Name", readonly=True)
+    field_description = fields.Char(string="Field Name", readonly=True)
+
+    @property
+    def _table_query(self):
+        return self._query()
+
+    def _query(self):
+        select_str = """
+            SELECT l.id, a.id as log_id, a.create_date, a.name, a.model_id, a.model_name,
+                a.model_model, a.res_id, a.user_id, a.method,
+                a.http_session_id, a.http_request_id, a.log_type,
+                l.field_id, l.old_value, l.new_value, l.old_value_text,
+                l.new_value_text, l.field_name, l.field_description
+            FROM auditlog_log a join auditlog_log_line l on (l.log_id=a.id)
+        """
+        return select_str

--- a/auditlog/report/auditlog_report.xml
+++ b/auditlog/report/auditlog_report.xml
@@ -1,0 +1,100 @@
+<odoo>
+    <record model="ir.ui.view" id="view_auditlog_report_tree">
+        <field name="name">view.auditlog.report.tree</field>
+        <field name="model">auditlog.report</field>
+        <field name="arch" type="xml">
+            <tree string="Auditlog Report">
+                <field name="create_date" optional="show" />
+                <field name="user_id" optional="show" />
+                <field name="http_session_id" optional="hide" />
+                <field name="http_request_id" optional="hide" />
+                <field name="name" optional="show" />
+                <field name="model_id" optional="hide" />
+                <field name="model_model" optional="hide" />
+                <field name="model_name" optional="hide" />
+                <field name="field_id" optional="hide" />
+                <field name="field_name" optional="hide" />
+                <field name="field_description" optional="show" />
+                <field name="old_value" optional="hide" />
+                <field name="new_value" optional="hide" />
+                <field name="old_value_text" optional="show" />
+                <field name="new_value_text" optional="show" />
+                <field name="log_type" optional="hide" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_auditlog_report_search" model="ir.ui.view">
+        <field name="name">auditlog.report.search</field>
+        <field name="model">auditlog.report</field>
+        <field name="arch" type="xml">
+            <search string="Logs Report">
+                <field name="name" />
+                <field name="model_id" />
+                <field name="res_id" />
+                <field name="user_id" />
+                <group expand="0" string="Group By...">
+                    <filter
+                        name="group_by_user_id"
+                        string="User"
+                        domain="[]"
+                        context="{'group_by':'user_id'}"
+                    />
+                    <filter
+                        name="group_by_model_id"
+                        string="Model"
+                        domain="[]"
+                        context="{'group_by':'model_id'}"
+                    />
+                    <filter
+                        name="group_by_field_id"
+                        string="Field"
+                        domain="[]"
+                        context="{'group_by':'field_id'}"
+                    />
+                    <filter
+                        name="group_by_res_id"
+                        string="Resource ID"
+                        domain="[]"
+                        context="{'group_by':'res_id'}"
+                    />
+                    <filter
+                        name="group_by_create_date"
+                        string="Date"
+                        domain="[]"
+                        context="{'group_by':'create_date'}"
+                    />
+                    <filter
+                        name="group_by_http_session"
+                        string="User session"
+                        domain="[]"
+                        context="{'group_by':'http_session_id'}"
+                    />
+                    <filter
+                        name="group_by_http_request"
+                        string="HTTP Request"
+                        domain="[]"
+                        context="{'group_by':'http_request_id'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_auditlog_report" model="ir.actions.act_window">
+        <field name="name">Auditlog Report</field>
+        <field name="res_model">auditlog.report</field>
+        <field name="view_mode">tree</field>
+        <field name="search_view_id" ref="view_auditlog_report_search" />
+        <field name="context">{'search_default_group_by_model_id': 1}</field>
+    </record>
+
+    <menuitem
+        id="menu_auditlog_report"
+        name="Logs Report"
+        parent="menu_audit"
+        action="action_auditlog_report"
+        sequence="20"
+    />
+
+</odoo>

--- a/auditlog/security/ir.model.access.csv
+++ b/auditlog/security/ir.model.access.csv
@@ -11,3 +11,5 @@ access_auditlog_log_line_manager,auditlog_log_line_manager,model_auditlog_log_li
 access_auditlog_http_session_manager,auditlog_http_session_manager,model_auditlog_http_session,base.group_erp_manager,1,1,1,1
 access_auditlog_http_request_manager,auditlog_http_request_manager,model_auditlog_http_request,base.group_erp_manager,1,1,1,1
 access_auditlog_autovacuum,access_auditlog_autovacuum,model_auditlog_autovacuum,base.group_user,1,1,1,1
+
+access_auditlog_report_user,auditlog.report user,model_auditlog_report,base.group_user,1,0,0,0


### PR DESCRIPTION
* Add new menu "Logs Report", for **auditlog.report** view that join between log and log.line
* So that, it is possible to create simple server action to see all logs like following,

![image](https://user-images.githubusercontent.com/1973598/122577344-def43300-d07c-11eb-91ed-8cfd54025de9.png)

**Note:** example server action code for `purchase.order`

```
res = env.ref('auditlog.action_auditlog_report').sudo().read()[0]
res['domain'] = ['&', ('field_name', 'in', ['price_unit', 'name', 'partner_id', 'product_id', 'date_order']),  # limit fields to view
                 '|',
                 '&', ('model_model', '=', 'purchase.order'), ('res_id', '=', record.id),  # purchase.order log
                 '&', ('model_model', '=', 'purchase.order.line'), ('res_id', 'in', record.order_line.ids)]  # purchase.order.line log
action = res
```


