### PR TITLE
[FIX] letsencrypt: freeze acme lib before version 2.0.0

### DIFF
--- a/letsencrypt/__manifest__.py
+++ b/letsencrypt/__manifest__.py
@@ -18,6 +18,6 @@
     "post_init_hook": "post_init_hook",
     "installable": True,
     "external_dependencies": {
-        "python": ["acme", "cryptography", "dnspython", "josepy"]
+        "python": ["acme<2.0.0", "cryptography", "dnspython", "josepy"]
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # generated from manifests external_dependencies
-acme
+acme<2.0.0
 astor
 cryptography
 dataclasses


### PR DESCRIPTION
I like to suggest this PR to avoid slowdown merge process on other PR but should be improved by #2502 (which I've not plan to deep into right now).