### PR TITLE
[14.0][IMP] sql_export: Make possible to make sql queries on an external database

### DIFF
--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -65,6 +65,10 @@
                             name="encoding"
                             attrs="{'readonly': [('state', '!=', 'draft')]}"
                         />
+                        <field
+                            name="use_external_database"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                        />
                     </group>
                     <group
                         name="request"

--- a/sql_request_abstract/__init__.py
+++ b/sql_request_abstract/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import sql_db

--- a/sql_request_abstract/readme/CONFIGURE.rst
+++ b/sql_request_abstract/readme/CONFIGURE.rst
@@ -1,0 +1,6 @@
+To configure the use of an external database, you need to edit the main configuration file of your instance and add the external database configuration with following keys :
+* external_db_user
+* external_db_password
+* external_db_name
+* external_db_host
+* external_db_port

--- a/sql_request_abstract/readme/DESCRIPTION.rst
+++ b/sql_request_abstract/readme/DESCRIPTION.rst
@@ -18,3 +18,6 @@ Implemented features
     * SQL Request / User : Can see all the sql requests by default and execute
       them, if they are valid.
     * SQL Request / Manager : has full access on sql requests.
+
+* The request can be run against an external database (only read queries for now)
+  It may be usefull to avoid overloading the production server for example.

--- a/sql_request_abstract/sql_db.py
+++ b/sql_request_abstract/sql_db.py
@@ -1,0 +1,22 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import tools
+from odoo.sql_db import Connection, ConnectionPool, _Pool  # noqa
+
+
+def connection_info_for_external_database():
+    db_name = tools.config.get("external_db_name")
+    connection_info = {"database": db_name}
+    for p in ("host", "port", "user", "password"):
+        cfg = tools.config.get("external_db_" + p)
+        if cfg:
+            connection_info[p] = cfg
+    return db_name, connection_info
+
+
+def get_external_cursor():
+    global _Pool
+    if _Pool is None:
+        _Pool = ConnectionPool(int(tools.config["db_maxconn"]))
+    db, info = connection_info_for_external_database()
+    return Connection(_Pool, db, info).cursor()


### PR DESCRIPTION
Replace https://github.com/OCA/server-tools/pull/2290

Make possible to make queries on an external database (Common case would be a replication of the production database).
The goal beeing to not overload the production database server in case many heavy queries are done frequently.