### PR TITLE
[8.0] pin unidecode==1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
   pstats_print2list
   python-ldap
-  unidecode
+  unidecode==1.2.0
   validate_email
   pysftp
   acme_tiny


### PR DESCRIPTION
Pin unidecode on [lates version (1.2.0) ](https://pypi.org/project/Unidecode/1.2.0/)that support python 2.7