### PR TITLE
[14.0][IMP] video_link add the possibility to not specify any provider and to manually set url

### DIFF
--- a/base_video_link/models/video_video.py
+++ b/base_video_link/models/video_video.py
@@ -12,20 +12,26 @@ class VideoVideo(models.Model):
 
     sequence = fields.Integer()
     name = fields.Char(required=True)
-    provider_id = fields.Many2one("video.provider", "Provider", required=True)
+    provider_id = fields.Many2one("video.provider", "Provider")
     identifier = fields.Char(required=True)
+    manual_url = fields.Char()
+    manual_thumbnail_url = fields.Char()
     url = fields.Char(compute="_compute_url")
     thumbnail_url = fields.Char(compute="_compute_url")
 
     @api.depends("identifier", "provider_id")
     def _compute_url(self):
         for record in self:
-            record.url = ""
-            record.thumbnail_url = ""
-            provider = record.provider_id
-            if provider.pattern_video_url:
-                record.url = provider.pattern_video_url.format(record=record)
-            if provider.pattern_thumbnail_url:
-                record.thumbnail_url = provider.pattern_thumbnail_url.format(
-                    record=record
-                )
+            if record.provider_id:
+                record.url = ""
+                record.thumbnail_url = ""
+                provider = record.provider_id
+                if provider.pattern_video_url:
+                    record.url = provider.pattern_video_url.format(record=record)
+                if provider.pattern_thumbnail_url:
+                    record.thumbnail_url = provider.pattern_thumbnail_url.format(
+                        record=record
+                    )
+            else:
+                record.url = record.manual_url
+                record.thumbnail_url = record.thumbnail_url

--- a/base_video_link/views/video_video_view.xml
+++ b/base_video_link/views/video_video_view.xml
@@ -24,8 +24,24 @@
             </div>
             <group name="config">
                 <field name="provider_id" />
-                <field name="identifier" />
-                <field name="url" />
+                <field
+                        name="manual_url"
+                        string="Url"
+                        attrs="{'invisible': [('provider_id', '!=', False)]}"
+                    />
+                <field
+                        name="manual_thumbnail_url"
+                        string="Thumbnail Url"
+                        attrs="{'invisible': [('provider_id', '!=', False)]}"
+                    />
+                <field
+                        name="identifier"
+                        attrs="{'invisible': [('provider_id', '=', False)]}"
+                    />
+                <field
+                        name="url"
+                        attrs="{'invisible': [('provider_id', '=', False)]}"
+                    />
             </group>
             <field name="thumbnail_url" widget="image_url" />
         </form>


### PR DESCRIPTION
In case that you import data from a external provider that give you links for video, we need to have a simple posibilty to set the url and thumbnail url without configuring a provider