### PR TITLE
[15.0][FIX] base_view_inheritance_extension: fix parsing of 'update' operation

### DIFF
--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -112,7 +112,8 @@ class IrUiView(models.Model):
         for spec in specs:
             attr_name = spec.get("name")
             # Parse ast from both node and spec
-            source_ast = ast.parse(node.get(attr_name) or "{}", mode="eval").body
+            node_attr = (node.get(attr_name) or "{}").strip()
+            source_ast = ast.parse(node_attr, mode="eval").body
             update_ast = ast.parse(spec.text.strip(), mode="eval").body
             if not isinstance(source_ast, ast.Dict):
                 raise TypeError(f"Attribute `{attr_name}` is not a dict")


### PR DESCRIPTION
This fixes an error we could get if the attribute of the inherited tag has some extra carriage returns.

Exception raised: SyntaxError: unexpected EOF while parsing

This is happening for instance when inheriting the context key of this view: https://github.com/odoo/odoo/blob/e6ca3ef1b38dec964dab416c6058d4c1b7161614/addons/mrp/views/stock_move_views.xml#L48-L56