### PR TITLE
[10.0][FIX] base_tier_validation; allow empty "tier definition expression" field

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "category": "Tools",
     "website": "https://github.com/OCA/server-tools",
     "author": "Eficent, Odoo Community Association (OCA)",

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.1",
     "category": "Tools",
     "website": "https://github.com/OCA/server-tools",
     "author": "Eficent, Odoo Community Association (OCA)",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -88,6 +88,8 @@ class TierValidation(models.AbstractModel):
 
     @api.multi
     def evaluate_tier(self, tier):
+        if not tier.python_code:
+            tier.python_code = "1 == 1"
         try:
             res = safe_eval(tier.python_code, globals_dict={'rec': self})
         except Exception, error:


### PR DESCRIPTION
[Isuue]
If you write no words or sentences to "tier definition expression" field, the module does not work because the result of safe_eval function become a falsy value (ortherwise the function does not accept the expression).

[Info]
Impacted versions: 10.0

Steps to reproduce: 
1. install base_tier_validation and xxx_tier_validation (I check with xxx=purchase)
2. make tier(s) without any strings in "tier definition expression" column.
3. create a new xxx_order by the user who is not a reviewer.

Current behavior:
After three operations above, the button to request validation does not appear and no offers of validation were registered.

Expected behavior:
It is intended to be approved that tiers without any strings in "tier definition expression" column.
In other words, It is hoped that safe_eval function returns truthy value when tier.python_code is empty.