### PR TITLE
[FIX] attachment_unindex_content: unsupported param on _index method

### DIFF
--- a/attachment_unindex_content/__manifest__.py
+++ b/attachment_unindex_content/__manifest__.py
@@ -7,7 +7,11 @@
     "version": "14.0.1.0.0",
     "author": "Vauxoo, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/server-tools",
-    "maintainers": ["moylop260", "ebirbe"],
+    "maintainers": [
+        "moylop260",
+        "ebirbe",
+        "luisg123v",
+    ],
     "license": "AGPL-3",
     "category": "Tools",
     "depends": ["base"],

--- a/attachment_unindex_content/models/ir_attachment.py
+++ b/attachment_unindex_content/models/ir_attachment.py
@@ -9,5 +9,5 @@ class IrAttachment(models.Model):
     _inherit = "ir.attachment"
 
     @api.model
-    def _index(self, bin_data, mimetype):
+    def _index(self, *args, **kwargs):
         return False


### PR DESCRIPTION
Odoo introduced a new param `checksum` to the method `_index` on the attachment model [1]. Since that param is not supported on this model, the following error is now being raised:

    TypeError: _index() got an unexpected keyword argument 'checksum'

[1] https://github.com/odoo/odoo/commit/3d59cc84