### PR TITLE
[14.0][FIX] base_changeset: models may not have a `name` field

### DIFF
--- a/base_changeset/models/record_changeset.py
+++ b/base_changeset/models/record_changeset.py
@@ -67,7 +67,7 @@ class RecordChangeset(models.Model):
     def name_get(self):
         result = []
         for changeset in self:
-            name = "{} ({})".format(changeset.date, changeset.record_id.name)
+            name = "{} ({})".format(changeset.date, changeset.record_id.display_name)
             result.append((changeset.id, name))
         return result
 

--- a/base_changeset/tests/test_changeset_flow.py
+++ b/base_changeset/tests/test_changeset_flow.py
@@ -329,3 +329,18 @@ class TestChangesetFlow(ChangesetTestCommon, TransactionCase):
         self.partner._compute_changeset_ids()
         changeset = self.partner.changeset_ids
         self.assertEqual(changeset.source, company)
+
+    def test_name_get(self):
+        """Test the name_get of a changeset for a model without name field"""
+        self.env["changeset.field.rule"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner_bank__active").id,
+                "action": "validate",
+            }
+        )
+        bank = self.env.ref("base.bank_partner_demo").with_context(
+            test_record_changeset=True
+        )
+        bank.active = False
+        self.assertTrue(bank.changeset_ids)
+        self.assertIn(bank.acc_number, bank.changeset_ids.name_get()[0][1])


### PR DESCRIPTION
Fixes

```
bank.changeset_ids.name_get()
*** AttributeError: 'res.partner.bank' object has no attribute 'name'
```