### PR TITLE
WIP: [13.0] database_cleanup improvements

### DIFF
--- a/database_cleanup/__manifest__.py
+++ b/database_cleanup/__manifest__.py
@@ -11,6 +11,7 @@
         "views/purge_wizard.xml",
         "views/purge_actions.xml",
         "views/purge_menus.xml",
+        "views/purge_menus_rel.xml",
         "views/purge_modules.xml",
         "views/purge_models.xml",
         "views/purge_columns.xml",

--- a/database_cleanup/__manifest__.py
+++ b/database_cleanup/__manifest__.py
@@ -9,6 +9,7 @@
     "category": "Tools",
     "data": [
         "views/purge_wizard.xml",
+        "views/purge_actions.xml",
         "views/purge_menus.xml",
         "views/purge_modules.xml",
         "views/purge_models.xml",

--- a/database_cleanup/models/__init__.py
+++ b/database_cleanup/models/__init__.py
@@ -8,3 +8,6 @@ from . import purge_menus
 from . import purge_actions
 from . import create_indexes
 from . import purge_properties
+from . import purge_menu_rel
+
+

--- a/database_cleanup/models/__init__.py
+++ b/database_cleanup/models/__init__.py
@@ -5,5 +5,6 @@ from . import purge_columns
 from . import purge_tables
 from . import purge_data
 from . import purge_menus
+from . import purge_actions
 from . import create_indexes
 from . import purge_properties

--- a/database_cleanup/models/__init__.py
+++ b/database_cleanup/models/__init__.py
@@ -9,5 +9,3 @@ from . import purge_actions
 from . import create_indexes
 from . import purge_properties
 from . import purge_menu_rel
-
-

--- a/database_cleanup/models/purge_actions.py
+++ b/database_cleanup/models/purge_actions.py
@@ -1,0 +1,61 @@
+# Copyright 2014-2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# pylint: disable=consider-merging-classes-inherited
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class CleanupPurgeLineAction(models.TransientModel):
+    _inherit = "cleanup.purge.line"
+    _name = "cleanup.purge.line.action"
+    _description = "Purge Window Action Lines"
+
+    wizard_id = fields.Many2one(
+        "cleanup.purge.wizard.action", "Purge Wizard", readonly=True
+    )
+    action_id = fields.Many2one("ir.actions.act_window", "Window action")
+
+    def purge(self):
+        """Unlink action entries upon manual confirmation."""
+        if self:
+            objs = self
+        else:
+            objs = self.env["cleanup.purge.line.action"].browse(
+                self._context.get("active_ids")
+            )
+        to_unlink = objs.filtered(lambda x: not x.purged and x.action_id)
+        self.logger.info("Purging window action entries: %s", to_unlink.mapped("name"))
+        to_unlink.mapped("action_id").unlink()
+        return to_unlink.write({"purged": True})
+
+
+class CleanupPurgeWizardMenu(models.TransientModel):
+    _inherit = "cleanup.purge.wizard"
+    _name = "cleanup.purge.wizard.action"
+    _description = "Purge Window Actions"
+
+    @api.model
+    def find(self):
+        """
+        Search for actions referring to non existent models
+        """
+        res = []
+        for action in (
+            self.env["ir.actions.act_window"]
+            .with_context(active_test=False)
+            .search([("res_model", "!=", False)])
+        ):
+            if action.type != "ir.actions.act_window":
+                continue
+            if (action.res_model and action.res_model not in self.env) or (
+                action.binding_model_id.model
+                and action.binding_model_id.model not in self.env
+            ):
+                res.append((0, 0, {"name": action.name, "action_id": action.id}))
+        if not res:
+            raise UserError(_("No obsolete Window Actions found"))
+        return res
+
+    purge_line_ids = fields.One2many(
+        "cleanup.purge.line.action", "wizard_id", "Window Actions to purge"
+    )

--- a/database_cleanup/models/purge_menu_rel.py
+++ b/database_cleanup/models/purge_menu_rel.py
@@ -1,0 +1,80 @@
+# Copyright 2021 Therp BV <http://www.sunflowerweb.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# pylint: disable=consider-merging-classes-inherited
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, MissingError
+
+
+class CleanupPurgeLineMenuRel(models.TransientModel):
+    _inherit = "cleanup.purge.line"
+    _name = "cleanup.purge.line.menu.rel"
+    _description = "Purge Parent Menu Rel Wizard Lines"
+
+    wizard_id = fields.Many2one(
+        "cleanup.purge.wizard.menu.rel", "Purge Wizard", readonly=True
+    )
+    menu_id = fields.Many2one("ir.ui.menu", "Parent menu entry")
+
+    def purge(self):
+        """Unlink parent menu entries and children upon manual confirmation."""
+        if self:
+            objs = self
+        else:
+            objs = self.env["cleanup.purge.line.menu.rel"].browse(
+                self._context.get("active_ids")
+            )
+        parent_menus = objs.filtered(lambda x: not x.purged and x.menu_id)
+        self.logger.info("Purging menu entries and "
+                         "their children: %s", parent_menus.mapped("name"))
+        for menu in parent_menus:
+            # pass root menu
+            self.recursive_purge([menu.menu_id])
+            # record success
+            menu.write({'purged': True})
+
+    # Recursive purge of parent -> children
+    #       --- (A) ---
+    #       |    |    |
+    #      (B)  (C)  (D)
+    #            |
+    #           (E)
+    #
+    def recursive_purge(self, purge_lst):
+        if not any(purge_lst):
+            return True
+        menu = purge_lst.pop()
+        child_menus = self.env["ir.ui.menu"].with_context(
+            {'ir.ui.menu.full_list': True, 'active_test': False}) \
+            .search([("parent_path", "ilike", "{0}/%".format(menu.id))])
+        menu.unlink()
+        if child_menus:
+            new = [x for x in child_menus]
+            purge_lst += new
+        return self.recursive_purge(purge_lst)
+
+
+class CleanupPurgeWizardMenuitem(models.TransientModel):
+    _inherit = "cleanup.purge.wizard"
+    _name = "cleanup.purge.wizard.menu.rel"
+    _description = "Purge parent menu and their child relations"
+
+    @api.model
+    def find(self):
+        """
+        Search for parent menus and their children and Purge them.
+        """
+        res = []
+        # Get all menus who don't have parent set.
+        parent_menus = self.env["ir.ui.menu"].with_context(
+            {'ir.ui.menu.full_list': True, 'active_test': False})\
+            .search([("parent_id", "=", False), ('action', '=', False)])
+        for menu in parent_menus:
+            res.append((0, 0, {"name": menu.complete_name, "menu_id": menu.id}))
+        if not res:
+            raise UserError(_("No dangling parent menus entries found"))
+        return res
+
+    purge_line_ids = fields.One2many(
+        "cleanup.purge.line.menu.rel", "wizard_id", "Parent menu to purge"
+    )
+

--- a/database_cleanup/models/purge_menu_rel.py
+++ b/database_cleanup/models/purge_menu_rel.py
@@ -1,8 +1,21 @@
 # Copyright 2021 Therp BV <http://www.sunflowerweb.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # pylint: disable=consider-merging-classes-inherited
+
+# NB: Dealing with RecursionError: Max no of Maximum Recursion Depth Exceeded
+# -----------------------------------------------------------------------------
+# Since we are using recursion, python has a recursive limit before it throws
+# 'RecursionError' of max no of calls. We can simply randomly increase this
+# limit however in large data menus can exceed the below set limit and leads to
+# random additions. We could possible use for loop based on the 'n' menus to
+# increase number of calls.
+# ----------------------------------------------------------------------------
+import sys
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+sys.setrecursionlimit(15000)
 
 
 class CleanupPurgeLineMenuRel(models.TransientModel):
@@ -40,8 +53,14 @@ class CleanupPurgeLineMenuRel(models.TransientModel):
     #      (B)  (C)  (D)
     #            |
     #           (E)
-    #
+    # This works well but python has a limit to the no of calls a recursion
+    # can do. In design of this it is assumed the user will not purge all,
+    # unless running migration script, in this case he/she should increase the
+    # no of calls from sys.setrecursionlimit(10000) e.g 10000. Menus can be
+    # a chain of hierarchy so if you know 'n' then set limit as per n or
+    # n+10 whichever. Also probably a for loop of n would be ok though tricky.
     def recursive_purge(self, purge_lst):
+        # boundary condition to break out of the recursion
         if not any(purge_lst):
             return True
         menu = purge_lst.pop()

--- a/database_cleanup/models/purge_menus.py
+++ b/database_cleanup/models/purge_menus.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # pylint: disable=consider-merging-classes-inherited
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, MissingError
 
 
 class CleanupPurgeLineMenu(models.TransientModel):
@@ -42,12 +42,16 @@ class CleanupPurgeWizardMenu(models.TransientModel):
         res = []
         for menu in (
             self.env["ir.ui.menu"]
-            .with_context(active_test=False)
+            .with_context({'ir.ui.menu.full_list': True, 'active_test': False})
             .search([("action", "!=", False)])
         ):
-            if menu.action.type != "ir.actions.act_window":
-                continue
-            if (menu.action.res_model and menu.action.res_model not in self.env) or (
+            action_missing = False
+            try:
+                if menu.action.type != "ir.actions.act_window":
+                    continue
+            except MissingError:
+                action_missing = True
+            if action_missing or (menu.action.res_model and menu.action.res_model not in self.env) or (
                 menu.action.binding_model_id.model
                 and menu.action.binding_model_id.model not in self.env
             ):

--- a/database_cleanup/models/purge_menus.py
+++ b/database_cleanup/models/purge_menus.py
@@ -48,8 +48,8 @@ class CleanupPurgeWizardMenu(models.TransientModel):
             if menu.action.type != "ir.actions.act_window":
                 continue
             if (menu.action.res_model and menu.action.res_model not in self.env) or (
-                menu.action.binding_model_id
-                and menu.action.binding_model_id not in self.env
+                menu.action.binding_model_id.model
+                and menu.action.binding_model_id.model not in self.env
             ):
                 res.append((0, 0, {"name": menu.complete_name, "menu_id": menu.id}))
         if not res:

--- a/database_cleanup/models/purge_menus.py
+++ b/database_cleanup/models/purge_menus.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # pylint: disable=consider-merging-classes-inherited
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, MissingError
+from odoo.exceptions import MissingError, UserError
 
 
 class CleanupPurgeLineMenu(models.TransientModel):
@@ -42,7 +42,7 @@ class CleanupPurgeWizardMenu(models.TransientModel):
         res = []
         for menu in (
             self.env["ir.ui.menu"]
-            .with_context({'ir.ui.menu.full_list': True, 'active_test': False})
+            .with_context({"ir.ui.menu.full_list": True, "active_test": False})
             .search([("action", "!=", False)])
         ):
             action_missing = False
@@ -51,9 +51,13 @@ class CleanupPurgeWizardMenu(models.TransientModel):
                     continue
             except MissingError:
                 action_missing = True
-            if action_missing or (menu.action.res_model and menu.action.res_model not in self.env) or (
-                menu.action.binding_model_id.model
-                and menu.action.binding_model_id.model not in self.env
+            if (
+                action_missing
+                or (menu.action.res_model and menu.action.res_model not in self.env)
+                or (
+                    menu.action.binding_model_id.model
+                    and menu.action.binding_model_id.model not in self.env
+                )
             ):
                 # get parent
                 res.append((0, 0, {"name": menu.complete_name, "menu_id": menu.id}))
@@ -64,4 +68,3 @@ class CleanupPurgeWizardMenu(models.TransientModel):
     purge_line_ids = fields.One2many(
         "cleanup.purge.line.menu", "wizard_id", "Menus to purge"
     )
-

--- a/database_cleanup/models/purge_menus.py
+++ b/database_cleanup/models/purge_menus.py
@@ -55,6 +55,7 @@ class CleanupPurgeWizardMenu(models.TransientModel):
                 menu.action.binding_model_id.model
                 and menu.action.binding_model_id.model not in self.env
             ):
+                # get parent
                 res.append((0, 0, {"name": menu.complete_name, "menu_id": menu.id}))
         if not res:
             raise UserError(_("No dangling menu entries found"))
@@ -63,3 +64,4 @@ class CleanupPurgeWizardMenu(models.TransientModel):
     purge_line_ids = fields.One2many(
         "cleanup.purge.line.menu", "wizard_id", "Menus to purge"
     )
+

--- a/database_cleanup/models/purge_tables.py
+++ b/database_cleanup/models/purge_tables.py
@@ -5,6 +5,12 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..identifier_adapter import IdentifierAdapter
+from psycopg2.extensions import AsIs
+
+_TABLE_TYPE_SELECTION = [
+    ('base', 'SQL Table'),
+    ('view', 'SQL View'),
+]
 
 
 class CleanupPurgeLineTable(models.TransientModel):
@@ -14,6 +20,10 @@ class CleanupPurgeLineTable(models.TransientModel):
 
     wizard_id = fields.Many2one(
         "cleanup.purge.wizard.table", "Purge Wizard", readonly=True
+    )
+
+    table_type = fields.Selection(
+        string='Table Type', selection=_TABLE_TYPE_SELECTION
     )
 
     def purge(self):
@@ -69,9 +79,17 @@ class CleanupPurgeLineTable(models.TransientModel):
                             IdentifierAdapter(constraint[0]),
                         ),
                     )
-
-            self.logger.info("Dropping table %s", line.name)
-            self.env.cr.execute("DROP TABLE %s", (IdentifierAdapter(line.name),))
+            if line.table_type == 'base':
+                _sql_type = "TABLE"
+            elif line.table_type == 'view':
+                _sql_type = "VIEW"
+            self.logger.info(
+                'Dropping %s %s', (_sql_type, line.name))
+            self.env.cr.execute(
+                "DROP %s %s", (
+                    AsIs(_sql_type),
+                    IdentifierAdapter(line.name),)
+            )
             line.write({"purged": True})
         return True
 
@@ -84,8 +102,7 @@ class CleanupPurgeWizardTable(models.TransientModel):
     @api.model
     def find(self):
         """
-        Search for tables that cannot be instantiated.
-        Ignore views for now.
+        Search for tables and views that cannot be instantiated.
         """
         known_tables = []
         for model in self.env["ir.model"].search([]):
@@ -103,13 +120,15 @@ class CleanupPurgeWizardTable(models.TransientModel):
 
         self.env.cr.execute(
             """
-            SELECT table_name FROM information_schema.tables
-            WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
-            AND table_name NOT IN %s""",
-            (tuple(known_tables),),
-        )
+            SELECT table_name, table_type FROM information_schema.tables
+            WHERE table_schema = 'public'
+            AND table_type in ('BASE TABLE', 'VIEW')
+            AND table_name NOT IN %s""", (tuple(known_tables),))
 
-        res = [(0, 0, {"name": row[0]}) for row in self.env.cr.fetchall()]
+        res = [(0, 0, {
+            'name': row[0],
+            'table_type': "base" if row[1] == "BASE TABLE" else "view"
+        }) for row in self.env.cr.fetchall()]
         if not res:
             raise UserError(_("No orphaned tables found"))
         return res

--- a/database_cleanup/models/purge_tables.py
+++ b/database_cleanup/models/purge_tables.py
@@ -1,15 +1,16 @@
 # Copyright 2014-2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 # pylint: disable=consider-merging-classes-inherited
+from psycopg2.extensions import AsIs
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..identifier_adapter import IdentifierAdapter
-from psycopg2.extensions import AsIs
 
 _TABLE_TYPE_SELECTION = [
-    ('base', 'SQL Table'),
-    ('view', 'SQL View'),
+    ("base", "SQL Table"),
+    ("view", "SQL View"),
 ]
 
 
@@ -22,9 +23,7 @@ class CleanupPurgeLineTable(models.TransientModel):
         "cleanup.purge.wizard.table", "Purge Wizard", readonly=True
     )
 
-    table_type = fields.Selection(
-        string='Table Type', selection=_TABLE_TYPE_SELECTION
-    )
+    table_type = fields.Selection(string="Table Type", selection=_TABLE_TYPE_SELECTION)
 
     def purge(self):
         """
@@ -79,16 +78,13 @@ class CleanupPurgeLineTable(models.TransientModel):
                             IdentifierAdapter(constraint[0]),
                         ),
                     )
-            if line.table_type == 'base':
+            if line.table_type == "base":
                 _sql_type = "TABLE"
-            elif line.table_type == 'view':
+            elif line.table_type == "view":
                 _sql_type = "VIEW"
-            self.logger.info(
-                'Dropping %s %s', (_sql_type, line.name))
+            self.logger.info("Dropping %s %s", (_sql_type, line.name))
             self.env.cr.execute(
-                "DROP %s %s", (
-                    AsIs(_sql_type),
-                    IdentifierAdapter(line.name),)
+                "DROP %s %s", (AsIs(_sql_type), IdentifierAdapter(line.name),)
             )
             line.write({"purged": True})
         return True
@@ -123,12 +119,21 @@ class CleanupPurgeWizardTable(models.TransientModel):
             SELECT table_name, table_type FROM information_schema.tables
             WHERE table_schema = 'public'
             AND table_type in ('BASE TABLE', 'VIEW')
-            AND table_name NOT IN %s""", (tuple(known_tables),))
+            AND table_name NOT IN %s""",
+            (tuple(known_tables),),
+        )
 
-        res = [(0, 0, {
-            'name': row[0],
-            'table_type': "base" if row[1] == "BASE TABLE" else "view"
-        }) for row in self.env.cr.fetchall()]
+        res = [
+            (
+                0,
+                0,
+                {
+                    "name": row[0],
+                    "table_type": "base" if row[1] == "BASE TABLE" else "view",
+                },
+            )
+            for row in self.env.cr.fetchall()
+        ]
         if not res:
             raise UserError(_("No orphaned tables found"))
         return res

--- a/database_cleanup/views/menu.xml
+++ b/database_cleanup/views/menu.xml
@@ -47,7 +47,7 @@
         <field name="name">Purge parent menu &amp; child entries</field>
         <field name="sequence" eval="62" />
         <field name="action" ref="action_purge_menu_rel" />
-        <field name="parent_id" ref="menu_database_cleanup"/>
+        <field name="parent_id" ref="menu_database_cleanup" />
     </record>
     <record model="ir.ui.menu" id="menu_purge_actions">
         <field name="name">Purge obsolete window actions</field>

--- a/database_cleanup/views/menu.xml
+++ b/database_cleanup/views/menu.xml
@@ -43,6 +43,12 @@
         <field name="action" ref="action_purge_menus" />
         <field name="parent_id" ref="menu_database_cleanup" />
     </record>
+    <record model="ir.ui.menu" id="menu_purge_actions">
+        <field name="name">Purge obsolete window actions</field>
+        <field name="sequence" eval="65" />
+        <field name="action" ref="action_purge_actions" />
+        <field name="parent_id" ref="menu_database_cleanup" />
+    </record>
     <record model="ir.ui.menu" id="menu_create_indexes">
         <field name="name">Create missing indexes</field>
         <field name="sequence" eval="70" />

--- a/database_cleanup/views/menu.xml
+++ b/database_cleanup/views/menu.xml
@@ -43,6 +43,12 @@
         <field name="action" ref="action_purge_menus" />
         <field name="parent_id" ref="menu_database_cleanup" />
     </record>
+    <record model="ir.ui.menu" id="menu_purge_menus_rel">
+        <field name="name">Purge parent menu &amp; child entries</field>
+        <field name="sequence" eval="62" />
+        <field name="action" ref="action_purge_menu_rel" />
+        <field name="parent_id" ref="menu_database_cleanup"/>
+    </record>
     <record model="ir.ui.menu" id="menu_purge_actions">
         <field name="name">Purge obsolete window actions</field>
         <field name="sequence" eval="65" />

--- a/database_cleanup/views/purge_actions.xml
+++ b/database_cleanup/views/purge_actions.xml
@@ -12,7 +12,10 @@
         <field name="name">Purge window actions</field>
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
-        <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_action" />
+        <field
+            name="model_id"
+            ref="database_cleanup.model_cleanup_purge_wizard_action"
+        />
         <field name="code">
             action = env.get('cleanup.purge.wizard.action').get_wizard_action()
         </field>

--- a/database_cleanup/views/purge_actions.xml
+++ b/database_cleanup/views/purge_actions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="purge_actions_view" model="ir.ui.view">
+        <field name="model">cleanup.purge.wizard.action</field>
+        <field name="inherit_id" ref="form_purge_wizard" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data />
+        </field>
+    </record>
+    <record id="action_purge_actions" model="ir.actions.server">
+        <field name="name">Purge window actions</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_action" />
+        <field name="code">
+            action = env.get('cleanup.purge.wizard.action').get_wizard_action()
+        </field>
+    </record>
+    <record id="purge_action_line_tree" model="ir.ui.view">
+        <field name="model">cleanup.purge.line.action</field>
+        <field name="inherit_id" ref="tree_purge_line" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data />
+        </field>
+    </record>
+    <record id="action_purge_action_line" model="ir.actions.server">
+        <field name="name">Purge</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_action" />
+        <field name="code">records.purge()</field>
+        <field
+            name="binding_model_id"
+            ref="database_cleanup.model_cleanup_purge_line_action"
+        />
+    </record>
+</odoo>

--- a/database_cleanup/views/purge_menus_rel.xml
+++ b/database_cleanup/views/purge_menus_rel.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="purge_menus_rel_view" model="ir.ui.view">
+        <field name="model">cleanup.purge.wizard.menu.rel</field>
+        <field name="inherit_id" ref="form_purge_wizard" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data />
+        </field>
+    </record>
+    <record id="action_purge_menu_rel" model="ir.actions.server">
+        <field name="name">Purge menus</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_menu_rel" />
+        <field name="code">
+            action = env.get('cleanup.purge.wizard.menu.rel').get_wizard_action()
+        </field>
+    </record>
+    <record id="purge_menu_rel_line_tree" model="ir.ui.view">
+        <field name="model">cleanup.purge.line.menu.rel</field>
+        <field name="inherit_id" ref="tree_purge_line"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <data />
+        </field>
+    </record>
+    <record id="action_purge_menu_rel_line" model="ir.actions.server">
+        <field name="name">Purge</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_menu_rel" />
+        <field name="code">records.purge()</field>
+        <field
+            name="binding_model_id"
+            ref="database_cleanup.model_cleanup_purge_line_menu_rel"
+        />
+    </record>
+</odoo>

--- a/database_cleanup/views/purge_menus_rel.xml
+++ b/database_cleanup/views/purge_menus_rel.xml
@@ -12,14 +12,17 @@
         <field name="name">Purge menus</field>
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
-        <field name="model_id" ref="database_cleanup.model_cleanup_purge_wizard_menu_rel" />
+        <field
+            name="model_id"
+            ref="database_cleanup.model_cleanup_purge_wizard_menu_rel"
+        />
         <field name="code">
             action = env.get('cleanup.purge.wizard.menu.rel').get_wizard_action()
         </field>
     </record>
     <record id="purge_menu_rel_line_tree" model="ir.ui.view">
         <field name="model">cleanup.purge.line.menu.rel</field>
-        <field name="inherit_id" ref="tree_purge_line"/>
+        <field name="inherit_id" ref="tree_purge_line" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <data />
@@ -29,7 +32,10 @@
         <field name="name">Purge</field>
         <field name="type">ir.actions.server</field>
         <field name="state">code</field>
-        <field name="model_id" ref="database_cleanup.model_cleanup_purge_line_menu_rel" />
+        <field
+            name="model_id"
+            ref="database_cleanup.model_cleanup_purge_line_menu_rel"
+        />
         <field name="code">records.purge()</field>
         <field
             name="binding_model_id"

--- a/database_cleanup/views/purge_tables.xml
+++ b/database_cleanup/views/purge_tables.xml
@@ -26,8 +26,8 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <field name="name" position="after">
-               <field name="table_type"/>
-           </field>
+                <field name="table_type" />
+            </field>
         </field>
     </record>
     <record id="action_purge_table_line" model="ir.actions.server">

--- a/database_cleanup/views/purge_tables.xml
+++ b/database_cleanup/views/purge_tables.xml
@@ -25,7 +25,9 @@
         <field name="inherit_id" ref="tree_purge_line" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <data />
+            <field name="name" position="after">
+               <field name="table_type"/>
+           </field>
         </field>
     </record>
     <record id="action_purge_table_line" model="ir.actions.server">


### PR DESCRIPTION
1. Small bugfix, illustrated by the below shell commands:

```
>>> env['ir.model'].search([('model', '=', 'sale.order')]) in env
False
>>> env['ir.model'].search([('model', '=', 'sale.order')]).model in env
True
```

2. Add cleanup of window actions

3. Cleanup menus with missing window actions too