### PR TITLE
[14.0 jsonifier: allow json_key override by resolver 

### DIFF
--- a/jsonifier/exceptions.py
+++ b/jsonifier/exceptions.py
@@ -1,0 +1,7 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+
+class SwallableException(Exception):
+    """An exception that can be safely skipped."""

--- a/jsonifier/models/ir_exports_resolver.py
+++ b/jsonifier/models/ir_exports_resolver.py
@@ -6,13 +6,18 @@ from odoo.tools.safe_eval import safe_eval
 
 help_message = [
     "Compute the result from 'value' by setting the variable 'result'.",
-    "For fields resolvers:",
+    "\n" "For fields resolvers:",
+    ":param record: the record",
     ":param name: name of the field",
     ":param value: value of the field",
     ":param field_type: type of the field",
-    "For global resolvers:",
+    "\n" "For global resolvers:",
     ":param value: JSON dict",
     ":param record: the record",
+    "\n"
+    "In both types, you can override the final json key."
+    "\nTo achieve this, simply return a dict like: "
+    "\n{'result': {'_value': $value, '_json_key': $new_json_key}}",
 ]
 
 
@@ -43,6 +48,7 @@ class FieldResolver(models.Model):
         else:  # param is a field
             for record in records:
                 values = {
+                    "record": record,
                     "value": record[param.name],
                     "name": param.name,
                     "field_type": param.type,

--- a/jsonifier/models/models.py
+++ b/jsonifier/models/models.py
@@ -161,6 +161,11 @@ class Base(models.AbstractModel):
     def _jsonify_record_handle_resolver(self, rec, field, resolver, json_key):
         value = rec._jsonify_value(field, rec[field.name])
         value = resolver.resolve(field, rec)[0] if resolver else value
+        if isinstance(value, dict) and "_json_key" in value and "_value" in value:
+            # Allow override of json_key.
+            # In this case,
+            # the final value must be encapsulated into _value key
+            value, json_key = value["_value"], value["_json_key"]
         return value, json_key
 
     def jsonify(self, parser, one=False):

--- a/jsonifier/models/models.py
+++ b/jsonifier/models/models.py
@@ -12,6 +12,7 @@ from odoo.exceptions import UserError
 from odoo.tools.misc import format_duration
 from odoo.tools.translate import _
 
+from ..exceptions import SwallableException
 from .utils import convert_simple_to_full_parser
 
 _logger = logging.getLogger(__name__)
@@ -77,56 +78,90 @@ class Base(models.AbstractModel):
         strict = self.env.context.get("jsonify_record_strict", False)
         for field in parser:
             field_dict, subparser = rec.__parse_field(field)
-            field_name = field_dict["name"]
-            if field_name not in rec._fields:
-                if strict:
-                    # let it fail
-                    rec._fields[field_name]  # pylint: disable=pointless-statement
-                if not tools.config["test_enable"]:
-                    # If running live, log proper error
-                    # so that techies can track it down
-                    _logger.error(
-                        "%(model)s.%(fname)s not available",
-                        {"model": self._name, "fname": field_name},
-                    )
+            try:
+                self._jsonify_record_validate_field(rec, field_dict, strict)
+            except SwallableException:
                 continue
-            json_key = field_dict.get("target", field_name)
-            field = rec._fields[field_name]
+            json_key = field_dict.get("target", field_dict["name"])
             if field_dict.get("function"):
-                function = field_dict["function"]
                 try:
-                    value = self._function_value(rec, function, field_name)
-                except UserError:
-                    if strict:
-                        raise
-                    if not tools.config["test_enable"]:
-                        _logger.error(
-                            "%(model)s.%(func)s not available",
-                            {"model": self._name, "func": str(function)},
-                        )
+                    value = self._jsonify_record_handle_function(
+                        rec, field_dict, strict
+                    )
+                except SwallableException:
                     continue
             elif subparser:
-                if not (field.relational or field.type == "reference"):
-                    if strict:
-                        self._jsonify_bad_parser_error(field_name)
-                    if not tools.config["test_enable"]:
-                        _logger.error(
-                            "%(model)s.%(fname)s not relational",
-                            {"model": self._name, "fname": field_name},
-                        )
+                try:
+                    value = self._jsonify_record_handle_subparser(
+                        rec, field_dict, strict, subparser
+                    )
+                except SwallableException:
                     continue
-                value = [
-                    self._jsonify_record(subparser, r, {}) for r in rec[field_name]
-                ]
-                if field.type in ("many2one", "reference"):
-                    value = value[0] if value else None
             else:
-                resolver = field_dict.get("resolver")
+                field = rec._fields[field_dict["name"]]
                 value = rec._jsonify_value(field, rec[field.name])
-                value = resolver.resolve(field, rec)[0] if resolver else value
-
+                resolver = field_dict.get("resolver")
+                if resolver:
+                    value, json_key = self._jsonify_record_handle_resolver(
+                        rec, field, resolver, json_key
+                    )
             self._add_json_key(root, json_key, value)
         return root
+
+    def _jsonify_record_validate_field(self, rec, field_dict, strict):
+        field_name = field_dict["name"]
+        if field_name not in rec._fields:
+            if strict:
+                # let it fail
+                rec._fields[field_name]  # pylint: disable=pointless-statement
+            if not tools.config["test_enable"]:
+                # If running live, log proper error
+                # so that techies can track it down
+                _logger.error(
+                    "%(model)s.%(fname)s not available",
+                    {"model": self._name, "fname": field_name},
+                )
+                raise SwallableException()
+
+        return True
+
+    def _jsonify_record_handle_function(self, rec, field_dict, strict):
+        field_name = field_dict["name"]
+        function = field_dict["function"]
+        try:
+            return self._function_value(rec, function, field_name)
+        except UserError:
+            if strict:
+                raise
+            if not tools.config["test_enable"]:
+                _logger.error(
+                    "%(model)s.%(func)s not available",
+                    {"model": self._name, "func": str(function)},
+                )
+                raise SwallableException()
+
+    def _jsonify_record_handle_subparser(self, rec, field_dict, strict, subparser):
+        field_name = field_dict["name"]
+        field = rec._fields[field_name]
+        if not (field.relational or field.type == "reference"):
+            if strict:
+                self._jsonify_bad_parser_error(field_name)
+            if not tools.config["test_enable"]:
+                _logger.error(
+                    "%(model)s.%(fname)s not relational",
+                    {"model": self._name, "fname": field_name},
+                )
+                raise SwallableException()
+
+        value = [self._jsonify_record(subparser, r, {}) for r in rec[field_name]]
+        if field.type in ("many2one", "reference"):
+            value = value[0] if value else None
+        return value
+
+    def _jsonify_record_handle_resolver(self, rec, field, resolver, json_key):
+        value = rec._jsonify_value(field, rec[field.name])
+        value = resolver.resolve(field, rec)[0] if resolver else value
+        return value, json_key
 
     def jsonify(self, parser, one=False):
         """Convert the record according to the given parser.

--- a/jsonifier/tests/test_get_parser.py
+++ b/jsonifier/tests/test_get_parser.py
@@ -1,4 +1,6 @@
 # Copyright 2017 ACSONE SA/NV
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com)
+# Simone Orsi <simahawk@gmail.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import mock
@@ -232,6 +234,16 @@ class TestParser(SavepointCase):
         )  # starting from different languages should not change anything
         self.assertEqual(json[self.translated_target], self.translated_target)
         self.assertEqual(json["name_resolved"], "name_pidgin")  # field resolver
+        self.assertEqual(json["X"], "X")  # added by global resolver
+
+    def test_full_parser_resolver_json_key_override(self):
+        self.resolver.write(
+            {"python_code": """result = {"_json_key": "foo", "_value": record.id}"""}
+        )
+        parser = self.category_export.get_json_parser()
+        json = self.category.jsonify(parser)[0]
+        self.assertNotIn("name_resolved", json)
+        self.assertEqual(json["foo"], self.category.id)  # field resolver
         self.assertEqual(json["X"], "X")  # added by global resolver
 
     def test_simple_parser_translations(self):


### PR DESCRIPTION
The relevant change is in the 2nd commit. The first one is to simplify the complexity of `_jsonify_record` to make the linter happy but also to make it more readable.