### PR TITLE
[ADD] field name

### DIFF
--- a/jsonifier/models/models.py
+++ b/jsonifier/models/models.py
@@ -160,16 +160,13 @@ class Base(models.AbstractModel):
              'field_name:json_key'
         ]
 
-        if parser has 'with_fieldname': True  , key the name of the field will be added
-        to the value. the name of the field will be translated if the 'lang' key
-        is present too. example
+        if with_fieldname=True,the name of the field will be added
+        to the value. the name of the field will be translated.
 
         rec.jsonify(
             parser=['name', 'create_date',
                     'order_line', ['id' , 'product_uom', 'is_expense'])],
             with_fieldname=False)
-
-
 
         returns:
 
@@ -216,7 +213,7 @@ class Base(models.AbstractModel):
                 # fieldname of  field.order_line.product_uom
                 result['order_line']['value']['product_uom']['fieldname']
 
-        I need to use structure{'value':x, 'fieldname': y}  because the json name
+        I need to use structure {'value':x, 'fieldname': y} because the json name
         (order_line) may be duplicated in the various levels of relational fields.
 
         """

--- a/jsonifier/models/models.py
+++ b/jsonifier/models/models.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from odoo import _, api, fields, models, tools
+from odoo import api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.tools.misc import format_duration
 from odoo.tools.translate import _
@@ -124,12 +124,14 @@ class Base(models.AbstractModel):
                 resolver = field_dict.get("resolver")
                 value = rec._jsonify_value(field, rec[field.name])
                 value = resolver.resolve(field, rec)[0] if resolver else value
-            if rec.env.context.get('with_fieldname'):
-                 # translation will be fetched automatically from context
-                 fieldname = _(field.string)
-                 self._add_json_key(root, json_key, {'value': value, 'fieldname': fieldname })
+            if rec.env.context.get("with_fieldname"):
+                # translation will be fetched automatically from context
+                fieldname = _(field.string)
+                self._add_json_key(
+                    root, json_key, {"value": value, "fieldname": fieldname}
+                )
             else:
-                 self._add_json_key(root, json_key, value)
+                self._add_json_key(root, json_key, value)
         return root
 
     def jsonify(self, parser, one=False, with_fieldname=False):
@@ -163,43 +165,43 @@ class Base(models.AbstractModel):
         is present too. example
 
         rec.jsonify(
-            parser=['name', 'create_date', 
+            parser=['name', 'create_date',
                     'order_line', ['id' , 'product_uom', 'is_expense'])],
             with_fieldname=False)
 
-          
+
 
         returns:
 
-        [{'name': 'SO/2022/006', 
-                   'create_date': '2022-10-14T15:55:39.823019+02:00', 
+        [{'name': 'SO/2022/006',
+                   'create_date': '2022-10-14T15:55:39.823019+02:00',
                    'order_line': {
-                         'id': 4, 
+                         'id': 4,
                          'product_uom': 'Stuk(s)
                          'is_expense': False}
                     }]
 
         rec.jsonify(
-            parser=['name', 'create_date', 
+            parser=['name', 'create_date',
                     'order_line', ['id' , 'product_uom', 'is_expense'])],
             with_fieldname=True)
 
         would give us:
         [{'name': { value: 'SO/2022/006', 'fieldname': 'Name'},
           'create_date': {
-                         'value': '2022-10-14T15:55:39.823019+02:00', 
+                         'value': '2022-10-14T15:55:39.823019+02:00',
                          'fieldname': 'Created On'},
           'order_line': {'value': {
-                             'id': {'value':  4, 'fieldname': 'ID'}, 
-                             'Product_uom': {'value': 'Stuks',  
+                             'id': {'value':  4, 'fieldname': 'ID'},
+                             'Product_uom': {'value': 'Stuks',
                                              'fieldname': 'Unit Of measure'},
-                             'is_expense': {'value': False  , 
+                             'is_expense': {'value': False  ,
                                             'fieldname': 'Is an Expense'}}
                          },
                          fieldname: 'Sale Order Lines'
               }
         ]
-         
+
         therefore the value of the field will be accessed not anymore as:
 
                 result['name']
@@ -210,11 +212,11 @@ class Base(models.AbstractModel):
                 result['name']['value']  # get value of field.name
                 result['name']['fieldname']   # get the translated fieldname of name
                 # get value of field.order_line.product_uom.
-                result['order_line']['value']['product_uom']['value'] 
+                result['order_line']['value']['product_uom']['value']
                 # fieldname of  field.order_line.product_uom
-                result['order_line']['value']['product_uom']['fieldname'] 
-              
-        I need to use structure{'value':x, 'fieldname': y}  because the json name 
+                result['order_line']['value']['product_uom']['fieldname']
+
+        I need to use structure{'value':x, 'fieldname': y}  because the json name
         (order_line) may be duplicated in the various levels of relational fields.
 
         """
@@ -236,8 +238,9 @@ class Base(models.AbstractModel):
         for lang in parsers:
             translate = lang or parser.get("language_agnostic")
             records = records.with_context(lang=lang) if translate else records
-            records = records.with_context(
-                    with_fieldname=True) if with_fieldname else records
+            records = (
+                records.with_context(with_fieldname=True) if with_fieldname else records
+            )
             for record, json in zip(records, results):
                 self._jsonify_record(parsers[lang], record, json)
 

--- a/jsonifier/models/models.py
+++ b/jsonifier/models/models.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from odoo import api, fields, models, tools
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.tools.misc import format_duration
 from odoo.tools.translate import _
@@ -124,11 +124,15 @@ class Base(models.AbstractModel):
                 resolver = field_dict.get("resolver")
                 value = rec._jsonify_value(field, rec[field.name])
                 value = resolver.resolve(field, rec)[0] if resolver else value
-
-            self._add_json_key(root, json_key, value)
+            if rec.env.context.get('with_fieldname'):
+                 # translation will be fetched automatically from context
+                 fieldname = _(field.string)
+                 self._add_json_key(root, json_key, {'value': value, 'fieldname': fieldname })
+            else:
+                 self._add_json_key(root, json_key, value)
         return root
 
-    def jsonify(self, parser, one=False):
+    def jsonify(self, parser, one=False, with_fieldname=False):
         """Convert the record according to the given parser.
 
         Example of (simple) parser:
@@ -154,6 +158,65 @@ class Base(models.AbstractModel):
              'field_name:json_key'
         ]
 
+        if parser has 'with_fieldname': True  , key the name of the field will be added
+        to the value. the name of the field will be translated if the 'lang' key
+        is present too. example
+
+        rec.jsonify(
+            parser=['name', 'create_date', 
+                    'order_line', ['id' , 'product_uom', 'is_expense'])],
+            with_fieldname=False)
+
+          
+
+        returns:
+
+        [{'name': 'SO/2022/006', 
+                   'create_date': '2022-10-14T15:55:39.823019+02:00', 
+                   'order_line': {
+                         'id': 4, 
+                         'product_uom': 'Stuk(s)
+                         'is_expense': False}
+                    }]
+
+        rec.jsonify(
+            parser=['name', 'create_date', 
+                    'order_line', ['id' , 'product_uom', 'is_expense'])],
+            with_fieldname=True)
+
+        would give us:
+        [{'name': { value: 'SO/2022/006', 'fieldname': 'Name'},
+          'create_date': {
+                         'value': '2022-10-14T15:55:39.823019+02:00', 
+                         'fieldname': 'Created On'},
+          'order_line': {'value': {
+                             'id': {'value':  4, 'fieldname': 'ID'}, 
+                             'Product_uom': {'value': 'Stuks',  
+                                             'fieldname': 'Unit Of measure'},
+                             'is_expense': {'value': False  , 
+                                            'fieldname': 'Is an Expense'}}
+                         },
+                         fieldname: 'Sale Order Lines'
+              }
+        ]
+         
+        therefore the value of the field will be accessed not anymore as:
+
+                result['name']
+                result['order_line']['product_uom']
+
+        but:
+
+                result['name']['value']  # get value of field.name
+                result['name']['fieldname']   # get the translated fieldname of name
+                # get value of field.order_line.product_uom.
+                result['order_line']['value']['product_uom']['value'] 
+                # fieldname of  field.order_line.product_uom
+                result['order_line']['value']['product_uom']['fieldname'] 
+              
+        I need to use structure{'value':x, 'fieldname': y}  because the json name 
+        (order_line) may be duplicated in the various levels of relational fields.
+
         """
         if one:
             self.ensure_one()
@@ -173,6 +236,8 @@ class Base(models.AbstractModel):
         for lang in parsers:
             translate = lang or parser.get("language_agnostic")
             records = records.with_context(lang=lang) if translate else records
+            records = records.with_context(
+                    with_fieldname=True) if with_fieldname else records
             for record, json in zip(records, results):
                 self._jsonify_record(parsers[lang], record, json)
 


### PR DESCRIPTION
Adds a parameter to jsonifier with_fieldnames.
THis will allow jsonifier to return a different type of result: instead of : 
`       {'product_qty' : 18}`
we will have:
`    {   product_qty : { 'value':18, 'fieldname': 'Product Quantity'} }`

               
Very useful to have , with one RPC call , the translated value of the field we are displaying, 100% the same as odoo backend.