### PR TITLE
[13.0][FIX] nsca client: external dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,6 @@ jobs:
       INCLUDE: "${{ matrix.include }}"
       EXCLUDE: "${{ matrix.exclude }}"
     steps:
-      - name: Install nsca-client
-        run: apt install -y nsca-client
       - uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/nsca_client/__manifest__.py
+++ b/nsca_client/__manifest__.py
@@ -11,6 +11,7 @@
     "application": False,
     "installable": True,
     "depends": ["base"],
+    "external_dependencies": {"deb": ["nsca-client"]},
     "data": [
         "security/ir.model.access.csv",
         "views/nsca_menu.xml",


### PR DESCRIPTION
Follow-up from https://github.com/OCA/server-tools/pull/2518, using the proper fix from https://github.com/OCA/server-tools/pull/2459 by @sbidoul 