### PR TITLE
[14.0] autovacuum_message_attachment: Support inherited models

### DIFF
--- a/autovacuum_message_attachment/models/ir_attachment.py
+++ b/autovacuum_message_attachment/models/ir_attachment.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 from odoo import fields, models
+from odoo.osv import expression
 
 
 class IrAttachment(models.Model):
@@ -15,14 +16,14 @@ class IrAttachment(models.Model):
         domain = super()._get_autovacuum_domain(rule)
         today = fields.Datetime.now()
         limit_date = today - timedelta(days=rule.retention_time)
-        domain += [("create_date", "<", limit_date)]
+        domains = [domain, [("create_date", "<", limit_date)]]
         if rule.filename_pattern:
-            domain += [("name", "ilike", rule.filename_pattern)]
+            domains.append([("name", "ilike", rule.filename_pattern)])
         if rule.model_ids:
             models = rule.model_ids.mapped("model")
-            domain += [("res_model", "in", models)]
+            domains.append([("res_model", "in", models)])
         else:
             # Avoid deleting attachment without model, if there are, it is
             # probably some attachments created by Odoo
-            domain += [("res_model", "!=", False)]
-        return domain
+            domains.append([("res_model", "!=", False)])
+        return expression.AND(domains)

--- a/autovacuum_message_attachment/readme/CONTRIBUTORS.rst
+++ b/autovacuum_message_attachment/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Florian da Costa <florian.dacosta@akretion.com>
 * Enric Tobella <etobella@creublanca.es>
 * Helly kapatel <helly.kapatel@initos.com>
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/autovacuum_message_attachment/views/rule_vacuum.xml
+++ b/autovacuum_message_attachment/views/rule_vacuum.xml
@@ -38,6 +38,7 @@
                         </group>
                         <group attrs="{'invisible': [('ttype', '!=', 'attachment')]}">
                             <field name="filename_pattern" />
+                            <field name="inheriting_model" />
                         </group>
                         <group string="Message Models">
                             <field name="model_ids" nolabel="1" />


### PR DESCRIPTION
Selection of attachments through inheriting model can be useful if
we want to purge attachments that are extended through another
model.

For example, shipping.label (from base_delivery_carrier_label)
inherits from ir.attachment but the attachment itself is linked to
the stock.picking model.
By using inheriting_model defined to shipping.label and setting
model_ids to stock.picking, we can safely select the attachments
linked to stock.pickings that are shipping labels and avoid deleting
any picking list or delivery note reports.