### PR TITLE
[FIX] module_change_auto_install : auto_install is now a set of dependencies. (before, was boolean)

### DIFF
--- a/module_change_auto_install/patch.py
+++ b/module_change_auto_install/patch.py
@@ -48,7 +48,7 @@ def _overload_load_information_from_description_file(module, mod_path=None):
 
     if not auto_install and module in modules_auto_install_enabled:
         _logger.info("Module '%s' has been marked as auto installable." % module)
-        res["auto_install"] = True
+        res["auto_install"] = set(res["depends"])
 
     return res
 


### PR DESCRIPTION
Hi.

in recent version of Odoo, the interpretation of ``auto_install`` is not a boolean, but the list of dependencies. 
applying the change in the patch, in ``module_change_auto_install``.

@GSLabIt : could you take a look on this one ?

Fix : #2242