### PR TITLE
Update dotfiles, rebel fetchmail_notify_error_to_sender

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.3.4
+_commit: v1.3.5
 _src_path: gh:oca/oca-addons-repo-template
 ci: Travis
 dependency_installation_mode: PIP
@@ -7,7 +7,7 @@ generate_requirements_txt: true
 include_wkhtmltopdf: true
 odoo_version: 14.0
 rebel_module_groups:
-- fetchmail_incoming_log,fetchmail_notify_error_to_sender_test
+- fetchmail_incoming_log,fetchmail_notify_error_to_sender_test,fetchmail_notify_error_to_sender
 repo_description: This project aims to deal with modules related to manage Odoo server
   environment and provide useful tools.
 repo_name: Tools for server environment(s)

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,12 @@ env:
 parserOptions:
   ecmaVersion: 2017
 
+overrides:
+  - files:
+      - "**/*.esm.js"
+    parserOptions:
+      sourceType: module
+
 # Globals available in Odoo that shouldn't produce errorings
 globals:
   _: readonly

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,24 +19,24 @@ stages:
 
 jobs:
   include:
-    # Test separately: fetchmail_incoming_log,fetchmail_notify_error_to_sender_test
+    # Test separately: fetchmail_incoming_log,fetchmail_notify_error_to_sender_test,fetchmail_notify_error_to_sender
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1
-          INCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test"
+          INCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test,fetchmail_notify_error_to_sender"
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="OCA/OCB"
-          INCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test"
+          INCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test,fetchmail_notify_error_to_sender"
     # Test all other addons together
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1
-          EXCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test"
+          EXCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test,fetchmail_notify_error_to_sender"
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="OCA/OCB"
-          EXCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test"
+          EXCLUDE="fetchmail_incoming_log,fetchmail_notify_error_to_sender_test,fetchmail_notify_error_to_sender"
 env:
   global:
     - VERSION="14.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"


### PR DESCRIPTION
fetchmail_notify_error_to_sender must be in the rebel
modules group, because it depends on fetchmail_notify_error_to_sender_test
which is a rebel module. Otherwise fetchmail_notify_error_to_sender
is in both jobs which creates issues for makepot.

Attempt to fix #2191 