### PR TITLE
]14.0][FIX] base_changeset: fix caching

### DIFF
--- a/base_changeset/models/base.py
+++ b/base_changeset/models/base.py
@@ -4,7 +4,7 @@
 from lxml import etree
 
 from odoo import _, api, fields, models
-from odoo.tools import config
+from odoo.tools import config, ormcache
 
 
 class Base(models.AbstractModel):
@@ -58,6 +58,7 @@ class Base(models.AbstractModel):
                 rec.count_pending_changeset_changes = 0.0
 
     @api.model
+    @ormcache(skiparg=1)
     def models_to_track_changeset(self):
         """Models to be tracked for changes
         :args:


### PR DESCRIPTION
ormcache is used to minimize the number of times that the active changeset rules are quered, but it was still missing in one important place.

In this module's tests, this reduces the number of calls to `models_to_track_changeset` from 354 to 135 times, and the number of test queries is reduced from 4069 to 3810.