### PR TITLE
[IMP] mass_editing: Add apply domain option in lines to fix some many2one fields with default domain (company_id for example)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   # Install libraries that require specific development headers, but not during lint test
-  - if ! [ "$LINT_CHECK" = "1" ]; then pip install "pymssql<3.0" MySQL-python pyodbc; fi
+  - if ! [ "$LINT_CHECK" = "1" ]; then pip install "pymssql<=2.1.5" MySQL-python pyodbc; fi
   - printf '[options]\n\nrunning_env = dev\n' > ${HOME}/.openerp_serverrc
   - ln -s ${TRAVIS_BUILD_DIR}/server_environment_files_sample ${TRAVIS_BUILD_DIR}/server_environment_files
 script:

--- a/mass_editing/models/mass_editing.py
+++ b/mass_editing/models/mass_editing.py
@@ -82,7 +82,7 @@ class MassEditing(models.Model):
             'groups_id': [(4, x.id) for x in self.group_ids],
             'view_type': 'form',
             'context': "{'mass_editing_object' : %d}" % (self.id),
-            'view_mode': 'form, tree',
+            'view_mode': 'form,tree',
             'target': 'new',
         }).id
         # We make sudo as any user with rights in this model should be able

--- a/mass_editing/models/mass_editing.py
+++ b/mass_editing/models/mass_editing.py
@@ -39,6 +39,14 @@ class MassEditing(models.Model):
         column2="group_id",
         string="Groups",
     )
+    apply_domain_in_lines = fields.Boolean(
+        string="Apply domain in lines", compute="_compute_apply_domain_in_lines"
+    )
+
+    @api.depends("line_ids")
+    def _compute_apply_domain_in_lines(self):
+        for record in self:
+            record.apply_domain_in_lines = any(record.line_ids.mapped("apply_domain"))
 
     _sql_constraints = [
         ('name_uniq', 'unique (name)', _('Name must be unique!')),

--- a/mass_editing/models/mass_editing_line.py
+++ b/mass_editing/models/mass_editing_line.py
@@ -38,6 +38,11 @@ class MassEditingLine(models.Model):
         " to display the field in the wizard. Example :\n"
         "'many2many_tags', 'selection'",
     )
+    apply_domain = fields.Boolean(
+        default=False,
+        string="Apply domain",
+        help="Apply default domain related to field",
+    )
 
     @api.depends("field_id")
     def _compute_widget_option(self):

--- a/mass_editing/readme/CONTRIBUTORS.rst
+++ b/mass_editing/readme/CONTRIBUTORS.rst
@@ -1,5 +1,9 @@
 * Oihane Crucelaegui <oihanecrucelaegi@gmail.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
-* Jairo Llopis <jairo.llopis@tecnativa.com>
 * Raul Martin <raul.martin@braintec-group.com>
 * Simone Vanin <simone.vanin@agilebg.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_
+
+  * Jairo Llopis
+  * Víctor Martínez

--- a/mass_editing/views/mass_editing_view.xml
+++ b/mass_editing/views/mass_editing_view.xml
@@ -48,8 +48,18 @@
                                         <field name="sequence" widget="handle"/>
                                         <field name="field_id"/>
                                         <field name="widget_option"/>
+                                        <field name="apply_domain" />
                                     </tree>
                                 </field>
+                                <field name="apply_domain_in_lines" invisible="1" />
+                                <div
+                                    colspan="2"
+                                    class="text-warning"
+                                    attrs="{'invisible': [('apply_domain_in_lines','=', False)]}"
+                                >
+                                    <b
+                                    >WARNING</b>: Take into account that adding a field with a domain, and not including the fields of such domain in this operation definition, will lead to an error when trying to perform it. Make sure you include them.
+                                </div>
                             </group>
                         </page>
                         <page string="Security">

--- a/mass_editing/wizard/mass_editing_wizard.py
+++ b/mass_editing/wizard/mass_editing_wizard.py
@@ -71,6 +71,8 @@ class MassEditingWizard(models.TransientModel):
                 field_vals = self._get_field_options(field)
                 if line.widget_option:
                     field_vals["widget"] = line.widget_option
+                if not line.apply_domain and "domain" in field_info[field.name]:
+                    field_vals["domain"] = "[]"
                 etree.SubElement(xml_group, "field", field_vals)
 
             # Patch fields with required extra data


### PR DESCRIPTION
Essentially a cherry-pick of https://github.com/OCA/server-ux/commit/82ac2bf3406b3c9eabca3b666fd0c38475e388ff.

**Steps to reproduce the issue**
1. Install Project
2. Create a mass editing **Update stage** for the field Stage of model Task
3. Add its sidebar button
4. Go to Project > Search > Tasks
5. Switch to list view
6. Select a task
7. Action > Mass editing (Update stage)

**Actual behavior**
Error:
```
Uncaught Error: NameError: name 'project_id' is not defined
```

**Desired behavior**
Update the stage of selected task