### PR TITLE
[12.0][FIX] auditlog: Allow passing a chunk size for autovacuum

### DIFF
--- a/auditlog/models/autovacuum.py
+++ b/auditlog/models/autovacuum.py
@@ -14,7 +14,7 @@ class AuditlogAutovacuum(models.TransientModel):
     _description = "Auditlog - Delete old logs"
 
     @api.model
-    def autovacuum(self, days):
+    def autovacuum(self, days, chunk_size=None):
         """Delete all logs older than ``days``. This includes:
             - CRUD logs (create, read, write, unlink)
             - HTTP requests
@@ -31,9 +31,11 @@ class AuditlogAutovacuum(models.TransientModel):
         )
         for data_model in data_models:
             records = self.env[data_model].search(
-                [('create_date', '<=', fields.Datetime.to_string(deadline))])
+                [('create_date', '<=', fields.Datetime.to_string(deadline))],
+                limit=chunk_size, order='create_date asc')
             nb_records = len(records)
-            records.unlink()
+            with self.env.norecompute():
+                records.unlink()
             _logger.info(
                 "AUTOVACUUM - %s '%s' records deleted",
                 nb_records, data_model)

--- a/auditlog/readme/CONFIGURE.rst
+++ b/auditlog/readme/CONFIGURE.rst
@@ -16,3 +16,7 @@ To activate it and/or change the delay, go to the
 `Auto-vacuum audit logs` entry:
 
 .. image:: ../static/description/autovacuum.png
+
+In case you're having trouble with the amount of records to delete per run,
+you can pass the amount of records to delete for one model per run as the second
+parameter, the default is to delete all records in one go.


### PR DESCRIPTION
this allows administrators to fine tune the amount of records to delete in one run of the autovacuum.

I also think we can get away with not recomputing after deletion, as we delete all relevant records eventually.

I'll be happy to cherry pick this to 13, 14, 15 when merged