### PR TITLE
[14.0][FIX] excel_import_export: external ids naming.

### DIFF
--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -50,7 +50,7 @@ class XLSXImport(models.AbstractModel):
             ModelData.create(
                 {
                     "name": "{}_{}".format(record._table, record.id),
-                    "module": "excel_import_export",
+                    "module": "__excel_import_export__",
                     "model": record._name,
                     "res_id": record.id,
                 }


### PR DESCRIPTION
FW Port from https://github.com/OCA/server-tools/pull/1899

Because of the naming given to the external ID's, Odoo
interprets all this data as regular module data and when
you update the module and those external ID's are not present
in the module files, it tries to delete them.