### PR TITLE
[14.0][FIX] base_time_parameter: type reference_id: show value_reference

### DIFF
--- a/base_time_parameter/views/base_time_parameter_views.xml
+++ b/base_time_parameter/views/base_time_parameter_views.xml
@@ -25,12 +25,11 @@
                                 <field name="type" invisible="1" />
                                 <field
                                     name="value"
-                                    attrs="{'column_invisible':[('parent.type', '=', 'reference')]}"
+                                    attrs="{'column_invisible':[('parent.type', 'in', ['reference', 'reference_id'])]}"
                                 />
                                 <field
                                     name="value_reference"
-                                    attrs="{'column_invisible':[('parent.type', '!=', 'reference')]}"
-                                    optional="hide"
+                                    attrs="{'column_invisible':[('parent.type', 'not in', ['reference', 'reference_id'])]}"
                                 />
                             </tree>
                         </field>


### PR DESCRIPTION
User interface fix: Show `value_reference` if the type is reference or reference_id, otherwise show `value`.