### PR TITLE
[FP][FIX][ENG][14.0] base_name_search_improved: forward port of patches and fix to interactive search

### DIFF
--- a/base_name_search_improved/__manifest__.py
+++ b/base_name_search_improved/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Improved Name Search",
     "summary": "Friendlier search when typing in relation fields",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "category": "Uncategorized",
     "website": "https://github.com/OCA/server-tools",
     "author": "Daniel Reis, Odoo Community Association (OCA), ADHOC SA",

--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -67,15 +67,14 @@ def patch_name_search():
         res = _name_search.origin(
             self, name=name, args=args, operator=operator, limit=limit, name_get_uid=name_get_uid
         )
-        if name and _get_use_smart_name_search(self) and operator in ALLOWED_OPS:
+        if name and _get_use_smart_name_search(self.sudo()) and operator in ALLOWED_OPS:
             limit = limit or 0
-            superself = self.sudo()
 
             # we add domain
-            args = args or [] + _get_name_search_domain(superself)
+            args = args or [] + _get_name_search_domain(self.sudo())
 
             # Support a list of fields to search on
-            all_names = _get_rec_names(superself)
+            all_names = _get_rec_names(self.sudo())
             base_domain = args or []
             # Try regular search on each additional search field
             for rec_name in all_names[1:]:
@@ -159,9 +158,8 @@ class Base(models.AbstractModel):
         """
         name = value
         if name and operator in ALLOWED_OPS:
-            superself = self.sudo()
-            all_names = _get_rec_names(superself)
-            domain = _get_name_search_domain(superself)
+            all_names = _get_rec_names(self.sudo())
+            domain = _get_name_search_domain(self.sudo())
             for word in name.split():
                 word_domain = []
                 for rec_name in all_names:

--- a/base_name_search_improved/readme/CONTRIBUTORS.rst
+++ b/base_name_search_improved/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Daniel Reis <https://github.com/dreispt>
 * Kitti U. <kittiu@ecosoft.co.th> (migrate to v14)
+* Radovan Skolnik <radovan@skolnik.info>

--- a/base_name_search_improved/tests/test_name_search.py
+++ b/base_name_search_improved/tests/test_name_search.py
@@ -18,14 +18,15 @@ class NameSearchCase(TransactionCase):
         model_partner.name_search_domain = "[('parent_id', '=', False)]"
         self.Partner = self.env["res.partner"]
         self.partner1 = self.Partner.create(
-            {"name": "Luigi Verconti", "phone": "+351 555 777 333"}
+            {"name": "Luigi Verconti", "customer_rank": 1, "phone": "+351 555 777 333"}
         )
         self.partner2 = self.Partner.create(
-            {"name": "Ken Shabby", "phone": "+351 555 333 777"}
+            {"name": "Ken Shabby", "customer_rank": 1, "phone": "+351 555 333 777"}
         )
         self.partner3 = self.Partner.create(
             {
                 "name": "Johann Gambolputty of Ulm",
+                "supplier_rank": 1,
                 "phone": "+351 777 333 555",
                 "barcode": "1111",
             }
@@ -63,7 +64,7 @@ class NameSearchCase(TransactionCase):
 
     def test_MustHonorDomain(self):
         """Must also honor a provided Domain"""
-        res = self.Partner.name_search("+351", args=[("barcode", "=", "1111")])
+        res = self.Partner.name_search("+351", args=[("supplier_rank", "=", True)])
         gambulputty = self.partner3.id
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0][0], gambulputty)

--- a/base_name_search_improved/tests/test_name_search.py
+++ b/base_name_search_improved/tests/test_name_search.py
@@ -12,21 +12,22 @@ class NameSearchCase(TransactionCase):
         model_partner = self.env.ref("base.model_res_partner")
         model_partner.name_search_ids = phone_field
         model_partner.add_smart_search = True
+        model_partner.use_smart_name_search = True
 
         # this use does not make muche sense but with base module we dont have
         # much models to use for tests
         model_partner.name_search_domain = "[('parent_id', '=', False)]"
         self.Partner = self.env["res.partner"]
         self.partner1 = self.Partner.create(
-            {"name": "Luigi Verconti", "customer_rank": 1, "phone": "+351 555 777 333"}
+            {"name": "Luigi Verconti", "vat": "1111", "phone": "+351 555 777 333"}
         )
         self.partner2 = self.Partner.create(
-            {"name": "Ken Shabby", "customer_rank": 1, "phone": "+351 555 333 777"}
+            {"name": "Ken Shabby", "vat": "2222", "phone": "+351 555 333 777"}
         )
         self.partner3 = self.Partner.create(
             {
                 "name": "Johann Gambolputty of Ulm",
-                "supplier_rank": 1,
+                "vat": "3333",
                 "phone": "+351 777 333 555",
                 "barcode": "1111",
             }
@@ -64,7 +65,7 @@ class NameSearchCase(TransactionCase):
 
     def test_MustHonorDomain(self):
         """Must also honor a provided Domain"""
-        res = self.Partner.name_search("+351", args=[("supplier_rank", "=", True)])
+        res = self.Partner.name_search("+351", args=[("vat", "=", "3333")])
         gambulputty = self.partner3.id
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0][0], gambulputty)

--- a/base_name_search_improved/views/ir_model_views.xml
+++ b/base_name_search_improved/views/ir_model_views.xml
@@ -15,24 +15,28 @@
                         </h1>
                     </div>
                     <p class="alert alert-info" role="alert" style="margin-bottom:0px;">
-                        Smart Search se puede activar de dos formas que pueden ser complementarias:
+                        Smart Search can be activated in two complementary ways:
                         <ul>
-                            <li><b
-                                >Vista de búsqueda</b>: a la hora de buscar en vistas listas, kanban y demás, la primer opción será buscar mediante "Smart Search"
+                            <li>
+                                <b
+                                >Smart Search</b>: when searching in list, kanban and other views, the first option will be to search using "Smart Search"
                             </li>
-                            <li><b
-                                >Name Search</b>: es para cuando estemos queriendo buscar un registro desde otro registro a través de los widgets m2o/m2m, por ejemplo al agregar un producto en una línea de venta o al elegir un contacto en una factura.
+                            <li>
+                                <b
+                                >Smart Name Search</b>: when searching for a record from another record through the m2o/m2m widgets, for example when adding a Product in a Sales Order Line or when selecting a Contact in an Invoice.
                             </li>
                         </ul>
-                        En donde se haya activado "Smart Search" las búsquedas tendrán un comportmiento más "relajado". Nativamente Odoo busca por registors que incluyan las palabras ingresadas tal cual las ha ingresado, al activar esta opción se buscará por registros que contegan dichas palabras y sin importar el orden en el que se ingresen. Por ej. si buscamos un Contacto con "Pedro Picapiedra", naticamente Odoo solo nos retornaría aquellos registros  que contengan exactamente ese texto, con smart search activo se devolverá cualquier registro que contenga las palabras "Pedro" y "Picapiedra".<br
-                        /><br />
+                        If "Smart Search" has been activated, searches will have a more "relaxed" behaviour. Odoo natively searches for records that include the phrases entered as they are entered. When activating this option it will search for records that contain entered words regardless of the order in which they are entered. For example if we search for a Contact "Fred Flinstone", Odoo would by default only return those records that contain exactly that phrase. With Smart Search active any record containing the words "Fred" and "Flinstone" will be returned.
+                        <br />
+                        <br />
 
-                        Al activar Smart Search podrá además agregar configurar estos dos comportamientos opcionales:
+                        By enabling Smart Search you can also add configure these two optional behaviours:
                         <ul>
-                            <li>Definir un <b
-                                >dominio personalizado</b> (por ejemplo solo mostrar usuarios internos y no los portal)</li>
-                            <li><b
-                                >Búsquedas por otros campos</b>. Podremos definir un conjunto de campos por el cual querramos buscar</li>
+                            <li>Define a <b
+                                >Smart Search Domain</b> (for example, only show internal users and not portal users)</li>
+                            <li>
+                                <b
+                                >Smart Search Fields</b>. You can define a set of fields by which we want to search</li>
                         </ul>
                     </p>
                     <p
@@ -41,7 +45,7 @@
                         style="margin-bottom:0px;"
                     >
                         <b
-                        >IMPORTANTE:</b> tenga en cuenta que activar smart search puede afectar la performance de las búsquedas y del sistema en general.
+                        >IMPORTANT:</b> Please note that enabling smart search may affect the performance of searches and the system in general.
                         <field name="smart_search_warning" />
                     </p>
                     <group>

--- a/base_name_search_improved/views/ir_model_views.xml
+++ b/base_name_search_improved/views/ir_model_views.xml
@@ -2,7 +2,6 @@
 <!-- © 2016 Daniel Reis
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-
     <record id="view_model_form_new" model="ir.ui.view">
         <field name="name">view.model.form</field>
         <field name="model">ir.model</field>
@@ -18,37 +17,64 @@
                     <p class="alert alert-info" role="alert" style="margin-bottom:0px;">
                         Smart Search se puede activar de dos formas que pueden ser complementarias:
                         <ul>
-                            <li><b>Vista de búsqueda</b>: a la hora de buscar en vistas listas, kanban y demás, la primer opción será buscar mediante "Smart Search"
+                            <li><b
+                                >Vista de búsqueda</b>: a la hora de buscar en vistas listas, kanban y demás, la primer opción será buscar mediante "Smart Search"
                             </li>
-                            <li><b>Name Search</b>: es para cuando estemos queriendo buscar un registro desde otro registro a través de los widgets m2o/m2m, por ejemplo al agregar un producto en una línea de venta o al elegir un contacto en una factura.
+                            <li><b
+                                >Name Search</b>: es para cuando estemos queriendo buscar un registro desde otro registro a través de los widgets m2o/m2m, por ejemplo al agregar un producto en una línea de venta o al elegir un contacto en una factura.
                             </li>
                         </ul>
-                        En donde se haya activado "Smart Search" las búsquedas tendrán un comportmiento más "relajado". Nativamente Odoo busca por registors que incluyan las palabras ingresadas tal cual las ha ingresado, al activar esta opción se buscará por registros que contegan dichas palabras y sin importar el orden en el que se ingresen. Por ej. si buscamos un Contacto con "Pedro Picapiedra", naticamente Odoo solo nos retornaría aquellos registros  que contengan exactamente ese texto, con smart search activo se devolverá cualquier registro que contenga las palabras "Pedro" y "Picapiedra".<br/><br/>
+                        En donde se haya activado "Smart Search" las búsquedas tendrán un comportmiento más "relajado". Nativamente Odoo busca por registors que incluyan las palabras ingresadas tal cual las ha ingresado, al activar esta opción se buscará por registros que contegan dichas palabras y sin importar el orden en el que se ingresen. Por ej. si buscamos un Contacto con "Pedro Picapiedra", naticamente Odoo solo nos retornaría aquellos registros  que contengan exactamente ese texto, con smart search activo se devolverá cualquier registro que contenga las palabras "Pedro" y "Picapiedra".<br
+                        /><br />
 
                         Al activar Smart Search podrá además agregar configurar estos dos comportamientos opcionales:
                         <ul>
-                            <li>Definir un <b>dominio personalizado</b> (por ejemplo solo mostrar usuarios internos y no los portal)</li>
-                            <li><b>Búsquedas por otros campos</b>. Podremos definir un conjunto de campos por el cual querramos buscar</li>
+                            <li>Definir un <b
+                                >dominio personalizado</b> (por ejemplo solo mostrar usuarios internos y no los portal)</li>
+                            <li><b
+                                >Búsquedas por otros campos</b>. Podremos definir un conjunto de campos por el cual querramos buscar</li>
                         </ul>
                     </p>
-                    <p class="alert alert-warning" role="alert" style="margin-bottom:0px;">
-                        <b>IMPORTANTE:</b> tenga en cuenta que activar smart search puede afectar la performance de las búsquedas y del sistema en general.
-                        <field name="smart_search_warning"/>
+                    <p
+                        class="alert alert-warning"
+                        role="alert"
+                        style="margin-bottom:0px;"
+                    >
+                        <b
+                        >IMPORTANTE:</b> tenga en cuenta que activar smart search puede afectar la performance de las búsquedas y del sistema en general.
+                        <field name="smart_search_warning" />
                     </p>
                     <group>
                         <group>
                             <field name="id" invisible="1" />
                             <field name="model" readonly="1" />
-                            <field name="add_smart_search" string="Smart Search (search view)" widget="boolean_toggle"/>
-                            <field name="use_smart_name_search" string="Smart Name Search" widget="boolean_toggle"/>
+                            <field
+                                name="add_smart_search"
+                                string="Smart Search (search view)"
+                                widget="boolean_toggle"
+                            />
+                            <field
+                                name="use_smart_name_search"
+                                string="Smart Name Search"
+                                widget="boolean_toggle"
+                            />
                             <!-- TODO use new odoo domain widget -->
-                            <field name="name_search_domain" attrs="{'invisible': [('use_smart_name_search', '=', False), ('add_smart_search', '=', False)]}"/>
+                            <field
+                                name="name_search_domain"
+                                attrs="{'invisible': [('use_smart_name_search', '=', False), ('add_smart_search', '=', False)]}"
+                            />
                         </group>
                     </group>
-                    <notebook colspan="4" attrs="{'invisible': [('use_smart_name_search', '=', False), ('add_smart_search', '=', False)]}">
+                    <notebook
+                        colspan="4"
+                        attrs="{'invisible': [('use_smart_name_search', '=', False), ('add_smart_search', '=', False)]}"
+                    >
                         <page string="Smart Search Fields">
                             <!-- we use default m2m widget and not tags widget so that is clearer the technical name of the field added -->
-                            <field name="name_search_ids" domain="[('model_id', '=', id), ('selectable', '=', True)]">
+                            <field
+                                name="name_search_ids"
+                                domain="[('model_id', '=', id), ('selectable', '=', True)]"
+                            >
                                 <tree>
                                     <field name="name" />
                                     <field name="field_description" />
@@ -122,7 +148,9 @@
             (0, 0, {'view_mode': 'form', 'view_id': ref('view_model_form_new')}
         )]"
         />
-        <field name="context">{'search_default_smart_search': 1, 'search_default_smart_name_search': 1}</field>
+        <field
+            name="context"
+        >{'search_default_smart_search': 1, 'search_default_smart_name_search': 1}</field>
         <field name="domain">[('transient', '=', False)]</field>
     </record>
     <menuitem

--- a/base_name_search_improved/views/ir_model_views.xml
+++ b/base_name_search_improved/views/ir_model_views.xml
@@ -2,69 +2,53 @@
 <!-- © 2016 Daniel Reis
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <record id="view_model_form" model="ir.ui.view">
-        <field name="name">Add Name Searchable to Models</field>
-        <field name="model">ir.model</field>
-        <field name="inherit_id" ref="base.view_model_form" />
-        <field name="arch" type="xml">
-            <field name="state" position="after">
-                <field name="add_smart_search" />
-                <field
-                    name="name_search_ids"
-                    widget="many2many_tags"
-                    domain="[('model_id', '=', id), ('store', '=', True)]"
-                />
-                <field name="name_search_domain" />
-            </field>
-        </field>
-    </record>
+
     <record id="view_model_form_new" model="ir.ui.view">
         <field name="name">view.model.form</field>
         <field name="model">ir.model</field>
         <field name="arch" type="xml">
             <form string="Custom Search">
                 <sheet>
-                    <div class="oe_button_box" name="buttons">
-                        <button
-                            name="toggle_smart_search"
-                            type="object"
-                            class="oe_stat_button"
-                            icon="fa-archive"
-                        >
-                            <field
-                                name="add_smart_search"
-                                widget="boolean_button"
-                                options="{'terminology': {
-                                'string_true': 'Smart Active',
-                                'hover_true': 'Remove Smart Search',
-                                'string_false': 'Not Smart Search',
-                                'hover_false': 'Add Smart Search',
-                                }}"
-                            />
-                        </button>
-                    </div>
                     <div class="oe_title">
                         <label for="name" class="oe_edit_only" />
                         <h1>
                             <field name="name" readonly="1" />
                         </h1>
                     </div>
+                    <p class="alert alert-info" role="alert" style="margin-bottom:0px;">
+                        Smart Search se puede activar de dos formas que pueden ser complementarias:
+                        <ul>
+                            <li><b>Vista de búsqueda</b>: a la hora de buscar en vistas listas, kanban y demás, la primer opción será buscar mediante "Smart Search"
+                            </li>
+                            <li><b>Name Search</b>: es para cuando estemos queriendo buscar un registro desde otro registro a través de los widgets m2o/m2m, por ejemplo al agregar un producto en una línea de venta o al elegir un contacto en una factura.
+                            </li>
+                        </ul>
+                        En donde se haya activado "Smart Search" las búsquedas tendrán un comportmiento más "relajado". Nativamente Odoo busca por registors que incluyan las palabras ingresadas tal cual las ha ingresado, al activar esta opción se buscará por registros que contegan dichas palabras y sin importar el orden en el que se ingresen. Por ej. si buscamos un Contacto con "Pedro Picapiedra", naticamente Odoo solo nos retornaría aquellos registros  que contengan exactamente ese texto, con smart search activo se devolverá cualquier registro que contenga las palabras "Pedro" y "Picapiedra".<br/><br/>
+
+                        Al activar Smart Search podrá además agregar configurar estos dos comportamientos opcionales:
+                        <ul>
+                            <li>Definir un <b>dominio personalizado</b> (por ejemplo solo mostrar usuarios internos y no los portal)</li>
+                            <li><b>Búsquedas por otros campos</b>. Podremos definir un conjunto de campos por el cual querramos buscar</li>
+                        </ul>
+                    </p>
+                    <p class="alert alert-warning" role="alert" style="margin-bottom:0px;">
+                        <b>IMPORTANTE:</b> tenga en cuenta que activar smart search puede afectar la performance de las búsquedas y del sistema en general.
+                        <field name="smart_search_warning"/>
+                    </p>
                     <group>
                         <group>
                             <field name="id" invisible="1" />
                             <field name="model" readonly="1" />
-                            <field name="name_search_domain" />
+                            <field name="add_smart_search" string="Smart Search (search view)" widget="boolean_toggle"/>
+                            <field name="use_smart_name_search" string="Smart Name Search" widget="boolean_toggle"/>
+                            <!-- TODO use new odoo domain widget -->
+                            <field name="name_search_domain" attrs="{'invisible': [('use_smart_name_search', '=', False), ('add_smart_search', '=', False)]}"/>
                         </group>
                     </group>
-                    <notebook colspan="4">
-                        <page string="Fields">
-                            <!-- widget="many2many_tags" -->
-                            <field
-                                name="name_search_ids"
-                                colspan="4"
-                                nolabel="1"
-                                domain="[('model_id', '=', id), ('store', '=', True)]"
-                            >
+                    <notebook colspan="4" attrs="{'invisible': [('use_smart_name_search', '=', False), ('add_smart_search', '=', False)]}">
+                        <page string="Smart Search Fields">
+                            <!-- we use default m2m widget and not tags widget so that is clearer the technical name of the field added -->
+                            <field name="name_search_ids" domain="[('model_id', '=', id), ('selectable', '=', True)]">
                                 <tree>
                                     <field name="name" />
                                     <field name="field_description" />
@@ -97,6 +81,11 @@
                     string="Smart Search"
                     widget="boolean_toggle"
                 />
+                <field
+                    name="use_smart_name_search"
+                    string="Smart Name Search"
+                    widget="boolean_toggle"
+                />
             </tree>
         </field>
     </record>
@@ -109,20 +98,20 @@
                 <field name="name" />
                 <field name="model" />
                 <filter
-                    name="extra_search"
-                    string="With Custom Search"
-                    domain="[('name_search_ids', '!=', False)]"
-                />
-                <filter
                     name="smart_search"
                     string="Smart Search"
                     domain="[('add_smart_search', '=', True)]"
+                />
+                <filter
+                    name="smart_name_search"
+                    string="Smart Name Search"
+                    domain="[('use_smart_name_search', '=', True)]"
                 />
             </search>
         </field>
     </record>
     <record id="action_improved_name_search" model="ir.actions.act_window">
-        <field name="name">Custom Searches</field>
+        <field name="name">Smart Searches</field>
         <field name="res_model">ir.model</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="view_model_search" />
@@ -133,12 +122,12 @@
             (0, 0, {'view_mode': 'form', 'view_id': ref('view_model_form_new')}
         )]"
         />
-        <field name="context">{'search_default_extra_search': 1}</field>
+        <field name="context">{'search_default_smart_search': 1, 'search_default_smart_name_search': 1}</field>
         <field name="domain">[('transient', '=', False)]</field>
     </record>
     <menuitem
         id="menu_improved_name_search"
-        name="Custom Searches"
+        name="Smart Searches"
         parent="base.menu_administration"
         sequence="6"
         action="action_improved_name_search"


### PR DESCRIPTION
This has 2 parts:

1. Forward port of patches from 13.0 to improve GUI, tests, ...
2. Fix to interactive search where code taken from 13.0 leads to exceptions in `_extend_name_results` as `results` contains list of ids directly (instead of expected records). Upon fixing that extending results with `lazy_name_get` results into exception in ORM like `psycopg2.ProgrammingError: can't adapt type 'lazy'` So I am trying to fix both of these.
3. Translate Spanish texts to English

Feedback is welcome.