### PR TITLE
[FIX] auditlog: autovacuum performance

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -16,7 +16,9 @@ class AuditlogHTTPRequest(models.Model):
     name = fields.Char("Path")
     root_url = fields.Char("Root URL")
     user_id = fields.Many2one("res.users", string="User")
-    http_session_id = fields.Many2one("auditlog.http.session", string="Session")
+    http_session_id = fields.Many2one(
+        "auditlog.http.session", string="Session", index=True
+    )
     user_context = fields.Char("Context")
     log_ids = fields.One2many("auditlog.log", "http_request_id", string="Logs")
 

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -19,8 +19,12 @@ class AuditlogLog(models.Model):
     user_id = fields.Many2one("res.users", string="User")
     method = fields.Char(size=64)
     line_ids = fields.One2many("auditlog.log.line", "log_id", string="Fields updated")
-    http_session_id = fields.Many2one("auditlog.http.session", string="Session")
-    http_request_id = fields.Many2one("auditlog.http.request", string="HTTP Request")
+    http_session_id = fields.Many2one(
+        "auditlog.http.session", string="Session", index=True
+    )
+    http_request_id = fields.Many2one(
+        "auditlog.http.request", string="HTTP Request", index=True
+    )
     log_type = fields.Selection(
         [("full", "Full log"), ("fast", "Fast log")], string="Type"
     )
@@ -70,8 +74,12 @@ class AuditlogLogLine(models.Model):
     res_id = fields.Integer(related="log_id.res_id", store=True)
     user_id = fields.Many2one(related="log_id.user_id", store=True)
     method = fields.Char(related="log_id.method", store=True)
-    http_session_id = fields.Many2one(related="log_id.http_session_id", store=True)
-    http_request_id = fields.Many2one(related="log_id.http_request_id", store=True)
+    http_session_id = fields.Many2one(
+        related="log_id.http_session_id", store=True, index=True
+    )
+    http_request_id = fields.Many2one(
+        related="log_id.http_request_id", store=True, index=True
+    )
     log_type = fields.Selection(related="log_id.log_type", store=True)
 
     @api.model_create_multi


### PR DESCRIPTION
Add database indices on the foreign key fields of the auditlog models. Without these indices, the performance of the autovacuum cron are terrible because the "ON DELETE SET NULL" trigger has to make a full table scan on the auditlog_log and auditlog_log_line tables when auditlog_http_session and auditlog_http_request rows are deleted.