### PR TITLE
[FIX][11.0] Make branch green

### DIFF
--- a/company_country/models/res_config.py
+++ b/company_country/models/res_config.py
@@ -35,10 +35,12 @@ class CompanyCountryConfigSettings(models.AbstractModel):
                 ('state', '=', 'to install'),
                 ('name', '=like', 'l10n_%')], limit=1)
             if not l10n_to_install:
-                raise ValidationError(_(
+                _logger.error(_(
                     'COUNTRY environment variable with country code is not '
                     'set and no localization module is marked to be '
-                    'installed.'))
+                    'installed.'
+                ))
+                return
             country_code = l10n_to_install.name.split('l10n_')[1][:2].upper()
 
         country = self.env['res.country'].search([

--- a/company_country/tests/test_company_country.py
+++ b/company_country/tests/test_company_country.py
@@ -38,8 +38,11 @@ class TestCompanyCountry(TransactionCase):
         self.wizard.load_company_country()
         self.assertEqual(self.main_company.country_id.id, False)
 
-        # COUNTRY environment variable not set, should raise
-        with self.assertRaises(ValidationError):
+        # COUNTRY environment variable not set, should log error
+        with self.assertLogs(
+                'odoo.addons.company_country.models.res_config',
+                level='ERROR',
+        ):
             l10n_to_install = self.env['ir.module.module'].search([
                 ('state', '=', 'to install'),
                 ('name', '=like', 'l10n_%')])

--- a/setup/letsencrypt/setup.py
+++ b/setup/letsencrypt/setup.py
@@ -2,5 +2,14 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'acme': 'acme',
+                'cryptography': 'cryptography',
+                'dns': 'dnspython==1.16.0',
+                'josepy': 'josepy',
+            }
+        }
+    },
 )


### PR DESCRIPTION
All new 11.0 PR's currently turn red because of these two problems, [example here](https://github.com/OCA/server-tools/pull/2014):

**Problem 1** `letsencrypt` depends on `dns` Python package but the real name is `dnspython`, which confuses Travis and Runboat. See discussion in https://github.com/OCA/server-tools/pull/2014.

**Problem 2** `COUNTRY` variable does not exist, and `company_country` module does not handle that gracefully. Backport of https://github.com/OCA/server-tools/pull/2336