### PR TITLE
[13.0][FIX] auditlog: Allow passing a chunk size for autovacuum

### DIFF
--- a/auditlog/models/autovacuum.py
+++ b/auditlog/models/autovacuum.py
@@ -27,7 +27,9 @@ class AuditlogAutovacuum(models.TransientModel):
         for data_model in data_models:
             records = self.env[data_model].search(
                 [("create_date", "<=", fields.Datetime.to_string(deadline))],
-                limit=chunk_size, order="create_date asc")
+                limit=chunk_size,
+                order="create_date asc",
+            )
             nb_records = len(records)
             with self.env.norecompute():
                 records.unlink()

--- a/auditlog/models/autovacuum.py
+++ b/auditlog/models/autovacuum.py
@@ -13,7 +13,7 @@ class AuditlogAutovacuum(models.TransientModel):
     _description = "Auditlog - Delete old logs"
 
     @api.model
-    def autovacuum(self, days):
+    def autovacuum(self, days, chunk_size=None):
         """Delete all logs older than ``days``. This includes:
             - CRUD logs (create, read, write, unlink)
             - HTTP requests
@@ -26,9 +26,10 @@ class AuditlogAutovacuum(models.TransientModel):
         data_models = ("auditlog.log", "auditlog.http.request", "auditlog.http.session")
         for data_model in data_models:
             records = self.env[data_model].search(
-                [("create_date", "<=", fields.Datetime.to_string(deadline))]
-            )
+                [('create_date', '<=', fields.Datetime.to_string(deadline))],
+                limit=chunk_size, order='create_date asc')
             nb_records = len(records)
-            records.unlink()
+            with self.env.norecompute():
+                records.unlink()
             _logger.info("AUTOVACUUM - %s '%s' records deleted", nb_records, data_model)
         return True

--- a/auditlog/models/autovacuum.py
+++ b/auditlog/models/autovacuum.py
@@ -26,8 +26,8 @@ class AuditlogAutovacuum(models.TransientModel):
         data_models = ("auditlog.log", "auditlog.http.request", "auditlog.http.session")
         for data_model in data_models:
             records = self.env[data_model].search(
-                [('create_date', '<=', fields.Datetime.to_string(deadline))],
-                limit=chunk_size, order='create_date asc')
+                [("create_date", "<=", fields.Datetime.to_string(deadline))],
+                limit=chunk_size, order="create_date asc")
             nb_records = len(records)
             with self.env.norecompute():
                 records.unlink()

--- a/auditlog/readme/CONFIGURE.rst
+++ b/auditlog/readme/CONFIGURE.rst
@@ -1,0 +1,22 @@
+Rules
+~~~~~
+
+Go to `Settings / Technical / Audit / Rules` to subscribe rules. A rule defines
+which operations to log for a given data model.
+
+.. image:: ../static/description/rule.png
+
+Cleanup
+~~~~~~~
+
+A scheduled action exists to delete logs older than 6 months (180 days)
+automatically but is not enabled by default.
+To activate it and/or change the delay, go to the
+`Configuration / Technical / Automation / Scheduled Actions` menu and edit the
+`Auto-vacuum audit logs` entry:
+
+.. image:: ../static/description/autovacuum.png
+
+In case you're having trouble with the amount of records to delete per run,
+you can pass the amount of records to delete for one model per run as the second
+parameter, the default is to delete all records in one go.


### PR DESCRIPTION
(cherry picked from commit d4f8eb345acfb60d7ff28180614340944c03225e)
The commit was already cherry-picked into all branches v14+, only v13 is missing.

Original PR in v12 #2335 

This allows administrators to fine tune the amount of records to delete in one run of the autovacuum.