### PR TITLE
[ADD] upgrade_analysis: generate noupdate_changes for template tag

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -324,6 +324,13 @@ class UpgradeAnalysis(models.Model):
             if remote_record is None and not module_xmlid:
                 continue
 
+            if local_record.tag == "template":
+                old_tmpl = etree.tostring(remote_record, encoding="utf-8")
+                new_tmpl = etree.tostring(local_record, encoding="utf-8")
+                if old_tmpl != new_tmpl:
+                    odoo.append(local_record)
+                continue
+
             element = etree.Element(
                 "record", id=xml_id, model=local_record.attrib["model"]
             )
@@ -389,7 +396,7 @@ class UpgradeAnalysis(models.Model):
         self, data_node, records_update, records_noupdate, module_name
     ):
         noupdate = nodeattr2bool(data_node, "noupdate", False)
-        for record in data_node.xpath("./record"):
+        for record in data_node.xpath("./record") + data_node.xpath("./template"):
             self._process_record_node(
                 record, noupdate, records_update, records_noupdate, module_name
             )


### PR DESCRIPTION
Need to backport to version 14.0

The `digest.digest_mail_layout` template from `14.0` and `15.0` has changed, we need to create `noupdate_changes` to avoid manual updating