### PR TITLE
[12.0][FIX] auditlog: support update after data model changes in rules

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import copy
+import logging
+from psycopg2 import ProgrammingError
 
 from odoo import models, fields, api, modules, _
 
@@ -132,6 +134,14 @@ class AuditlogRule(models.Model):
         """Patch ORM methods of models defined in rules to log their calls."""
         updated = False
         model_cache = self.pool._auditlog_model_cache
+        try:
+            with self.env.cr.savepoint():
+                self.read()
+        except ProgrammingError:
+            logging.getLogger(__name__).error(
+                "Error reading auditlog rules. Logs will not be created. "
+                "Do you need to upgrade the auditlog module?", exc_info=True)
+            return False
         for rule in self:
             if rule.state != 'subscribed':
                 continue


### PR DESCRIPTION
this allows an Odoo database being updated with logging enabled, part of https://github.com/OCA/server-tools/pull/903