### PR TITLE
[13.0][FIX] sentry: enable use of "sentry_odoo_dir" config parameter

### DIFF
--- a/sentry/__init__.py
+++ b/sentry/__init__.py
@@ -46,11 +46,7 @@ def initialize_raven(config, client_cls=None):
         _logger.debug(
             "Both sentry_odoo_dir and sentry_release defined, choosing sentry_release"
         )
-    options = {
-        "release": config.get(
-            "sentry_release", get_odoo_commit(config.get("sentry_odoo_dir"))
-        )
-    }
+    options = {}
     for option in const.get_sentry_options():
         value = config.get("sentry_%s" % option.key, option.default)
         if isinstance(option.converter, collections.abc.Callable):
@@ -63,6 +59,11 @@ def initialize_raven(config, client_cls=None):
     )
     if level not in const.LOG_LEVEL_MAP:
         level = const.DEFAULT_LOG_LEVEL
+
+    if not options.get("release"):
+        options["release"] = config.get(
+            "sentry_release", get_odoo_commit(config.get("sentry_odoo_dir"))
+        )
 
     client_cls = client_cls or raven.Client
     client = client_cls(**options)

--- a/sentry/tests/test_client.py
+++ b/sentry/tests/test_client.py
@@ -4,6 +4,7 @@
 import logging
 import sys
 import unittest
+from unittest.mock import patch
 
 import raven
 
@@ -11,6 +12,9 @@ from odoo import exceptions
 
 from .. import initialize_raven
 from ..logutils import OdooSentryHandler
+
+GIT_SHA = "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
+RELEASE = "test@1.2.3"
 
 
 def log_handler_by_class(logger, handler_cls):
@@ -117,3 +121,32 @@ class TestClientSetup(unittest.TestCase):
         record = logging.LogRecord(__name__, level, __file__, 42, msg, (), exc_info)
         handler.emit(record)
         self.assertEventNotCaptured(client, level, msg)
+
+    @patch("odoo.addons.sentry.get_odoo_commit", return_value=GIT_SHA)
+    def test_config_odoo_dir(self, get_odoo_commit):
+        config = {
+            "sentry_enabled": True,
+            "sentry_dsn": "http://public:secret@example.com/1",
+            "sentry_odoo_dir": "/opt/odoo/core",
+        }
+        client = initialize_raven(config, client_cls=InMemoryClient)
+        self.assertEqual(
+            client.release,
+            GIT_SHA,
+            "Failed to use 'sentry_odoo_dir' parameter appropriately",
+        )
+
+    @patch("odoo.addons.sentry.get_odoo_commit", return_value=GIT_SHA)
+    def test_config_release(self, get_odoo_commit):
+        config = {
+            "sentry_enabled": True,
+            "sentry_dsn": "http://public:secret@example.com/1",
+            "sentry_odoo_dir": "/opt/odoo/core",
+            "sentry_release": RELEASE,
+        }
+        client = initialize_raven(config, client_cls=InMemoryClient)
+        self.assertEqual(
+            client.release,
+            RELEASE,
+            "Failed to use 'sentry_release' parameter appropriately",
+        )


### PR DESCRIPTION
Allow using `sentry_release` or `sentry_odoo_dir` in the Odoo configuration file.

Previously, the `sentry_odoo_dir` was never actually respected. It would always be overridden by `sentry_release`. Even if `sentry_release` is not set, it will use an empty value instead of using `sentry_odoo_dir` to find the Git commit hash.

After this commit, the `sentry_release` parameter still takes precedence. However, if `sentry_release` is not set and
`sentry_odoo_dir` is set, then `sentry_odoo_dir` will be used to find the appropriate Git commit hash, which will be used as the `release` value.

Both cases are covered by the added unit tests.

---

<details>
    <summary>Test results before fix</summary>

```
2021-09-25 03:13:12,861 1 INFO odoo odoo.modules.module: odoo.addons.sentry.tests.test_client running tests.
2021-09-25 03:13:12,862 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_capture_event ...
2021-09-25 03:13:12,871 1 WARNING odoo odoo.addons.sentry.tests.test_client: Test event, can be ignored
2021-09-25 03:13:12,900 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_config_odoo_dir ...
2021-09-25 03:13:12,909 1 INFO odoo odoo.addons.sentry.tests.test_client: ======================================================================
2021-09-25 03:13:12,909 1 ERROR odoo odoo.addons.sentry.tests.test_client: FAIL: TestClientSetup.test_config_odoo_dir
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/opt/odoo/vendor/_lib/sentry/tests/test_client.py", line 134, in test_config_odoo_dir
    self.assertEqual(client.release, GIT_SHA, "Failed to use 'sentry_odoo_dir' parameter appropriately")
AssertionError: None != 'd670460b4b4aece5915caf5c68d12f560a9fe3e4' : Failed to use 'sentry_odoo_dir' parameter appropriately

2021-09-25 03:13:12,911 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_config_release ...
2021-09-25 03:13:12,914 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_ignore_exceptions ...
2021-09-25 03:13:12,921 1 INFO odoo odoo.addons.sentry.tests.test_client.InMemoryClient: Not capturing exception due to filters: <class 'odoo.exceptions.UserError'>
NoneType: None
2021-09-25 03:13:12,922 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_initialize_raven_sets_dsn ...
2021-09-25 03:13:12,923 1 INFO odoo odoo.modules.module: Ran 5 tests in 0.062s
2021-09-25 03:13:12,924 1 ERROR odoo odoo.modules.module: Module sentry: 1 failures, 0 errors
2021-09-25 03:13:13,698 1 INFO odoo odoo.modules.loading: 13 modules loaded in 0.97s, 2 queries
2021-09-25 03:13:13,982 1 ERROR odoo odoo.modules.loading: At least one test failed when loading the modules.
```
</details>

<details>
    <summary>Test results after fix</summary>

```
2021-09-25 03:15:00,762 1 INFO odoo odoo.modules.module: odoo.addons.sentry.tests.test_client running tests.
2021-09-25 03:15:00,762 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_capture_event ...
2021-09-25 03:15:00,775 1 WARNING odoo odoo.addons.sentry.tests.test_client: Test event, can be ignored
2021-09-25 03:15:00,824 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_config_odoo_dir ...
2021-09-25 03:15:00,834 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_config_release ...
2021-09-25 03:15:00,837 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_ignore_exceptions ...
2021-09-25 03:15:00,842 1 INFO odoo odoo.addons.sentry.tests.test_client.InMemoryClient: Not capturing exception due to filters: <class 'odoo.exceptions.UserError'>
NoneType: None
2021-09-25 03:15:00,843 1 INFO odoo odoo.addons.sentry.tests.test_client: Starting TestClientSetup.test_initialize_raven_sets_dsn ...
2021-09-25 03:15:00,845 1 INFO odoo odoo.modules.module: Ran 5 tests in 0.083s
2021-09-25 03:15:01,668 1 INFO odoo odoo.modules.loading: 13 modules loaded in 1.08s, 2 queries
2021-09-25 03:15:02,062 1 INFO odoo odoo.modules.loading: Modules loaded.
```
</details>