### PR TITLE
[14.0][FIX] auditlog: allow loading of auditlog rules from module xml

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -240,7 +240,7 @@ class AuditlogRule(models.Model):
         model = self.env["ir.model"].browse(vals["model_id"])
         vals.update({"model_name": model.name, "model_model": model.model})
         new_record = super().create(vals)
-        if new_record._register_hook():
+        if not self.env.context.get("install_module") and new_record._register_hook():
             modules.registry.Registry(self.env.cr.dbname).signal_changes()
         return new_record
 
@@ -252,7 +252,7 @@ class AuditlogRule(models.Model):
             model = self.env["ir.model"].browse(vals["model_id"])
             vals.update({"model_name": model.name, "model_model": model.model})
         res = super().write(vals)
-        if self._register_hook():
+        if not self.env.context.get("install_module") and self._register_hook():
             modules.registry.Registry(self.env.cr.dbname).signal_changes()
         return res
 


### PR DESCRIPTION
The auditlog module patches the logged models' `create` and `write` methods in order to log from calls to these methods. Patching happens from `_register_hook` which is the correct place because it is called when all module code is loaded. To ensure correct patching when rules are created in the GUI, it calls `_registered_hook` from the `create` and `write` methods of the `auditlog.rule` model which should not a problem because no module code is loaded once the user has access to the GUI.

However, loading rules from xml data also trigger the `write`  and `create` methods of `auditlog.rule` and thus the immediate patching of the `read` and `create` methods of the target models, which undermine the regular overrides of these methods according to the Odoo orm model. This breaks any tests that depend on these overrides.

As a solution, this patch checks if `auditlog.rule`'s `write` and `create` method are called during Odoo's update process and in that case does not call `_register_hook`, which is safe because by definition `_register_hook` will always be called on all models at the end of the upgrade process.