### PR TITLE
[14.0][FIX] letsencrypt: workaround blocked domain name example.com

### DIFF
--- a/letsencrypt/tests/test_letsencrypt.py
+++ b/letsencrypt/tests/test_letsencrypt.py
@@ -32,13 +32,13 @@ class TestLetsencrypt(SingleTransactionCase):
     def setUp(self):
         super().setUp()
         self.env["ir.config_parameter"].set_param(
-            "web.base.url", "http://www.example.com"
+            "web.base.url", "http://www.example.ltd"
         )
         self.env["res.config.settings"].create(
             {
                 "letsencrypt_dns_provider": "shell",
                 "letsencrypt_dns_shell_script": "touch /tmp/.letsencrypt_test",
-                "letsencrypt_altnames": "www.example.com,*.example.com",
+                "letsencrypt_altnames": "www.example.ltd,*.example.ltd",
                 "letsencrypt_reload_command": "echo reloaded",
             }
         ).set_values()
@@ -51,7 +51,7 @@ class TestLetsencrypt(SingleTransactionCase):
             "touch /tmp/.letsencrypt_test",
         )
         self.assertEqual(
-            setting_vals["letsencrypt_altnames"], "www.example.com,*.example.com"
+            setting_vals["letsencrypt_altnames"], "www.example.ltd,*.example.ltd"
         )
         self.assertEqual(setting_vals["letsencrypt_reload_command"], "echo reloaded")
         self.assertTrue(setting_vals["letsencrypt_needs_dns_provider"])
@@ -73,7 +73,7 @@ class TestLetsencrypt(SingleTransactionCase):
         poll.assert_called()
         self.assertTrue(os.listdir(_get_challenge_dir()))
         self.assertFalse(path.isfile("/tmp/.letsencrypt_test"))
-        self.assertTrue(path.isfile(path.join(_get_data_dir(), "www.example.com.crt")))
+        self.assertTrue(path.isfile(path.join(_get_data_dir(), "www.example.ltd.crt")))
 
     # pylint: disable=unused-argument
     @mock.patch("odoo.addons.letsencrypt.models.letsencrypt.DNSUpdate")
@@ -101,7 +101,7 @@ class TestLetsencrypt(SingleTransactionCase):
 
         def query_effect(domain, rectype):
             nonlocal ncalls
-            self.assertEqual(domain, "_acme-challenge.example.com.")
+            self.assertEqual(domain, "_acme-challenge.example.ltd.")
             self.assertEqual(rectype, "TXT")
             ncalls += 1
             if ncalls == 1:
@@ -120,12 +120,12 @@ class TestLetsencrypt(SingleTransactionCase):
         poll.assert_called()
         self.assertEqual(ncalls, 3)
         self.assertTrue(path.isfile("/tmp/.letsencrypt_test"))
-        self.assertTrue(path.isfile(path.join(_get_data_dir(), "www.example.com.crt")))
+        self.assertTrue(path.isfile(path.join(_get_data_dir(), "www.example.ltd.crt")))
 
     def test_dns_challenge_error_on_missing_provider(self):
         self.env["res.config.settings"].create(
             {
-                "letsencrypt_altnames": "*.example.com",
+                "letsencrypt_altnames": "*.example.ltd",
                 "letsencrypt_dns_provider": False,
             }
         ).set_values()
@@ -134,7 +134,7 @@ class TestLetsencrypt(SingleTransactionCase):
 
     def test_prefer_dns_setting(self):
         self.env["res.config.settings"].create(
-            {"letsencrypt_altnames": "example.com", "letsencrypt_prefer_dns": True}
+            {"letsencrypt_altnames": "example.ltd", "letsencrypt_prefer_dns": True}
         ).set_values()
         # pylint: disable=no-value-for-parameter
         self.test_dns_challenge()
@@ -144,64 +144,64 @@ class TestLetsencrypt(SingleTransactionCase):
         self.assertEqual(
             cascade(
                 [
-                    "www.example.com",
-                    "*.example.com",
-                    "example.com",
-                    "example.com",
-                    "notexample.com",
-                    "multi.sub.example.com",
-                    "www2.example.com",
+                    "www.example.ltd",
+                    "*.example.ltd",
+                    "example.ltd",
+                    "example.ltd",
+                    "notexample.ltd",
+                    "multi.sub.example.ltd",
+                    "www2.example.ltd",
                     "unrelated.com",
                 ]
             ),
             [
-                "*.example.com",
-                "example.com",
-                "multi.sub.example.com",
-                "notexample.com",
+                "*.example.ltd",
+                "example.ltd",
+                "multi.sub.example.ltd",
+                "notexample.ltd",
                 "unrelated.com",
             ],
         )
         self.assertEqual(cascade([]), [])
-        self.assertEqual(cascade(["*.example.com"]), ["*.example.com"])
-        self.assertEqual(cascade(["www.example.com"]), ["www.example.com"])
+        self.assertEqual(cascade(["*.example.ltd"]), ["*.example.ltd"])
+        self.assertEqual(cascade(["www.example.ltd"]), ["www.example.ltd"])
         self.assertEqual(
-            cascade(["www.example.com", "example.com"]),
-            ["example.com", "www.example.com"],
+            cascade(["www.example.ltd", "example.ltd"]),
+            ["example.ltd", "www.example.ltd"],
         )
 
         with self.assertRaises(UserError):
-            cascade(["www.*.example.com"])
+            cascade(["www.*.example.ltd"])
 
         with self.assertRaises(UserError):
-            cascade(["*.*.example.com"])
+            cascade(["*.*.example.ltd"])
 
     def test_altnames_parsing(self):
         config = self.env["ir.config_parameter"]
         letsencrypt = self.env["letsencrypt"]
 
         self.assertEqual(
-            letsencrypt._get_altnames(), ["www.example.com", "*.example.com"]
+            letsencrypt._get_altnames(), ["www.example.ltd", "*.example.ltd"]
         )
 
         config.set_param("letsencrypt.altnames", "")
-        self.assertEqual(letsencrypt._get_altnames(), ["www.example.com"])
+        self.assertEqual(letsencrypt._get_altnames(), ["www.example.ltd"])
 
-        config.set_param("letsencrypt.altnames", "foobar.example.com")
-        self.assertEqual(letsencrypt._get_altnames(), ["foobar.example.com"])
+        config.set_param("letsencrypt.altnames", "foobar.example.ltd")
+        self.assertEqual(letsencrypt._get_altnames(), ["foobar.example.ltd"])
 
-        config.set_param("letsencrypt.altnames", "example.com,example.org,example.net")
+        config.set_param("letsencrypt.altnames", "example.ltd,example.org,example.net")
         self.assertEqual(
             letsencrypt._get_altnames(),
-            ["example.com", "example.org", "example.net"],
+            ["example.ltd", "example.org", "example.net"],
         )
 
         config.set_param(
-            "letsencrypt.altnames", "example.com, example.org\nexample.net"
+            "letsencrypt.altnames", "example.ltd, example.org\nexample.net"
         )
         self.assertEqual(
             letsencrypt._get_altnames(),
-            ["example.com", "example.org", "example.net"],
+            ["example.ltd", "example.org", "example.net"],
         )
 
     def test_key_generation_and_retrieval(self):
@@ -228,8 +228,8 @@ class TestLetsencrypt(SingleTransactionCase):
         generate_key.assert_called()
 
     def test_domain_validation(self):
-        self.env["letsencrypt"]._validate_domain("example.com")
-        self.env["letsencrypt"]._validate_domain("www.example.com")
+        self.env["letsencrypt"]._validate_domain("example.ltd")
+        self.env["letsencrypt"]._validate_domain("www.example.ltd")
 
         with self.assertRaises(UserError):
             self.env["letsencrypt"]._validate_domain("1.1.1.1")
@@ -246,8 +246,8 @@ class TestLetsencrypt(SingleTransactionCase):
         self.install_certificate(60)
         self.assertFalse(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com", "*.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd", "*.example.ltd"],
             )
         )
 
@@ -255,8 +255,8 @@ class TestLetsencrypt(SingleTransactionCase):
         self.install_certificate(20)
         self.assertTrue(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com", "*.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd", "*.example.ltd"],
             )
         )
 
@@ -264,31 +264,31 @@ class TestLetsencrypt(SingleTransactionCase):
         self.install_certificate(-10)
         self.assertTrue(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com", "*.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd", "*.example.ltd"],
             )
         )
 
     def test_missing_certificate(self):
         self.assertTrue(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com", "*.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd", "*.example.ltd"],
             )
         )
 
     def test_new_altnames(self):
-        self.install_certificate(60, "www.example.com", ())
+        self.install_certificate(60, "www.example.ltd", ())
         self.assertTrue(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com", "*.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd", "*.example.ltd"],
             )
         )
         self.assertFalse(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd"],
             )
         )
 
@@ -296,16 +296,16 @@ class TestLetsencrypt(SingleTransactionCase):
         self.install_certificate(60, use_altnames=False)
         self.assertFalse(
             self.env["letsencrypt"]._should_run(
-                path.join(_get_data_dir(), "www.example.com.crt"),
-                ["www.example.com"],
+                path.join(_get_data_dir(), "www.example.ltd.crt"),
+                ["www.example.ltd"],
             )
         )
 
     def install_certificate(
         self,
         days_left,
-        common_name="www.example.com",
-        altnames=("*.example.com",),
+        common_name="www.example.ltd",
+        altnames=("*.example.ltd",),
         use_altnames=True,
     ):
         from cryptography import x509


### PR DESCRIPTION
Backport of https://github.com/OCA/server-tools/pull/2432