### PR TITLE
[12.0][FIX] scheduler_error_mailer: fixed email template fields

### DIFF
--- a/scheduler_error_mailer/__manifest__.py
+++ b/scheduler_error_mailer/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Scheduler Error Mailer',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.2.0',
     'category': 'Extra Tools',
     'license': 'AGPL-3',
     'author': "Akretion,Sodexis,Odoo Community Association (OCA)",

--- a/scheduler_error_mailer/data/ir_cron_email_tpl.xml
+++ b/scheduler_error_mailer/data/ir_cron_email_tpl.xml
@@ -25,9 +25,8 @@ ${ctx.get('job_exception') or 'Failed to get the error message from the context.
 
 <p>Properties of the scheduler <em>${object.name or ''}</em> :</p>
 <ul>
-<li>Model : ${object.model or ''}</li>
-<li>Method : ${object.function or ''}</li>
-<li>Arguments : ${object.args or ''}</li>
+<li>Model : ${object.model_id.name or ''}</li>
+<li>Python code : <code>${object.code or ''}</code></li>
 <li>Interval : ${object.interval_number or '0'} ${object.interval_type or ''}</li>
 <li>Number of calls : ${object.numbercall or '0'}</li>
 <li>Repeat missed : ${object.doall}</li>

--- a/scheduler_error_mailer/migrations/12.0.1.2.0/post-migration.py
+++ b/scheduler_error_mailer/migrations/12.0.1.2.0/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    template = env.ref("scheduler_error_mailer.scheduler_error_mailer")
+    template.body_html = template.body_html.replace(
+        "${object.model or ''}", "${object.model_id.name or ''}"
+    )
+    template.body_html = template.body_html.replace(
+        "<li>Method : ${object.function or ''}</li>", ""
+    )
+    template.body_html = template.body_html.replace(
+        "<li>Arguments : ${object.args or ''}</li>",
+        "<li>Python code : <code>${object.code or ''}</code></li>"
+    )


### PR DESCRIPTION
Currently some fields in the scheduler_error_mailer email are always empty simply because the field names are wrong. This PR updates those fields so their names are correct and they are shown in the email.

- Model
- Method (renamed to Python code to match the UI)
- Arguments (Removed)

Superseed: https://github.com/OCA/server-tools/pull/2174

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT27587