### PR TITLE
[ADD] url_attachment_search_fuzzy

### DIFF
--- a/setup/url_attachment_search_fuzzy/odoo/addons/url_attachment_search_fuzzy
+++ b/setup/url_attachment_search_fuzzy/odoo/addons/url_attachment_search_fuzzy
@@ -1,0 +1,1 @@
+../../../../url_attachment_search_fuzzy

--- a/setup/url_attachment_search_fuzzy/setup.py
+++ b/setup/url_attachment_search_fuzzy/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/url_attachment_search_fuzzy/__manifest__.py
+++ b/url_attachment_search_fuzzy/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Fuzzy Search of URL in Attachments",
+    "version": "14.0.1.0.0",
+    "depends": [
+        "base_search_fuzzy",
+    ],
+    "website": "https://github.com/OCA/server-tools",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Tools",
+    "license": "AGPL-3",
+    "maintainers": ["mariadforgelow"],
+    "data": [
+        "data/url_attachment_index.xml",
+    ],
+    "installable": True,
+}

--- a/url_attachment_search_fuzzy/data/url_attachment_index.xml
+++ b/url_attachment_search_fuzzy/data/url_attachment_index.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="trgm_index_gin_url_attacment" model="trgm.index">
+        <field name="field_id" ref="base.field_ir_attachment__url" />
+        <field name="index_type">gin</field>
+    </record>
+</odoo>

--- a/url_attachment_search_fuzzy/readme/CONFIGURE.rst
+++ b/url_attachment_search_fuzzy/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+You just have to install this module and the Index for 'url' field in ir_attachment
+model will be automatically created.

--- a/url_attachment_search_fuzzy/readme/CONTRIBUTORS.rst
+++ b/url_attachment_search_fuzzy/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+`ForgeFlow <https://www.forgeflow.com>`_:
+    * Maria de Luna <maria.de.luna@forgeflow.com>

--- a/url_attachment_search_fuzzy/readme/DESCRIPTION.rst
+++ b/url_attachment_search_fuzzy/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module creates a trigram index for the field url in ir_attachment in order to make
+more efficient sql searches with like operand and this field.
+In large dbs it can speed up a lot interface loading, for example when logging in.

--- a/url_attachment_search_fuzzy/readme/INSTALL.rst
+++ b/url_attachment_search_fuzzy/readme/INSTALL.rst
@@ -1,0 +1,7 @@
+(same as the base module)
+
+#. The PostgreSQL extension ``pg_trgm`` should be available. In debian based
+   distribution you have to install the `postgresql-contrib` module.
+#. Install the ``pg_trgm`` extension to your database or give your postgresql
+   user the ``SUPERUSER`` right (this allows the odoo module to install the
+   extension to the database).


### PR DESCRIPTION
This module creates a trigram index for the field url in ir_attachment in order to make
more efficient sql searches with like operand and this field.
In large dbs it can speed up a lot interface loading, for example when logging in.

cc @JordiBForgeFlow @ChrisOForgeFlow 