### PR TITLE
[14.0] rpc_helper: add config via UI

### DIFF
--- a/rpc_helper/__init__.py
+++ b/rpc_helper/__init__.py
@@ -1,1 +1,2 @@
+from . import models
 from .hooks import post_load_hook

--- a/rpc_helper/__manifest__.py
+++ b/rpc_helper/__manifest__.py
@@ -11,5 +11,7 @@
     "website": "https://github.com/OCA/server-tools",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["simahawk"],
+    "depends": ["base_sparse_field"],
+    "data": ["views/ir_model_views.xml"],
     "post_load": "post_load_hook",
 }

--- a/rpc_helper/models/__init__.py
+++ b/rpc_helper/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_model

--- a/rpc_helper/models/ir_model.py
+++ b/rpc_helper/models/ir_model.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Camptocamp SA
+# @author: Simone Orsi <simone.orsi@camptocamp.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import json
+
+from odoo import api, fields, models, tools
+
+from odoo.addons.base_sparse_field.models.fields import Serialized
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    rpc_config = Serialized(compute="_compute_rpc_config", default={})
+    # Allow editing via UI
+    rpc_config_edit = fields.Text(
+        help="Configure RPC config via JSON. "
+        "Value must be a list of methods to disable "
+        "wrapped by a dict with key `disable`. "
+        "Eg: {'disable': ['search', 'do_this']}"
+        "To disable all methods, use `{'disable: ['all']}`",
+        inverse="_inverse_rpc_config_edit",
+    )
+
+    @api.depends("rpc_config_edit")
+    def _compute_rpc_config(self):
+        for rec in self:
+            rec.rpc_config = rec._load_rpc_config()
+
+    def _inverse_rpc_config_edit(self):
+        for rec in self:
+            # Make sure options_edit is always readable
+            rec.rpc_config_edit = json.dumps(
+                rec.rpc_config or {}, indent=4, sort_keys=True
+            )
+
+    def _load_rpc_config(self):
+        return json.loads(self.rpc_config_edit or "{}")
+
+    @tools.ormcache("model")
+    def _get_rpc_config(self, model):
+        rec = self._get(model)
+        return rec.rpc_config or {}

--- a/rpc_helper/patch.py
+++ b/rpc_helper/patch.py
@@ -22,5 +22,9 @@ def protected__execute_cr(cr, uid, obj, method, *args, **kw):
 def _rpc_allowed(recordset, method):
     config = getattr(recordset, "_disable_rpc", None)
     if config is None:
+        config = (
+            recordset.env["ir.model"]._get_rpc_config(recordset._name).get("disable")
+        )
+    if config is None:
         return True
     return "all" not in config and method not in config

--- a/rpc_helper/readme/CONFIGURATION.rst
+++ b/rpc_helper/readme/CONFIGURATION.rst
@@ -1,0 +1,23 @@
+Enable debug mode and go to "Technical -> Database Structure -> Models".
+
+Open the model that you like to configure and go to the tab "RPC config".
+
+There you see a text field which supports JSON configuration.
+
+The configuration is the same you can pass via decorator.
+The only difference is that you have to wrap values in a dictionary
+like `{"disable": [...values...]}`.
+
+To disable all calls::
+
+    {
+        "disable": ["all"],
+    }
+
+To disable only some methods::
+
+    {
+        "disable": ["create", "write", "another_method"],
+    }
+
+NOTE: on the resulting JSON will be automatically formatted on save for better readability.

--- a/rpc_helper/readme/USAGE.rst
+++ b/rpc_helper/readme/USAGE.rst
@@ -1,3 +1,6 @@
+Via code
+~~~~~~~~
+
 Decorate an Odoo model class like this::
 
     from odoo.addons.rpc_helper.decorator import disable_rpc
@@ -13,3 +16,9 @@ To selectively disable only some methods::
     @disable_rpc("create", "write", "any_method")
     class AverageModel(models.Model):
         _inherit = "avg.model"
+
+
+Via `ir.model` configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See "Configuration" section.

--- a/rpc_helper/rpc_test_example.py
+++ b/rpc_helper/rpc_test_example.py
@@ -4,7 +4,7 @@ from xmlrpc import client
 
 HOST = "127.0.0.1"
 PORT = 8069
-DB_NAME = "ododdb"
+DB_NAME = "odoodb"
 
 url = "http://%s:%d/xmlrpc/2/" % (HOST, PORT)
 xmlrpc_common = client.ServerProxy(url + "common")

--- a/rpc_helper/views/ir_model_views.xml
+++ b/rpc_helper/views/ir_model_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+-->
+<odoo>
+    <record id="view_model_form" model="ir.ui.view">
+        <field name="name">rpc_helper view_model_form</field>
+        <field name="model">ir.model</field>
+        <field name="inherit_id" ref="base.view_model_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook/page[@name='views']" position="after">
+                <page name="rpc_config" string="RPC config">
+                  <field
+                        name="rpc_config_edit"
+                        groups="base.group_no_one"
+                        widget="ace"
+                    />
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Enable debug mode and go to "Technical -> Database Structure -> Models".

Open the model that you like to configure and go to the tab "RPC config".

There you see a text field which supports JSON configuration.

The configuration is the same you can pass via decorator.
The only difference is that you have to wrap values in a dictionary
like `{"disable": [...values...]}`.

To disable all calls::

    {
        "disable": ["all"],
    }

To disable only some methods::

    {
        "disable": ["create", "write", "another_method"],
    }

NOTE: on the resulting JSON will be automatically formatted on save for better readability.
