### PR TITLE
[12.0][FIX] fix database_cleanup logging arguments error

### DIFF
--- a/database_cleanup/models/purge_tables.py
+++ b/database_cleanup/models/purge_tables.py
@@ -79,7 +79,7 @@ class CleanupPurgeLineTable(models.TransientModel):
             elif line.table_type == 'view':
                 _sql_type = "VIEW"
             self.logger.info(
-                'Dropping %s %s', (_sql_type, line.name))
+                'Dropping %s %s', _sql_type, line.name)
             self.env.cr.execute(
                 "DROP %s %s", (
                     AsIs(_sql_type),


### PR DESCRIPTION
fix "TypeError: not enough arguments for format string" error in `database_cleanup` logging.