### PR TITLE
[IMP] auditlog: Improve performance of creating logs for recordsets

### DIFF
--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Audit Log",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.3.0",
     "author": "ABF OSIELL,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/server-tools",


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR contains performance improvement on creating logs for recordsets. 

Current behaviour before PR:
There was one-by-one creating log and log line records. It was very slow when we want to create logs for recordsets. 

Desired behaviour after PR is merged:
I group recordset by batches, so each log record will write in two stages (SQL) requests: 
- create log
- audit log lines for this log
Also there was added optimization for reading `current_http_request` and `current_http_session` - because before this it was calling inside the cycle and it read data from database - it was also slowing down performance. In this PR they were moved outside the cycle.