### PR TITLE
[14.0][ADD] base_generate_code module

### DIFF
--- a/base_generate_code/__init__.py
+++ b/base_generate_code/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/base_generate_code/__manifest__.py
+++ b/base_generate_code/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "base_generate_code",
+    "summary": "Code Generator",
+    "version": "14.0.1.0.0",
+    "category": "Tools",
+    "website": "https://github.com/OCA/server-tools",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["sale"],
+    "data": [
+        "security/ir.model.access.csv",
+    ],
+}

--- a/base_generate_code/i18n/fr.po
+++ b/base_generate_code/i18n/fr.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* base_generate_code
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-24 21:07+0000\n"
+"PO-Revision-Date: 2022-02-24 22:09+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr_FR\n"
+"X-Generator: Poedit 3.0\n"
+
+#. module: base_generate_code
+#: model:ir.model.fields,field_description:base_generate_code.field_code_format_mixin__code
+msgid "Code"
+msgstr "Code"
+
+#. module: base_generate_code
+#: model:ir.model,name:base_generate_code.model_code_format_mixin
+msgid "Customizable code format Mixin"
+msgstr ""
+
+#. module: base_generate_code
+#: model:ir.model.fields,field_description:base_generate_code.field_code_format_mixin__display_name
+msgid "Display Name"
+msgstr "Nom"
+
+#. module: base_generate_code
+#: model:ir.model.fields,field_description:base_generate_code.field_code_format_mixin__id
+msgid "ID"
+msgstr "ID"
+
+#. module: base_generate_code
+#: model:ir.model.fields,field_description:base_generate_code.field_code_format_mixin____last_update
+msgid "Last Modified on"
+msgstr "Dernière Modification le"
+
+#. module: base_generate_code
+#: code:addons/base_generate_code/models/code_format_mixin.py:0
+#, python-format
+msgid "Unable to generate a non existing random code."
+msgstr "Impossible de générer un code aléatoire non existant."

--- a/base_generate_code/models/__init__.py
+++ b/base_generate_code/models/__init__.py
@@ -1,0 +1,1 @@
+from . import code_format_mixin

--- a/base_generate_code/models/code_format_mixin.py
+++ b/base_generate_code/models/code_format_mixin.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2021 Akretion (<http://www.akretion.com>).
+# @author Florian Mounier <florian.mounier@akretion.com>
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from random import choice
+from string import ascii_lowercase, ascii_uppercase, digits
+
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+
+class CodeFormatMixin(models.AbstractModel):
+    _name = "code.format.mixin"
+    _description = "Customizable code format Mixin"
+
+    #  1/ _code_mask must be added in the related model
+    # e.g. in "gift.card":
+    #     _code_mask = {
+    #       "mask": "code_mask",
+    #       "template": "gift_card_tmpl_id"
+    #      }
+
+    # 2/ In addition, update a method of the target model to
+    # compute the code. For example the create method:
+    #     @api.model
+    #     def create(self, vals):
+    #         res = super().create(vals)
+    #         vals["code"] = res._generate_code()
+
+    _code_mask = {}
+
+    _default_mask = "XXXXXX-00"
+    _forbidden_characters = "iI1oO0"
+    _dedup_max_retries = 20
+
+    def _generate_code(self):
+        choices = self._get_choice_collections()
+        for rec in self:
+            mask = rec._get_mask()
+            code = rec._generate_code_from_mask(choices, mask)
+            retries = 0
+            while len(self.search([("code", "=", code)])):
+                code = rec._generate_code_from_mask(choices, mask)
+                retries += 1
+                if retries > self._dedup_max_retries:
+                    raise ValidationError(
+                        _("Unable to generate a non existing random code.")
+                    )
+            return code
+
+    code = fields.Char(compute=_generate_code, readonly=True, store=True)
+
+    def _get_mask(self):
+        return self[self._code_mask["template"]][self._code_mask["mask"]]
+
+    def _generate_mask(self, mask):
+        if not mask:
+            mask = self._default_mask
+        return mask
+
+    def _generate_code_from_mask(self, choices, mask):
+        def unmask(char):
+            char_collection = choices.get(char)
+            if char_collection:
+                return choice(char_collection)
+            return char
+
+        final_mask = self._generate_mask(mask)
+        return "".join(unmask(char) for char in final_mask)
+
+    def _get_choice_collections(self):
+        # x means a random lowercase letter
+        # X means a random uppercase letter
+        # 0 means a random digit
+        return {
+            "X": [
+                char
+                for char in ascii_uppercase
+                if char not in self._forbidden_characters
+            ],
+            "x": [
+                char
+                for char in ascii_lowercase
+                if char not in self._forbidden_characters
+            ],
+            "0": digits,
+        }

--- a/base_generate_code/readme/CONTRIBUTORS.rst
+++ b/base_generate_code/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Kévin Roche <kevin.roche@akretion.com>
+* Florian Mounier <florian.mounier@akretion.com>

--- a/base_generate_code/readme/DESCRIPTION.rst
+++ b/base_generate_code/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module generate code as readable for humans: not too long, random enough, without some ambiguous char like ( "O" "0", "I", "L"), not memorable, without meaning (no words), acceptable as a barcode (like code123, 123CoDe, 1code-23, ...).

--- a/base_generate_code/readme/USAGE.rst
+++ b/base_generate_code/readme/USAGE.rst
@@ -1,0 +1,9 @@
+1/ _code_mask must be added in the related model e.g. in "gift.card":
+_code_mask = {
+"mask": "code_mask",
+"template": "gift_card_tmpl_id"
+}
+2/ In the related model, You can change the code_mask value or use its default value (XXXXXX-00): x means a random lowercase letter, X means a random uppercase letter, 0 means a random digit.
+3/ In addition, update a method of the target model to compute the code. For example the create method:
+res = super().create(vals)
+vals["code"] = res._generate_code()

--- a/base_generate_code/security/ir.model.access.csv
+++ b/base_generate_code/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_code_format_mixin,code.format.mixin,model_code_format_mixin,base.group_user,1,1,1,1

--- a/base_generate_code/tests/__init__.py
+++ b/base_generate_code/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_code_format_mixin

--- a/base_generate_code/tests/fake_models.py
+++ b/base_generate_code/tests/fake_models.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class FakeProductFactory(models.Model):
+    _name = "fake.product.factory"
+    _description = "fake model for tests"
+
+    name = fields.Char()
+    code_mask = fields.Char()
+
+
+class FakeProduct(models.Model):
+    _name = "fake.product"
+    _inherit = "code.format.mixin"
+    _description = "fake model for tests"
+    _code_mask = {"mask": "code_mask", "template": "tmpl_id"}
+    tmpl_id = fields.Many2one("fake.product.factory")
+    code = fields.Char()
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        res.code = res._generate_code()
+        return res

--- a/base_generate_code/tests/test_code_format_mixin.py
+++ b/base_generate_code/tests/test_code_format_mixin.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from string import ascii_lowercase, ascii_uppercase, digits
+
+from odoo_test_helper import FakeModelLoader
+
+from odoo.tests.common import SavepointCase
+
+
+class TestCodeFormatMixin(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .fake_models import FakeProduct, FakeProductFactory
+
+        cls.loader.update_registry((FakeProductFactory, FakeProduct))
+
+        factory = cls.env["fake.product.factory"]
+
+        cls.factory_1 = factory.create({"code_mask": "XXX-000"})
+
+        cls.factory_2 = factory.create({"code_mask": "Xxx-000-x0X0"})
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
+
+    def _reverse_mask(self, code):
+        reverse_mask = ""
+        for car in code:
+            if car in ascii_uppercase:
+                reverse_mask += "X"
+            elif car in ascii_lowercase:
+                reverse_mask += "x"
+            elif car in digits:
+                reverse_mask += "0"
+            else:
+                reverse_mask += car
+        return reverse_mask
+
+    def test_1_default_code_format(self):
+        self.factory_1.code_mask = ""
+
+        product = self.env["fake.product"]
+        product_1 = product.create({"tmpl_id": self.factory_1.id})
+        self._reverse_mask(product_1.code)
+        self.assertEqual(self._reverse_mask(product_1.code), "XXXXXX-00")
+
+    def test_2_custom_code(self):
+
+        product = self.env["fake.product"]
+        product_1 = product.create({"tmpl_id": self.factory_1.id})
+        self._reverse_mask(product_1.code)
+        self.assertEqual(self._reverse_mask(product_1.code), self.factory_1.code_mask)
+
+        product_2 = product.create({"tmpl_id": self.factory_2.id})
+        self.assertEqual(self._reverse_mask(product_2.code), self.factory_2.code_mask)

--- a/setup/base_generate_code/odoo/addons/base_generate_code
+++ b/setup/base_generate_code/odoo/addons/base_generate_code
@@ -1,0 +1,1 @@
+../../../../base_generate_code

--- a/setup/base_generate_code/setup.py
+++ b/setup/base_generate_code/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module with a mixin model,  can be plugged to other models, in order to generate random codes  (e.g. for customers' purposes : coupon code, Gift card code, etc.).

It's inspired by <https://github.com/akretion/sale-promotion/tree/14.0-sale-coupon-custom-code-format/sale_coupon_custom_code_format> from @paradoxxxzero

Two questions : 
1) It is the good place for this module? 
2) The test include a fake model, maybe in a second time, split the tests in a second module for test only ?

cc @hparfr, @PierrickBrun 