### PR TITLE
[14.0][FIX] dbs value has to be kept in case of special dbfilter config

### DIFF
--- a/dbfilter_from_header/override.py
+++ b/dbfilter_from_header/override.py
@@ -13,11 +13,13 @@ db_filter_org = http.db_filter
 
 
 def db_filter(dbs, httprequest=None):
-    dbs = db_filter_org(dbs, httprequest)
+    dbs_orig = db_filter_org(dbs, httprequest)
     httprequest = httprequest or http.request.httprequest
     db_filter_hdr = httprequest.environ.get("HTTP_X_ODOO_DBFILTER")
     if db_filter_hdr:
         dbs = [db for db in dbs if re.match(db_filter_hdr, db)]
+    else:
+        dbs = dbs_orig
     return dbs
 
 


### PR DESCRIPTION
I had to commit this fix to make it work on our architecture
Our dbfilter is `dbfilter = %d$`
Our proxy is Apache 2.4.6
