### PR TITLE
[FIX] sentry: change with_locals to include_local_variables variable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ openpyxl
 openupgradelib
 pygount
 pysftp
-sentry_sdk
+sentry_sdk>=1.17.0

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk",
+            "sentry_sdk>=1.17.0",
         ]
     },
     "depends": [

--- a/sentry/const.py
+++ b/sentry/const.py
@@ -77,7 +77,9 @@ def get_sentry_options():
         SentryOption("dsn", "", str.strip),
         SentryOption("transport", DEFAULT_OPTIONS["transport"], select_transport),
         SentryOption("logging_level", DEFAULT_LOG_LEVEL, get_sentry_logging),
-        SentryOption("with_locals", DEFAULT_OPTIONS["with_locals"], None),
+        SentryOption(
+            "include_local_variables", DEFAULT_OPTIONS["include_local_variables"], None
+        ),
         SentryOption(
             "max_breadcrumbs", DEFAULT_OPTIONS["max_breadcrumbs"], to_int_if_defined
         ),


### PR DESCRIPTION
Currently, version 1.17.0 of sentry_sdk is causing the following error:

SentryOption("with_locals", DEFAULT_OPTIONS["with_locals"], None), KeyError: 'with_locals'.

Where the with_locals key is not found in the dictionary, generating an error, stopping the installation of the sentry module.

In version 1.17.0 rename 'with_locals'  to 'include_local_variables' https://github.com/getsentry/sentry-python/commit/79e33169aa629ec67cf9636b8440f64bf0a6d566

This commit adjust the  get_sentry_options() method in https://github.com/Vauxoo/server-tools/blob/15.0/sentry/const.py file, set the new variable.

related #2586 