### PR TITLE
[13.0] [IMP] database_cleanup: purge orphaned SQL views

### DIFF
--- a/database_cleanup/views/purge_tables.xml
+++ b/database_cleanup/views/purge_tables.xml
@@ -25,7 +25,9 @@
         <field name="inherit_id" ref="tree_purge_line" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <data />
+            <field name="name" position="after">
+                <field name="table_type"/>
+            </field>
         </field>
     </record>
     <record id="action_purge_table_line" model="ir.actions.server">


### PR DESCRIPTION
Improve the "Purge obsolete tables" feature to purge SQL views.
SQL views are not automatically dropped after uninstalling an addons, or upgrading odoo.
For example, the view mail_statistics_report is not dropped after migration to v13: https://github.com/odoo/odoo/blob/12.0/addons/mass_mailing/models/mass_mailing_report.py#L32
