### PR TITLE
[14.0][FIX] upgrade_analysis: misleading representation of read/write computed fields

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -134,8 +134,6 @@ def report_generic(new, old, attrs, reprs):
         if attr == "required":
             if old[attr] != new["required"] and new["required"]:
                 text = "now required"
-                if new["req_default"]:
-                    text += ", req_default: %s" % new["req_default"]
                 fieldprint(old, new, "", text, reprs)
         elif attr == "stored":
             if old[attr] != new[attr]:
@@ -284,14 +282,18 @@ def compare_sets(old_records, new_records):
         ],
     )
 
-    printkeys = [
+    # Info that is displayed for deleted fields
+    printkeys_old = [
         "relation",
         "required",
         "selection_keys",
-        "req_default",
         "_inherits",
         "mode",
         "attachment",
+    ]
+    # Info that is displayed for new fields
+    printkeys_new = printkeys_old + [
+        "hasdefault",
     ]
     for column in old_records:
         if column["field"] == "_order":
@@ -304,7 +306,7 @@ def compare_sets(old_records, new_records):
         extra_message = ", ".join(
             [
                 k + ": " + str(column[k]) if k != str(column[k]) else k
-                for k in printkeys
+                for k in printkeys_old
                 if column[k]
             ]
         )
@@ -312,11 +314,6 @@ def compare_sets(old_records, new_records):
             extra_message = " " + extra_message
         fieldprint(column, "", "", "DEL" + extra_message, reprs)
 
-    printkeys.extend(
-        [
-            "hasdefault",
-        ]
-    )
     for column in new_records:
         if column["field"] == "_order":
             continue
@@ -325,13 +322,13 @@ def compare_sets(old_records, new_records):
             continue
         if column["mode"] == "create":
             column["mode"] = ""
-        printkeys_plus = printkeys.copy()
+        printkeys = printkeys_new.copy()
         if column["isfunction"] or column["isrelated"]:
-            printkeys_plus.extend(["isfunction", "isrelated", "stored"])
+            printkeys.extend(["isfunction", "isrelated", "stored"])
         extra_message = ", ".join(
             [
                 k + ": " + str(column[k]) if k != str(column[k]) else k
-                for k in printkeys_plus
+                for k in printkeys
                 if column[k]
             ]
         )

--- a/upgrade_analysis/models/upgrade_record.py
+++ b/upgrade_analysis/models/upgrade_record.py
@@ -104,7 +104,6 @@ class UpgradeRecord(models.Model):
             "required",
             "stored",
             "selection_keys",
-            "req_default",
             "hasdefault",
             "table",
             "_inherits",

--- a/upgrade_analysis/wizards/upgrade_install_wizard.py
+++ b/upgrade_analysis/wizards/upgrade_install_wizard.py
@@ -42,9 +42,15 @@ class UpgradeInstallWizard(models.TransientModel):
         modules = self.env["ir.module.module"].search(domain)
 
         for start_pattern in BLACKLIST_MODULES_STARTS_WITH:
-            modules = modules.filtered(lambda x: not x.name.startswith(start_pattern))
+            modules = modules.filtered(
+                lambda x, start_pattern=start_pattern: not x.name.startswith(
+                    start_pattern
+                )
+            )
         for end_pattern in BLACKLIST_MODULES_ENDS_WITH:
-            modules = modules.filtered(lambda x: not x.name.endswith(end_pattern))
+            modules = modules.filtered(
+                lambda x, end_pattern=end_pattern: not x.name.endswith(end_pattern)
+            )
         return [("id", "in", modules.ids)]
 
     @api.depends("module_ids")


### PR DESCRIPTION
Backport of https://github.com/OCA/server-tools/pull/2416

Odoo 14 introduced the widescale usage of computed fields with readonly=False. In that case, the compute method functions as a default that can also be used to compute a value some time *after* the initial creation of the record.

In the OpenUpgrade analysis files, these fields would be misrepresented as computed fields rather than fields with a default function. This change fixes that.