### PR TITLE
[14.0][FIX] base_changeset: assign values for all computed fields

### DIFF
--- a/base_changeset/tests/test_changeset_flow.py
+++ b/base_changeset/tests/test_changeset_flow.py
@@ -115,6 +115,8 @@ class TestChangesetFlow(ChangesetTestCommon, TransactionCase):
         self.assertEqual(self.partner.count_pending_changesets, 0)
         self.assertEqual(self.partner.name, "Y")
         self.assertEqual(changeset.change_ids.state, "done")
+        # All computed fields are assigned
+        changeset.change_ids.read()
 
     def test_apply_done_change(self):
         """ Done changes do not apply (already applied) """


### PR DESCRIPTION
Prevents error on record.changeset.change's read() method
```
    changeset.change_ids.read()
  File "/home/odoo/odoo/models.py", line 3022, in read
    return self._read_format(fnames=fields, load=load)
  File "/home/odoo/odoo/models.py", line 3042, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "/home/odoo/odoo/models.py", line 5667, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/home/odoo/odoo/fields.py", line 1028, in __get__
    raise ValueError("Compute method failed to assign %s.%s" % (record, self.name))
ValueError: Compute method failed to assign record.changeset.change(1403,).origin_value_date
```