### PR TITLE
[13.0][FIX] base_time_window: Disallow hours > 23

### DIFF
--- a/base_time_window/models/time_window_mixin.py
+++ b/base_time_window/models/time_window_mixin.py
@@ -88,6 +88,19 @@ class TimeWindowMixin(models.AbstractModel):
                 end=format_time(self.env, record.get_time_window_end_time()),
             )
 
+    @api.constrains("time_window_start", "time_window_end")
+    def _check_window_under_twenty_four_hours(self):
+        error_msg = _("Hour should be between 00 and 23")
+        for record in self:
+            if record.time_window_start:
+                hour, minute = self._get_hour_min_from_value(record.time_window_start)
+                if hour > 23:
+                    raise ValidationError(error_msg)
+            if record.time_window_end:
+                hour, minute = self._get_hour_min_from_value(record.time_window_end)
+                if hour > 23:
+                    raise ValidationError(error_msg)
+
     @api.model
     def _get_hour_min_from_value(self, value):
         hour = math.floor(value)

--- a/test_base_time_window/tests/test_base_time_window.py
+++ b/test_base_time_window/tests/test_base_time_window.py
@@ -215,3 +215,33 @@ class TestTimeWindow(SavepointCase):
         self.assertTrue(self.partner_2.time_window_ids)
         with self.assertRaises(ValidationError):
             p1_timewindow.partner_id = self.partner_2
+
+    def test_07(self):
+        """
+        Data:
+            A partner without time window
+        Test Case:
+            1 Add a time window with stop hour > 23:59
+            2 Add a time window with start hour > 23:59
+        Expected result:
+            ValidationError is raised
+        """
+        exception_regex = "Hour should be between 00 and 23"
+        with self.assertRaisesRegex(ValidationError, exception_regex):
+            self.TimeWindow.create(
+                {
+                    "partner_id": self.partner_1.id,
+                    "time_window_start": 0.0,
+                    "time_window_end": 27.0,
+                    "time_window_weekday_ids": [(4, self.monday.id)],
+                }
+            )
+        with self.assertRaisesRegex(ValidationError, exception_regex):
+            self.TimeWindow.create(
+                {
+                    "partner_id": self.partner_1.id,
+                    "time_window_start": 25.0,
+                    "time_window_end": 27.0,
+                    "time_window_weekday_ids": [(4, self.monday.id)],
+                }
+            )


### PR DESCRIPTION
`time()` does not accept hours > 23 and raises an exception if user enters `24:00` for instance.
This little addition ensures that this cannot happen.