### PR TITLE
[13.0] session_db: reconnect if needed

### DIFF
--- a/session_db/pg_session_store.py
+++ b/session_db/pg_session_store.py
@@ -47,6 +47,7 @@ def with_cursor(func):
         while True:
             tries += 1
             try:
+                self._ensure_connection()
                 return func(self, *args, **kwargs)
             except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
                 _logger.info("Session in DB connection Retry %s/5" % tries)
@@ -68,6 +69,11 @@ class PGSessionStore(werkzeug.contrib.sessions.SessionStore):
     def __del__(self):
         if self._cr is not None:
             self._cr.close()
+
+    @with_lock
+    def _ensure_connection(self):
+        if self._cr is None:
+            self._open_connection()
 
     @with_lock
     def _open_connection(self):

--- a/session_db/pg_session_store.py
+++ b/session_db/pg_session_store.py
@@ -49,11 +49,14 @@ def with_cursor(func):
             try:
                 self._ensure_connection()
                 return func(self, *args, **kwargs)
-            except (psycopg2.InterfaceError, psycopg2.OperationalError) as e:
-                _logger.info("Session in DB connection Retry %s/5" % tries)
+            except (psycopg2.InterfaceError, psycopg2.OperationalError):
+                self._close_connection()
                 if tries > 4:
-                    raise e
-                self._open_connection()
+                    _logger.warning(
+                        "session_db operation try %s/5 failed, aborting", tries
+                    )
+                    raise
+                _logger.info("session_db operation try %s/5 failed, retrying", tries)
 
     return wrapper
 
@@ -67,8 +70,7 @@ class PGSessionStore(werkzeug.contrib.sessions.SessionStore):
         self._setup_db()
 
     def __del__(self):
-        if self._cr is not None:
-            self._cr.close()
+        self._close_connection()
 
     @with_lock
     def _ensure_connection(self):
@@ -77,16 +79,20 @@ class PGSessionStore(werkzeug.contrib.sessions.SessionStore):
 
     @with_lock
     def _open_connection(self):
-        # return cursor to the pool
+        self._close_connection()
+        cnx = odoo.sql_db.db_connect(self._uri, allow_uri=True)
+        self._cr = cnx.cursor()
+        self._cr.autocommit(True)
+
+    @with_lock
+    def _close_connection(self):
+        """Return cursor to the pool."""
         if self._cr is not None:
             try:
                 self._cr.close()
             except Exception:
                 pass
             self._cr = None
-        cnx = odoo.sql_db.db_connect(self._uri, allow_uri=True)
-        self._cr = cnx.cursor()
-        self._cr.autocommit(True)
 
     @with_lock
     @with_cursor

--- a/session_db/tests/__init__.py
+++ b/session_db/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_pg_session_store

--- a/session_db/tests/test_pg_session_store.py
+++ b/session_db/tests/test_pg_session_store.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+import psycopg2
+
+from odoo.http import OpenERPSession
+from odoo.sql_db import connection_info_for
+from odoo.tests.common import TransactionCase
+from odoo.tools import config
+
+from odoo.addons.session_db.pg_session_store import PGSessionStore
+
+
+def _make_postgres_uri(
+    login=None, password=None, host=None, port=None, database=None, **kwargs
+):
+    uri = ["postgres://"]
+    if login:
+        uri.append(login)
+        if password:
+            uri.append(f":{password}")
+        uri.append("@")
+    if host:
+        uri.append(host)
+        if port:
+            uri.append(f":{port}")
+    uri.append("/")
+    if database:
+        uri.append(database)
+    return "".join(uri)
+
+
+class TestPGSessionStore(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        _, connection_info = connection_info_for(config["db_name"])
+        self.session_store = PGSessionStore(
+            _make_postgres_uri(**connection_info), session_class=OpenERPSession
+        )
+
+    def test_session_crud(self):
+        session = self.session_store.new()
+        session["test"] = "test"
+        self.session_store.save(session)
+        assert session.sid is not None
+        assert self.session_store.get(session.sid)["test"] == "test"
+        self.session_store.delete(session)
+        assert self.session_store.get(session.sid).get("test") is None
+
+    def test_retry(self):
+        """Test that session operations are retried before failing"""
+        with mock.patch("odoo.sql_db.Cursor.execute") as mock_execute:
+            mock_execute.side_effect = psycopg2.OperationalError()
+            with self.assertRaises(psycopg2.OperationalError):
+                self.session_store.get("abc")
+            assert mock_execute.call_count == 5
+        # when the error is resolved, it works again
+        self.session_store.get("abc")
+
+    def test_retry_connect_fail(self):
+        with mock.patch("odoo.sql_db.Cursor.execute") as mock_execute, mock.patch(
+            "odoo.sql_db.db_connect"
+        ) as mock_db_connect:
+            mock_execute.side_effect = psycopg2.OperationalError()
+            mock_db_connect.side_effect = RuntimeError("connection failed")
+            # get fails, and a RuntimeError is raised when trying to reconnect
+            with self.assertRaises(RuntimeError):
+                self.session_store.get("abc")
+            assert mock_execute.call_count == 1
+        # when the error is resolved, it works again
+        self.session_store.get("abc")


### PR DESCRIPTION
If the connection to the database fails when
retrying a session operation, we end up
with no cursore, which makes subsequent
session operations fail.

We fix this by ensuring we have cursor
before any operations.