### PR TITLE
[12.0][ADD] auditlog: blacklist password fields

### DIFF
--- a/auditlog/__manifest__.py
+++ b/auditlog/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': "Audit Log",
-    'version': "12.0.1.1.0",
+    'version': "12.0.2.0.0",
     'author': "ABF OSIELL,Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'website': "https://github.com/OCA/server-tools/",

--- a/auditlog/migrations/12.0.2.0.0/pre-migration.py
+++ b/auditlog/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2022 Hunki Enterprises BV (<https://hunki-enterprises.com>)
+
+
+def migrate(cr, version=None):
+    """ delete all logs of fields called 'password' as we ignore them from now on """
+    cr.execute(
+        "delete from auditlog_log_line al using ir_model_fields imf "
+        "where al.field_id=imf.id and imf.name='password'"
+    )

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -7,7 +7,7 @@ from odoo import models, fields, api, modules, _
 
 FIELDS_BLACKLIST = [
     'id', 'create_uid', 'create_date', 'write_uid', 'write_date',
-    'display_name', '__last_update',
+    'display_name', '__last_update', 'password',
 ]
 # Used for performance, to avoid a dictionary instanciation when we need an
 # empty dict to simplify algorithms

--- a/auditlog/readme/CONFIGURE.rst
+++ b/auditlog/readme/CONFIGURE.rst
@@ -20,3 +20,12 @@ To activate it and/or change the delay, go to the
 In case you're having trouble with the amount of records to delete per run,
 you can pass the amount of records to delete for one model per run as the second
 parameter, the default is to delete all records in one go.
+
+Security / Policy
+~~~~~~~~~~~~~~~~~
+
+You need to be aware that logging can contain sensitive data. With raw HTTP logs,
+there not much to do about that, but for ORM logging, the module blacklists all
+fields called `password`. If you really need to audit that (having plain passwords
+laying around is a policy violation basically everywhere), rename your field or
+create a related field used for input.


### PR DESCRIPTION
my users turned on logging for `res.users` a while ago, and today somebody realized this means we have a list of plain text passwords of the past $long_period.

Given I don't believe this kind of data should be anywhere, I think we can use the bazooka and simply ditch any field called `password`

Alternative would be to allow to configure a blacklist per rule, but that would be much more work to implement, and I'm not sure how often we'll blacklist anything else than `password` or similar, because otherwise it's not really an audit