### PR TITLE
[14.0][IMP] base_view_inheritance_extension: real python_dict from ast tree

### DIFF
--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -10,6 +10,6 @@
     "summary": "Adds more operators for view inheritance",
     "website": "https://github.com/OCA/server-tools",
     "depends": ["base"],
-    "external_dependencies": {"python": ["pyyaml"]},
+    "external_dependencies": {"python": ["astor"]},
     "demo": ["demo/ir_ui_view.xml"],
 }

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -1,38 +1,14 @@
 # Copyright 2016 Therp BV <https://therp.nl>
 # Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+import ast
+
+import astor
 from lxml import etree
-from yaml import safe_load
 
-from odoo import api, models, tools
-
-
-class UnquoteObject(str):
-    def __getattr__(self, name):
-        return UnquoteObject("{}.{}".format(self, name))
-
-    def __repr__(self):
-        return self
-
-    def __call__(self, *args, **kwargs):
-        return UnquoteObject(
-            "%s(%s)"
-            % (
-                self,
-                ",".join(
-                    [
-                        UnquoteObject(a if not isinstance(a, str) else "'%s'" % a)
-                        for a in args
-                    ]
-                    + ["{}={}".format(UnquoteObject(k), v) for (k, v) in kwargs.items()]
-                ),
-            )
-        )
-
-
-class UnquoteEvalObjectContext(tools.misc.UnquoteEvalContext):
-    def __missing__(self, key):
-        return UnquoteObject(key)
+from odoo import api, models
 
 
 class IrUiView(models.Model):
@@ -79,24 +55,6 @@ class IrUiView(models.Model):
             )
         return handler
 
-    def _is_variable(self, value):
-        return not ("'" in value or '"' in value) and True or False
-
-    def _list_variables(self, str_dict):
-        """
-        Store non literal dictionary values into a list to post-process
-        operations.
-        """
-        variables = []
-        items = str_dict.replace("{", "").replace("}", "").split(",")
-        for item in items:
-            key_value = item.split(":")
-            if len(key_value) == 2:
-                value = key_value[1]
-                if self._is_variable(value):
-                    variables.append(value.strip())
-        return variables
-
     @api.model
     def inheritance_handler_attributes_python_dict(self, source, specs):
         """Implement
@@ -107,15 +65,35 @@ class IrUiView(models.Model):
         </$node>"""
         node = self.locate_node(source, specs)
         for attribute_node in specs:
-            str_dict = node.get(attribute_node.get("name")) or "{}"
-            variables = self._list_variables(str_dict)
-            if self._is_variable(attribute_node.text):
-                variables.append(attribute_node.text)
-            my_dict = safe_load(str_dict)
-            my_dict[attribute_node.get("key")] = attribute_node.text
-            for k, v in my_dict.items():
-                my_dict[k] = UnquoteObject(v) if v in variables else v
-            node.attrib[attribute_node.get("name")] = str(my_dict)
+            attr_name = attribute_node.get("name")
+            attr_key = attribute_node.get("key")
+            str_dict = node.get(attr_name) or "{}"
+            ast_dict = ast.parse(str_dict, mode="eval").body
+            assert isinstance(ast_dict, ast.Dict), f"'{attr_name}' is not a dict"
+            assert attr_key, "No key specified for 'python_dict' operation"
+            # Find the ast dict key
+            # python < 3.8 uses ast.Str; python >= 3.8 uses ast.Constant
+            key_idx = next(
+                (
+                    i
+                    for i, k in enumerate(ast_dict.keys)
+                    if (isinstance(k, ast.Str) and k.s == attr_key)
+                    or (isinstance(k, ast.Constant) and k.value == attr_key)
+                ),
+                None,
+            )
+            # Update or create the key
+            value = ast.parse(attribute_node.text.strip(), mode="eval").body
+            if key_idx:
+                ast_dict.values[key_idx] = value
+            else:
+                ast_dict.keys.append(ast.Str(attr_key))
+                ast_dict.values.append(value)
+            # Dump the ast back to source
+            # TODO: once odoo requires python >= 3.9; use `ast.unparse` instead
+            node.attrib[attribute_node.get("name")] = astor.to_source(
+                ast_dict, pretty_source=lambda s: "".join(s).strip()
+            )
         return source
 
     @api.model

--- a/base_view_inheritance_extension/readme/CONTRIBUTORS.rst
+++ b/base_view_inheritance_extension/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Holger Brunn <hbrunn@therp.nl>
 * Ronald Portier <rportier@therp.nl>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
+* Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/base_view_inheritance_extension/readme/ROADMAP.rst
+++ b/base_view_inheritance_extension/readme/ROADMAP.rst
@@ -1,3 +1,2 @@
-* add ``<attribute operation="json_dict" key="$key">$value</attribute>``
-* support ``<xpath expr="$xpath" position="move" target="xpath" target_position="position" />``
-* support an ``eval`` attribute for our new node types
+* On `15.0`, remove `list_add` and `list_remove` fetures.
+* Support an ``eval`` attribute for our new node types.

--- a/base_view_inheritance_extension/readme/USAGE.rst
+++ b/base_view_inheritance_extension/readme/USAGE.rst
@@ -12,20 +12,12 @@ to refer to some xmlid, say ``%(xmlid)s``.
 
 **Add to values in a list (states for example)**
 
-.. code-block:: xml
-
-    <attribute name="$attribute" operation="list_add">
-        $new_value(s)
-    </attribute>
+Deprecated. This feature is now native, use `<attribute name="attrname" separator="," add="something" />`.
 
 **Remove values from a list (states for example)**
 
-.. code-block:: xml
-
-    <attribute name="$attribute" operation="list_remove">
-        $remove_value(s)
-    </attribute>
+Deprecated. This feature is now native, use `<attribute name="attrname" separator="," remove="something" />`.
 
 **Move an element in the view**
 
-This feature is now native, cf the `official Odoo documentation <https://www.odoo.com/documentation/14.0/reference/views.html#inheritance-specs>`_.
+This feature is now native, cf the `official Odoo documentation <https://www.odoo.com/documentation/14.0/developer/reference/addons/views.html#inheritance-specs>`_.

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -1,11 +1,19 @@
 # Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
 from lxml import etree
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestBaseViewInheritanceExtension(TransactionCase):
+class TestBaseViewInheritanceExtension(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ViewModel = cls.env["ir.ui.view"]
+
     def test_base_view_inheritance_extension(self):
         view_id = self.env.ref("base.view_partner_simple_form").id
         fields_view_get = self.env["res.partner"].fields_view_get(view_id=view_id)
@@ -89,40 +97,194 @@ class TestBaseViewInheritanceExtension(TransactionCase):
         button_node = modified_source.xpath('//button[@name="test"]')[0]
         self.assertEqual(button_node.attrib["states"], "draft,valid,paid")
 
-    def test_python_dict_inheritance(self):
-        view_model = self.env["ir.ui.view"]
+    def test_python_dict_inheritance_context_default(self):
         source = etree.fromstring(
-            """<form>
-                <field name="invoice_line_ids"
-                    context="{
-                    'default_type': context.get('default_type'),
-                    'journal_id': journal_id,
-                    'default_partner_id': commercial_partner_id,
-                    'default_currency_id':
-                    currency_id != company_currency_id and currency_id or False,
-                    'default_name': 'The company name',
-                    }"/>
-            </form>"""
+            """
+            <form>
+                <field name="account_move_id" context="{'default_journal_id': journal_id}" />
+            </form>
+            """
         )
         specs = etree.fromstring(
-            """\
-            <field name="invoice_line_ids" position="attributes">
-                <attribute name="context" operation="python_dict"
-                    key="my_key">my_value</attribute>
-                <attribute name="context" operation="python_dict"
-                    key="my_key2">'my name'</attribute>
-                <attribute name="context" operation="python_dict"
-                 key="default_cost_center_id">cost_center_id</attribute>
+            """
+            <field name="account_move_id" position="attributes">
+                <attribute name="context" operation="python_dict" key="default_company_id">
+                    company_id
+                </attribute>
             </field>
             """
         )
-        modified_source = view_model.inheritance_handler_attributes_python_dict(
-            source, specs
+        res = self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)
+        self.assertEqual(
+            res.xpath('//field[@name="account_move_id"]')[0].attrib["context"],
+            "{'default_journal_id': journal_id, 'default_company_id': company_id}",
         )
-        field_node = modified_source.xpath('//field[@name="invoice_line_ids"]')[0]
-        self.assertTrue(
-            "currency_id != company_currency_id and currency_id or False"
-            in field_node.attrib["context"]
+
+    def test_python_dict_inheritance_context_complex(self):
+        source = etree.fromstring(
+            """
+            <form>
+                <field
+                    name="invoice_line_ids"
+                    context="{
+                        'default_type': context.get('default_type'),
+                        'journal_id': journal_id,
+                        'default_partner_id': commercial_partner_id,
+                        'default_currency_id': (
+                            currency_id != company_currency_id and currency_id or False
+                        ),
+                        'default_name': 'The company name',
+                    }"
+                />
+            </form>
+            """
         )
-        self.assertTrue("my_value" in field_node.attrib["context"])
-        self.assertFalse("'cost_center_id'" in field_node.attrib["context"])
+        specs = etree.fromstring(
+            """
+            <field name="invoice_line_ids" position="attributes">
+                <attribute name="context" operation="python_dict" key="default_product_id">
+                    product_id
+                </attribute>
+                <attribute name="context" operation="python_dict" key="default_cost_center_id">
+                    context.get('handle_mrp_cost') and cost_center_id or False
+                </attribute>
+            </field>
+            """
+        )
+        res = self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)
+        self.assertEqual(
+            res.xpath('//field[@name="invoice_line_ids"]')[0].attrib["context"],
+            "{'default_type': context.get('default_type'), 'journal_id': journal_id, "
+            "'default_partner_id': commercial_partner_id, 'default_currency_id': "
+            "currency_id != company_currency_id and currency_id or False, "
+            "'default_name': 'The company name', 'default_product_id': product_id, "
+            "'default_cost_center_id': context.get('handle_mrp_cost') and "
+            "cost_center_id or False}",
+        )
+
+    def test_python_dict_inheritance_attrs_add(self):
+        """Test that we can add new keys to an existing dict"""
+        source = etree.fromstring(
+            """
+            <form>
+                <field
+                    name="ref"
+                    attrs="{'invisible': [('state', '=', 'draft')]}"
+                />
+            </form>
+            """
+        )
+        specs = etree.fromstring(
+            """
+            <field name="ref" position="attributes">
+                <attribute name="attrs" operation="python_dict" key="required">
+                    [('state', '!=', 'draft')]
+                </attribute>
+            </field>
+            """
+        )
+        res = self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)
+        self.assertEqual(
+            res.xpath('//field[@name="ref"]')[0].attrib["attrs"],
+            "{'invisible': [('state', '=', 'draft')], "
+            "'required': [('state', '!=', 'draft')]}",
+        )
+
+    def test_python_dict_inheritance_attrs_update(self):
+        """Test that we can replace an existing dict key"""
+        source = etree.fromstring(
+            """
+            <form>
+                <field
+                    name="ref"
+                    attrs="{
+                        'invisible': [('state', '=', 'draft')],
+                        'required': [('state', '=', False)],
+                    }"
+                />
+            </form>
+            """
+        )
+        specs = etree.fromstring(
+            """
+            <field name="ref" position="attributes">
+                <attribute name="attrs" operation="python_dict" key="required">
+                    [('state', '!=', 'draft')]
+                </attribute>
+            </field>
+            """
+        )
+        res = self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)
+        self.assertEqual(
+            res.xpath('//field[@name="ref"]')[0].attrib["attrs"],
+            "{'invisible': [('state', '=', 'draft')], "
+            "'required': [('state', '!=', 'draft')]}",
+        )
+
+    def test_python_dict_inheritance_attrs_new(self):
+        """Test that we can add new keys by creating the dict if it's missing"""
+        source = etree.fromstring(
+            """
+            <form>
+                <field name="ref" />
+            </form>
+            """
+        )
+        specs = etree.fromstring(
+            """
+            <field name="ref" position="attributes">
+                <attribute name="attrs" operation="python_dict" key="required">
+                    [('state', '!=', 'draft')]
+                </attribute>
+            </field>
+            """
+        )
+        res = self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)
+        self.assertEqual(
+            res.xpath('//field[@name="ref"]')[0].attrib["attrs"],
+            "{'required': [('state', '!=', 'draft')]}",
+        )
+
+    def test_python_dict_inheritance_attrs_missing_key(self):
+        """We should get an error if we try to update a dict without specifing a key"""
+        source = etree.fromstring(
+            """
+            <form>
+                <field name="ref" />
+            </form>
+            """
+        )
+        specs = etree.fromstring(
+            """
+            <field name="ref" position="attributes">
+                <attribute name="attrs" operation="python_dict">
+                    [('state', '!=', 'draft')]
+                </attribute>
+            </field>
+            """
+        )
+        with self.assertRaisesRegex(
+            AssertionError, "No key specified for 'python_dict' operation"
+        ):
+            self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)
+
+    def test_python_dict_inheritance_error_if_not_a_dict(self):
+        """We should get an error if we try to update a non-dict attribute"""
+        source = etree.fromstring(
+            """
+            <form>
+                <field name="child_ids" domain="[('state', '=', 'confirm')]" />
+            </form>
+            """
+        )
+        specs = etree.fromstring(
+            """
+            <field name="child_ids" position="attributes">
+                <attribute name="domain" operation="python_dict" key="required">
+                    [('state', '!=', 'draft')]
+                </attribute>
+            </field>
+            """
+        )
+        with self.assertRaisesRegex(AssertionError, "'domain' is not a dict"):
+            self.ViewModel.inheritance_handler_attributes_python_dict(source, specs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # generated from manifests external_dependencies
 acme
+astor
 cryptography
 dataclasses
 dnspython
@@ -9,7 +10,6 @@ odoorpc
 openpyxl
 openupgradelib
 pysftp
-pyyaml
 raven
 unidecode
 xlrd


### PR DESCRIPTION
Use `ast` parsing for `python_dict`, which enables its use in other cases than simply just `context`, for example `attrs`. It treats the value as a real python expression and not just a string

The added unit test fails without this change.


[btw `astor` is already an optional dependency on odoo core](https://github.com/odoo/odoo/blob/b3302398bc79f107588ff755666bf74a2ef4e11a/openerp/addons/base/ir/ir_qweb/qweb.py#L116-L120)