### PR TITLE
[12.0] IMP base_model_restrict_update: readonly users can create wizards

### DIFF
--- a/base_model_restrict_update/models/ir_model.py
+++ b/base_model_restrict_update/models/ir_model.py
@@ -12,3 +12,5 @@ class IrModel(models.Model):
         help="When selected, the model is restricted to read-only unless the "
         "user has the special permission.",
     )
+    skip_check_for_readonly_users = fields.Boolean(
+        help="Allow readonly users to create/write/delete records of this model")

--- a/base_model_restrict_update/models/ir_model_access.py
+++ b/base_model_restrict_update/models/ir_model_access.py
@@ -49,13 +49,11 @@ class IrModelAccess(models.Model):
 
     @api.model
     def _readonly_exclude_models(self):
-        transient_models = self.env["ir.model"].sudo().search(
-            [("transient", "=", True)]).mapped("model")
         skipped_models = self.env["ir.model"].sudo().search([
-            ("skip_check_for_readonly_users", "=", True)
+            "|", ("transient", "=", True), ("skip_check_for_readonly_users", "=", True)
         ]).mapped("model")
         # Models updtate/create by system, and should be excluded from checking
-        return skipped_models + transient_models + self.sudo().search([
+        return skipped_models + self.sudo().search([
             ("group_id", "=", False),
             "|", ("perm_write", "=", True),
             "|", ("perm_create", "=", True), ("perm_unlink", "=", True)

--- a/base_model_restrict_update/models/ir_model_access.py
+++ b/base_model_restrict_update/models/ir_model_access.py
@@ -48,8 +48,10 @@ class IrModelAccess(models.Model):
 
     @api.model
     def _readonly_exclude_models(self):
-        """ Models updtate/create by system, and should be excluded from checking """
-        return self.sudo().search([
+        transient_models = self.env["ir.model"].sudo().search(
+            [("transient", "=", True)]).mapped("model")
+        # Models updtate/create by system, and should be excluded from checking
+        return transient_models + self.sudo().search([
             ("group_id", "=", False),
             "|", ("perm_write", "=", True),
             "|", ("perm_create", "=", True), ("perm_unlink", "=", True)

--- a/base_model_restrict_update/readme/CONFIGURE.rst
+++ b/base_model_restrict_update/readme/CONFIGURE.rst
@@ -1,3 +1,7 @@
 Enable the "Update Restrict Model" of specific model to restrict update from unpermitted users.
+
 To set a user as a permitted user to update restricted model(s), click on "Grant Update Permit" in user form.
+
 Optionally, to set a user as readonly user to all models, click on "Readonly User" in user form.
+
+Also, you can allow readonly users to create/write/delete records of specific models by enabling "skip check for readonly users" field of specific model.

--- a/base_model_restrict_update/tests/test_base_model_restrict_update.py
+++ b/base_model_restrict_update/tests/test_base_model_restrict_update.py
@@ -62,3 +62,14 @@ class TestBaseModelRestrictUpdate(SavepointCase):
             self.test_partner.sudo(self.permit_test_user.id).update(
                 {"name": "Test Partner 2"}
             )
+
+        self.partner_model.restrict_update = False
+        with self.assertRaises(AccessError):
+            self.test_partner.sudo(self.permit_test_user.id).update(
+                {"name": "Test Partner 2"}
+            )
+
+        self.partner_model.skip_check_for_readonly_users = True
+        self.test_partner.sudo(self.permit_test_user.id).update(
+            {"name": "Test Partner 2"}
+        )

--- a/base_model_restrict_update/views/ir_model_views.xml
+++ b/base_model_restrict_update/views/ir_model_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <field name="transient" position="after">
                 <field name="restrict_update" />
+                <field name="skip_check_for_readonly_users" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This is useful for reporting wizards typically