### PR TITLE
[12.0][FIX] Scheduler_error_mailer: fixed error printing in email

### DIFF
--- a/scheduler_error_mailer/__manifest__.py
+++ b/scheduler_error_mailer/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Scheduler Error Mailer',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Extra Tools',
     'license': 'AGPL-3',
     'author': "Akretion,Sodexis,Odoo Community Association (OCA)",

--- a/scheduler_error_mailer/data/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/data/ir_cron_email_tpl.xml
@@ -18,7 +18,7 @@
 <p>Odoo tried to run the scheduler <em>${object.name or ''}</em> in the database <em>${ctx.get('dbname')}</em> but it failed. Here is the error message :</p>
 
 <strong>
-${ctx.get('job_exception') and ctx.get('job_exception').value or 'Failed to get the error message from the context.'}
+${ctx.get('job_exception') or 'Failed to get the error message from the context.'}
 </strong>
 
 <p>You may check the logs of the Odoo server to get more information about this failure.</p>

--- a/scheduler_error_mailer/migrations/12.0.1.1.0/post-migration.py
+++ b/scheduler_error_mailer/migrations/12.0.1.1.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    template = env.ref("scheduler_error_mailer.scheduler_error_mailer")
+    template.body_html = template.body_html.replace(
+        "${ctx.get('job_exception') and ctx.get('job_exception').value",
+        "${ctx.get('job_exception')"
+    )

--- a/scheduler_error_mailer/models/ir_cron.py
+++ b/scheduler_error_mailer/models/ir_cron.py
@@ -34,7 +34,7 @@ class IrCron(models.Model):
             # we put the job_exception in context to be able to print it inside
             # the email template
             context = {
-                'job_exception': job_exception,
+                'job_exception': str(job_exception),
                 'dbname': self._cr.dbname,
             }
 


### PR DESCRIPTION
Currently, the email template for the scheduler_error_mailer can never print the exception. With this fix the exception is printed correctly in the email.

Fixes #1927

Superseed https://github.com/OCA/server-tools/pull/2173 to add migration script.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT27587