### PR TITLE
[13.0][FIX] base_view_inheritance_extension: fix a bug that was preventing the first key of a dictionary to be replaced by a new value (because a 0 index is False)

### DIFF
--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Extended view inheritance",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.1.1",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "category": "Hidden/Dependency",

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -90,7 +90,7 @@ class IrUiView(models.Model):
             )
             # Update or create the key
             value = ast.parse(attribute_node.text.strip(), mode="eval").body
-            if key_idx:
+            if isinstance(key_idx, int):
                 ast_dict.values[key_idx] = value
             else:
                 ast_dict.keys.append(ast.Str(attr_key))

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -235,6 +235,38 @@ class TestBaseViewInheritanceExtension(SavepointCase):
             "'required': [('state', '!=', 'draft')]}",
         )
 
+    def test_python_dict_inheritance_attrs_update_dictionary_0th_key(self):
+        """Test that we can replace the first key of the dictionary (there was a bug that preventied this)"""
+        inherit_id = self.env.ref("base.view_partner_form").id
+        source = etree.fromstring(
+            """
+            <form>
+                <field
+                    name="ref"
+                    attrs="{
+                        'required': [('state', '=', False)],
+                    }"
+                />
+            </form>
+            """
+        )
+        specs = etree.fromstring(
+            """
+            <field name="ref" position="attributes">
+                <attribute name="attrs" operation="python_dict" key="required">
+                    [('state', '!=', 'draft')]
+                </attribute>
+            </field>
+            """
+        )
+        res = self.ViewModel.inheritance_handler_attributes_python_dict(
+            source, specs, inherit_id
+        )
+        self.assertEqual(
+            res.xpath('//field[@name="ref"]')[0].attrib["attrs"],
+            "{'required': [('state', '!=', 'draft')]}",
+        )
+
     def test_python_dict_inheritance_attrs_new(self):
         """Test that we can add new keys by creating the dict if it's missing"""
         inherit_id = self.env.ref("base.view_partner_form").id

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -236,7 +236,7 @@ class TestBaseViewInheritanceExtension(SavepointCase):
         )
 
     def test_python_dict_inheritance_attrs_update_dictionary_0th_key(self):
-        """Test that we can replace the first key of the dictionary (there was a bug that preventied this)"""
+        """Test that we can replace the first key of the dictionary (there was a bug that prevented this)"""
         inherit_id = self.env.ref("base.view_partner_form").id
         source = etree.fromstring(
             """


### PR DESCRIPTION
I tried to always show the account.move type on top of the form view, using the following patch:
<pre>
    &lt;xpath expr="//span[hasclass('o_form_label')]/field[@name='type']" position="attributes"&gt;
        &lt;attribute name="attrs" operation="python_dict" key="invisible"&gt;[('type', '=', False)]&lt;/attribute&gt;
    &lt;/xpath&gt;
</pre>
However, the result was:
<pre>
    &lt;field name="type" attrs="{'invisible': ['|', ('type', '=', 'entry'), ('state', '=', 'draft')], 'invisible': [('type', '=', False)]}" readonly="1" nolabel="1"/&gt;
</pre>
Whereas it should be:
<pre>
    &lt;field name="type" attrs="{'invisible': [('type', '=', False)]}" readonly="1" nolabel="1"/&gt;
</pre>

This pull request fixes this. The problem was that the python code was confusing a zero with a none object.