### PR TITLE
[12.0][FIX] excel_import_excel: fix adding new row in excel for pre-defined row and add extend attribute

### DIFF
--- a/excel_import_export/models/xlsx_export.py
+++ b/excel_import_export/models/xlsx_export.py
@@ -50,6 +50,7 @@ class XLSXExport(models.AbstractModel):
         """
         line_field, max_row = co.get_line_max(line_field)
         line_field = line_field.replace('_CONT_', '')  # Remove _CONT_ if any
+        line_field = line_field.replace('_EXTEND_', '')  # Remove _EXTEND_ if any
         lines = record[line_field]
         if max_row > 0 and len(lines) > max_row:
             raise Exception(
@@ -184,6 +185,7 @@ class XLSXExport(models.AbstractModel):
             fields = ws.get(line_field, {}).values()
             vals, func = self._get_line_vals(record, line_field, fields)
             is_cont = '_CONT_' in line_field and True or False  # continue row
+            is_extend = "_EXTEND_" in line_field and True or False  # extend row
             cont_set = 0
             rows_inserted = False  # flag to insert row
             for rc, field in ws.get(line_field, {}).items():
@@ -199,7 +201,7 @@ class XLSXExport(models.AbstractModel):
                 new_rc = False
                 row_count = len(vals[field])
                 # Insert rows to preserve total line
-                if not rows_inserted:
+                if is_extend and not rows_inserted:
                     rows_inserted = True
                     st.insert_rows(row+1, amount=row_count-1)
                 # --

--- a/excel_import_export/models/xlsx_template.py
+++ b/excel_import_export/models/xlsx_template.py
@@ -172,11 +172,16 @@ class XLSXTemplate(models.Model):
                     if '_CONT_' in row_field:
                         is_cont = True
                         row_field = row_field.replace('_CONT_', '')
+                    is_extend = False
+                    if "_EXTEND_" in row_field:
+                        is_extend = True
+                        row_field = row_field.replace("_EXTEND_", "")
                     vals = {'sequence': sequence,
                             'section_type': (row_field == '_HEAD_' and
                                              'head' or 'row'),
                             'row_field': row_field,
                             'is_cont': is_cont,
+                            'is_extend': is_extend,
                             }
                     export_lines.append((0, 0, vals))
                     for excel_cell, field_name in lines.items():
@@ -263,6 +268,8 @@ class XLSXTemplate(models.Model):
                     row_field = line.row_field
                     if line.section_type == 'row' and line.is_cont:
                         row_field = '_CONT_%s' % row_field
+                    if line.section_type == "row" and line.is_extend:
+                        row_field = "_EXTEND_%s" % row_field
                     row_dict = {row_field: {}}
                     inst_dict[itype][prev_sheet].update(row_dict)
                     prev_row = row_field
@@ -409,6 +416,11 @@ class XLSXTemplateExport(models.Model):
         string='Continue',
         default=False,
         help="Continue data rows after last data row",
+    )
+    is_extend = fields.Boolean(
+        string='Extend',
+        default=False,
+        help="Extend a blank row after filling each record, to extend the footer",
     )
     excel_cell = fields.Char(
         string='Cell',

--- a/excel_import_export/views/xlsx_template_view.xml
+++ b/excel_import_export/views/xlsx_template_view.xml
@@ -55,6 +55,11 @@
                                                                     'invisible': [('section_type', 'not in', ('head', 'row'))]}"/>
                                     <field name="is_cont" attrs="{'required': [('section_type', 'in', ('head', 'row'))],
                                                                   'invisible': [('section_type', 'not in', ('head', 'row'))]}"/>
+                                    <field
+                                        name="is_extend"
+                                        attrs="{'required': [('section_type', 'in', ('head', 'row'))],
+                                                                  'invisible': [('section_type', 'not in', ('head', 'row'))]}"
+                                    />
                                     <field name="excel_cell" attrs="{'required': [('section_type', '=', 'data')],
                                                                      'invisible': [('section_type', '!=', 'data')]}"/>
                                     <field name="field_name" attrs="{'invisible': [('section_type', '!=', 'data')]}"/>

--- a/excel_import_export_demo/report_sale_order/templates.xml
+++ b/excel_import_export_demo/report_sale_order/templates.xml
@@ -16,7 +16,7 @@
                         '_HEAD_': {
                             'B2': 'partner_id.display_name${value or ""}#{align=left;style=text}',
                         },
-                        'results': {
+                        '_EXTEND_results': {
                             'A5': 'name${value or ""}#{style=text}',
                             'B5': 'confirmation_date${value or ""}#{style=date}',
                             'C5': 'amount_untaxed${value or 0}#{style=number}@{sum}',


### PR DESCRIPTION
Before this commit, if we export excel with multiple rows (eg.sale order line) that has pre-defined row with attributes in excel file(eg. line rule and font),  the first output row will only affect the attributes and the attributes of the rest is none because the system insert new rows after added the first row.
After this commit, the above problem will be solved and inserting new row will work when we enable extend attribute (reference from  v13.0).

Please see the reference.
This is the default excel file for exporting.
[sale_order.xlsx](https://github.com/OCA/server-tools/files/10420366/sale_order.xlsx)

This is the export excel before this commit.
[SO007(8).xlsx](https://github.com/OCA/server-tools/files/10420368/SO007.8.xlsx)

This is the export excel after commit.
[SO007(20).xlsx](https://github.com/OCA/server-tools/files/10420371/SO007.20.xlsx)


@qrtl
