### PR TITLE
[12.0][FIX] company_country: handle nonexisting env variable gracefully

### DIFF
--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -35,10 +35,12 @@ class CompanyCountryConfigSettings(models.AbstractModel):
                 ('state', '=', 'to install'),
                 ('name', '=like', 'l10n_%')], limit=1)
             if not l10n_to_install:
-                raise ValidationError(_(
+                _logger.error(_(
                     'COUNTRY environment variable with country code is not '
                     'set and no localization module is marked to be '
-                    'installed.'))
+                    'installed.'
+                ))
+                return
             country_code = l10n_to_install.name.split('l10n_')[1][:2].upper()
 
         country = self.env['res.country'].search([

--- a/company_country/tests/test_company_country.py
+++ b/company_country/tests/test_company_country.py
@@ -38,8 +38,11 @@ class TestCompanyCountry(TransactionCase):
         self.wizard.load_company_country()
         self.assertEqual(self.main_company.country_id.id, False)
 
-        # COUNTRY environment variable not set, should raise
-        with self.assertRaises(ValidationError):
+        # COUNTRY environment variable not set, should log error
+        with self.assertLogs(
+                'odoo.addons.company_country.models.res_config',
+                level='ERROR',
+        ):
             l10n_to_install = self.env['ir.module.module'].search([
                 ('state', '=', 'to install'),
                 ('name', '=like', 'l10n_%')])


### PR DESCRIPTION
@moylop260 @luisg123v I'd like to make this module play nice with runboat (we can't inject env vars there, and probably shouldn't want that), does this totally destroy the point of this module for you or is this change fine?