### PR TITLE
[12.0][FIX] scheduler_error_mailer: fixed email template fields

### DIFF
--- a/scheduler_error_mailer/data/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/data/ir_cron_email_tpl.xml
@@ -25,9 +25,8 @@ ${ctx.get('job_exception') and ctx.get('job_exception').value or 'Failed to get 
 
 <p>Properties of the scheduler <em>${object.name or ''}</em> :</p>
 <ul>
-<li>Model : ${object.model or ''}</li>
-<li>Method : ${object.function or ''}</li>
-<li>Arguments : ${object.args or ''}</li>
+<li>Model : ${object.model_id.name or ''}</li>
+<li>Python code : <code>${object.code or ''}</code></li>
 <li>Interval : ${object.interval_number or '0'} ${object.interval_type or ''}</li>
 <li>Number of calls : ${object.numbercall or '0'}</li>
 <li>Repeat missed : ${object.doall}</li>


### PR DESCRIPTION
Currently some fields in the scheduler_error_mailer email are always empty simply because the field names are wrong. This PR updates those fields so their names are correct and they are shown in the email.

- Model
- Method (renamed to Python code to match the UI)
- Arguments (Removed)