### PR TITLE
[REF] excel_import_export: remove xlrd & xlwt from external dependencies

### DIFF
--- a/excel_import_export/__manifest__.py
+++ b/excel_import_export/__manifest__.py
@@ -10,7 +10,7 @@
     "website": "https://github.com/OCA/server-tools",
     "category": "Tools",
     "depends": ["mail"],
-    "external_dependencies": {"python": ["xlrd", "xlwt", "openpyxl"]},
+    "external_dependencies": {"python": ["openpyxl"]},
     "data": [
         "security/ir.model.access.csv",
         "wizard/export_xlsx_wizard.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ pysftp
 pyyaml
 raven
 unidecode
-xlrd
-xlwt


### PR DESCRIPTION
Because those dependencies are already part of Odoo's base dependencies.