### PR TITLE
[14.0][ADD] attachment_restrict_deletion module

### DIFF
--- a/attachment_restrict_deletion/__manifest__.py
+++ b/attachment_restrict_deletion/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Invoice Attachment Owner Rule",
+    "summary": "SUMMARY",
+    "version": "14.0.1.0.0",
+    "category": "tools",
+    "website": "https://github.com/OCA/server-tools",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "maintainers": ["Kev-Roche"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "account",
+        "sale",
+    ],
+    "data": [
+        "security/security.xml",
+    ],
+}

--- a/attachment_restrict_deletion/readme/CONTRIBUTORS.rst
+++ b/attachment_restrict_deletion/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kévin Roche <kevin.roche@akretion.com>

--- a/attachment_restrict_deletion/readme/DESCRIPTION.rst
+++ b/attachment_restrict_deletion/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module restricts the deletion of attachments to their creator, as well as to administrative groups.

--- a/attachment_restrict_deletion/security/security.xml
+++ b/attachment_restrict_deletion/security/security.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright (C) 2022 Akretion (<http://www.akretion.com>).
+     @author Kévin Roche <kevin.roche@akretion.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="rule_owner_attachment_unlink" model="ir.rule">
+        <field name="name">Only Creator of attachment can delete it</field>
+        <field name="model_id" ref="base.model_ir_attachment" />
+        <field name="groups" eval="[(4, ref('base.group_user'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[('create_uid','=',user.id)]</field>
+    </record>
+    <record id="rule_admin_attachment_unlink" model="ir.rule">
+        <field name="name">Admin can delete attachments</field>
+        <field name="model_id" ref="base.model_ir_attachment" />
+        <field name="groups" eval="[(4, ref('base.group_system'))]" />
+        <field name="perm_read" eval="0" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="1" />
+        <field name="domain_force">[(1,'=',1)]</field>
+    </record>
+</odoo>

--- a/attachment_restrict_deletion/tests/__init__.py
+++ b/attachment_restrict_deletion/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_invoice_attachment_owner_rule

--- a/attachment_restrict_deletion/tests/test_invoice_attachment_owner_rule.py
+++ b/attachment_restrict_deletion/tests/test_invoice_attachment_owner_rule.py
@@ -1,0 +1,111 @@
+# Copyright 2022 Akretion (https://www.akretion.com).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import base64
+
+from odoo import exceptions
+from odoo.tests.common import SavepointCase
+
+
+class TestInvoiceAttachmentOwnerRule(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestInvoiceAttachmentOwnerRule, cls).setUpClass()
+
+        cls.user1 = cls.env.ref("base.user_admin")
+        cls.user2 = cls.user1.copy(
+            {
+                "name": "user2",
+                "login": "test2",
+                "groups_id": [(6, 0, cls.env.ref("base.group_user").ids)],
+            }
+        )
+        cls.user3_admin = cls.env["res.users"].create(
+            {
+                "name": "User admin",
+                "login": "test admin",
+                "groups_id": [(6, 0, cls.env.ref("base.group_system").ids)],
+            }
+        )
+
+        cls.product = cls.env.ref("product.product_product_4")
+
+        cls.so = (
+            cls.env["sale.order"]
+            .with_user(cls.user1)
+            .create(
+                {
+                    "partner_id": cls.user2.partner_id.id,
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": "sol1",
+                                "product_id": cls.product.id,
+                                "product_uom_qty": 2,
+                                "product_uom": cls.product.uom_id.id,
+                                "price_unit": 100.00,
+                            },
+                        )
+                    ],
+                }
+            )
+        )
+
+        cls.so.order_line.write({"qty_delivered": cls.so.order_line.product_uom_qty})
+        cls.so.action_confirm()
+        cls.so._create_invoices()
+        cls.invoice = cls.so.invoice_ids
+
+    def test_1_owner_can_delete_attachment(self):
+        attachment_sale = (
+            self.env["ir.attachment"]
+            .with_user(self.user1)
+            .create(
+                {
+                    "name": "PJ test",
+                    "res_model": "sale.order",
+                    "res_id": self.so.id,
+                    "datas": base64.b64encode(b"\xff data"),
+                }
+            )
+        )
+        self.assertTrue(
+            self.env["ir.attachment"].search(
+                [("res_model", "=", "sale.order"), ("name", "=", "PJ test")], limit=1
+            )
+        )
+        with self.assertRaises(exceptions.UserError):
+            attachment_sale.with_user(self.user2).unlink()
+
+        attachment_sale.with_user(self.user1).unlink()
+
+        self.assertFalse(
+            self.env["ir.attachment"].search(
+                [("res_model", "=", "sale.order"), ("name", "=", "PJ test")], limit=1
+            )
+        )
+
+    def test_2_root_and_admin_can_delete_attachment(self):
+        attachment_invoice = (
+            self.env["ir.attachment"]
+            .with_user(self.user1)
+            .create(
+                {
+                    "name": "PJ test 2",
+                    "res_model": "account.invoice",
+                    "res_id": self.invoice.id,
+                    "datas": base64.b64encode(b"\xff data"),
+                }
+            )
+        )
+
+        attachment_invoice.with_user(self.user3_admin).unlink()
+        self.assertFalse(
+            self.env["ir.attachment"].search(
+                [("res_model", "=", "account_invoice"), ("name", "=", "PJ test 2")],
+                limit=1,
+            )
+        )

--- a/setup/attachment_restrict_deletion/odoo/addons/attachment_restrict_deletion
+++ b/setup/attachment_restrict_deletion/odoo/addons/attachment_restrict_deletion
@@ -1,0 +1,1 @@
+../../../../attachment_restrict_deletion

--- a/setup/attachment_restrict_deletion/setup.py
+++ b/setup/attachment_restrict_deletion/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module restricts the deletion of attachments to their creator, as well as to administrative groups.