### PR TITLE
[14.0][FIX] base_exception, error if rule's description is null

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -219,7 +219,7 @@ class BaseExceptionModel(models.AbstractModel):
                 rec.exceptions_summary = "<ul>%s</ul>" % "".join(
                     [
                         "<li>%s: <i>%s</i></li>"
-                        % tuple(map(html.escape, (e.name, e.description)))
+                        % tuple(map(html.escape, (e.name, e.description or "")))
                         for e in rec.exception_ids
                     ]
                 )


### PR DESCRIPTION
If I create an exception rule and leave description null, when use it, I got the error on click close.

cc @MiquelRForgeFlow @rvalyi 

![image](https://user-images.githubusercontent.com/1973598/127763337-faf88a54-2a60-4745-90c3-59f0190fdfcb.png)
