### PR TITLE
[FIX] Double requirement given

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # generated from manifests external_dependencies
 acme<2.0.0
 astor
-cryptography
 cryptography==2.6.1
 dataclasses
 dnspython


### PR DESCRIPTION
If I execute in this repo

`pip install -r requirements.txt` 

I've got this error:

<pre><span style="color:#C01C28">ERROR: Double requirement given: cryptography==2.6.1 (from -r requirements.txt (line 5)) (already in cryptography (from -r requirements.txt (line 4)), name=&apos;cryptography&apos;)</span></pre>