### PR TITLE
[12.0][FIX] Scheduler_error_mailer: fixed error printing in email

### DIFF
--- a/scheduler_error_mailer/data/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/data/ir_cron_email_tpl.xml
@@ -18,7 +18,7 @@
 <p>Odoo tried to run the scheduler <em>${object.name or ''}</em> in the database <em>${ctx.get('dbname')}</em> but it failed. Here is the error message :</p>
 
 <strong>
-${ctx.get('job_exception') and ctx.get('job_exception').value or 'Failed to get the error message from the context.'}
+${ctx.get('job_exception') or 'Failed to get the error message from the context.'}
 </strong>
 
 <p>You may check the logs of the Odoo server to get more information about this failure.</p>

--- a/scheduler_error_mailer/models/ir_cron.py
+++ b/scheduler_error_mailer/models/ir_cron.py
@@ -34,7 +34,7 @@ class IrCron(models.Model):
             # we put the job_exception in context to be able to print it inside
             # the email template
             context = {
-                'job_exception': job_exception,
+                'job_exception': str(job_exception),
                 'dbname': self._cr.dbname,
             }
 


### PR DESCRIPTION
Currently, the email template for the scheduler_error_mailer can never print the exception. With this fix the exception is printed correctly in the email.

Fixes #1927 