### PR TITLE
[IMP] 14.0 base_generate_code allow to manually set code

### DIFF
--- a/base_generate_code/__manifest__.py
+++ b/base_generate_code/__manifest__.py
@@ -13,7 +13,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["sale"],
+    "depends": ["sale", "mail"],
     "data": [
         "security/ir.model.access.csv",
     ],

--- a/base_generate_code/models/code_format_mixin.py
+++ b/base_generate_code/models/code_format_mixin.py
@@ -7,13 +7,14 @@
 from random import choice
 from string import ascii_lowercase, ascii_uppercase, digits
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
 class CodeFormatMixin(models.AbstractModel):
     _name = "code.format.mixin"
     _description = "Customizable code format Mixin"
+    _inherit = ["mail.thread"]
 
     #  1/ _code_mask must be added in the related model
     # e.g. in "gift.card":
@@ -50,7 +51,14 @@ class CodeFormatMixin(models.AbstractModel):
                     )
             return code
 
-    code = fields.Char(compute=_generate_code, readonly=True, store=True)
+    code = fields.Char(tracking=True)
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        if not res.code:
+            res.code = res._generate_code()
+        return res
 
     def _get_mask(self):
         return self[self._code_mask["template"]][self._code_mask["mask"]]


### PR DESCRIPTION
In my case this is needed to import data from another system.

I think this module should allow to manually set a code, it should be removed in the implementing modules if needed