### PR TITLE
[15.0][FIX] module_analysis: Fix tests

### DIFF
--- a/module_analysis/post_init_hook.py
+++ b/module_analysis/post_init_hook.py
@@ -6,9 +6,8 @@ from odoo import SUPERUSER_ID, api
 
 
 def analyse_installed_modules(cr, registry):
-    with api.Environment.manage():
-        env = api.Environment(cr, SUPERUSER_ID, {})
-        installed_modules = env["ir.module.module"].search(
-            ["|", ("state", "=", "installed"), ("name", "=", "module_analysis")]
-        )
-        installed_modules.button_analyse_code()
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    installed_modules = env["ir.module.module"].search(
+        ["|", ("state", "=", "installed"), ("name", "=", "module_analysis")]
+    )
+    installed_modules.button_analyse_code()

--- a/module_analysis/tests/test_module.py
+++ b/module_analysis/tests/test_module.py
@@ -2,11 +2,10 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase, at_install, post_install
+from odoo.tests.common import TransactionCase, tagged
 
 
-@at_install(False)
-@post_install(True)
+@tagged("-at_install", "post_install")
 class TestModule(TransactionCase):
     def setUp(self):
         super().setUp()

--- a/module_analysis/tests/test_module.py
+++ b/module_analysis/tests/test_module.py
@@ -7,9 +7,16 @@ from odoo.tests.common import TransactionCase, tagged
 
 @tagged("-at_install", "post_install")
 class TestModule(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.IrModuleModule = self.env["ir.module.module"]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.IrModuleModule = cls.env["ir.module.module"]
+        # Remove lib because it breaks tests in case of installation of modules with
+        # pip
+        cls.env["ir.config_parameter"].set_param(
+            "module_analysis.exclude_directories", "demo,test,tests,doc,description"
+        )
+        cls.IrModuleModule.cron_analyse_code()
 
     def test_installed_modules(self):
         installed_modules = self.IrModuleModule.search(


### PR DESCRIPTION
Prevent import error

`ImportError: cannot import name 'at_install' from 'odoo.tests.common' (/opt/odoo/odoo/tests/common.py)`

Please @pedrobaeza can you review it?

@Tecnativa