### PR TITLE
[WIP][13.0] Add method_control_execution_order

### DIFF
--- a/method_control_execution_order/README.rst
+++ b/method_control_execution_order/README.rst
@@ -1,0 +1,1 @@
+wait for the bot

--- a/method_control_execution_order/__init__.py
+++ b/method_control_execution_order/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/method_control_execution_order/__manifest__.py
+++ b/method_control_execution_order/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Method Control Execution Order",
+    "summary": (
+        "Utility module that allows to manage the execution order of methods overloads"
+    ),
+    "version": "13.0.1.0.0",
+    "category": "Whatever",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "maintainers": ["mmequignon"],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/method_control_execution_order/models/__init__.py
+++ b/method_control_execution_order/models/__init__.py
@@ -1,0 +1,1 @@
+from . import method_override_rule

--- a/method_control_execution_order/models/method_override_rule.py
+++ b/method_control_execution_order/models/method_override_rule.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+from itertools import groupby
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class MethodOverrideRule(models.Model):
+    _name = "method.override.rule"
+    _description = "Representation of a method override"
+
+    method_name = fields.Char(string="Name", help="The name of the overrideed method",)
+    method_model = fields.Char(string="Model", help="The name of the overridden model",)
+    method_delegate_name = fields.Char(
+        help=(
+            "The name of the method that will be used to "
+            "alter the output of the overrideed method."
+        )
+    )
+    sequence = fields.Integer()
+
+    _sql_constraints = [
+        (
+            "unique_delegate_method_per_method",
+            "unique(method_name, method_model, method_delegate_name)",
+            "There can be only one delegate method for an overridden method.",
+        ),
+    ]
+
+    def _register_hook(self):
+        self._patch_methods()
+
+    def _make_patched_method(self):
+        rule_ids = self.ids
+
+        def patched_method(self, *args, **kwargs):
+            res = patched_method.origin(self, *args, **kwargs)
+            rules = self.env["method.override.rule"].browse(rule_ids).sorted("sequence")
+            for rule in rules:
+                delegate_method = getattr(self, rule.method_delegate_name, None)
+                if not delegate_method:
+                    _logger.error(
+                        f"No method named {rule.method_delegate_name} "
+                        f"for {rule.method_model}"
+                    )
+                    continue
+                res = delegate_method(res)
+            return res
+
+        return patched_method
+
+    def _patch_methods(self):
+        groups = self._get_groupped_rules()
+        for (model_name, method_name), rules in groups:
+            rule_ids = [rule.id for rule in rules]
+            rules = self.browse(rule_ids)
+            model = self.env[model_name]
+            patched_method = rules._make_patched_method()
+            model._patch_method(method_name, patched_method)
+
+    def _get_groupped_rules(self):
+        overrides = self.search([], order="method_model, method_name")
+        return groupby(overrides, key=lambda o: (o.method_model, o.method_name))

--- a/method_control_execution_order/readme/CONFIGURE.rst
+++ b/method_control_execution_order/readme/CONFIGURE.rst
@@ -1,0 +1,21 @@
+For each override you want to order, you will have to create a "method.overload" record::
+
+    <record id="model_overridden_method" model="method.overload">::
+        <field name="method_name">overridden_method</field>
+        <field name="method_model">model</field>
+        <field name="method_delegate_name">delegate_method</field>
+        <field name="sequence">1</field>
+    </record>
+
+The override logic should be delegated to another method like so::
+
+    def overridden_method(self):::
+        res = super().overridden_method()
+        return delegate_method(res)
+
+    def delegate_method(self, res):::
+        # alter result here
+        return res
+
+In order to make it configurable, you'll have to add a Many2many field on the company,
+and display it in the related configuration section.

--- a/method_control_execution_order/readme/CONTRIBUTORS.rst
+++ b/method_control_execution_order/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>

--- a/method_control_execution_order/readme/DESCRIPTION.rst
+++ b/method_control_execution_order/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Adds a configurable way to manage the order in which method overloads are executed.


### PR DESCRIPTION
This module adds a configurable way to manage the order in which method overloads are executed.