### PR TITLE
sql_export: improve menu position

### DIFF
--- a/sql_export/views/sql_export_view.xml
+++ b/sql_export/views/sql_export_view.xml
@@ -137,7 +137,7 @@
     <menuitem
         id="sql_export_menu"
         name="Sql Export"
-        parent="base.menu_reporting_dashboard"
+        parent="base.menu_board_root"
         sequence="80"
     />
 


### PR DESCRIPTION
Change the parent to avoid to have in first position the SQL Export.
SQL export is less important then native dashboard so it should be after

Before when opening dashboard menu

![image](https://user-images.githubusercontent.com/1164578/187240572-5e724074-aa31-4477-96d8-93df801a01a5.png)


After When opening dashboard menu

![image](https://user-images.githubusercontent.com/1164578/187241062-cd7c9479-fb86-432a-8d41-9383e29f560d.png)

