### PR TITLE
[15.0][FIX] database_cleanup: 'Environment' object has no attribute 'invalidate_all'

### DIFF
--- a/database_cleanup/models/purge_modules.py
+++ b/database_cleanup/models/purge_modules.py
@@ -53,7 +53,7 @@ class CleanupPurgeLineModule(models.TransientModel):
         modules.filtered(
             lambda x: x.state not in ("uninstallable", "uninstalled")
         ).button_immediate_uninstall()
-        modules.env.invalidate_all()
+        modules.invalidate_cache()
         modules.unlink()
         return self.write({"purged": True})
 


### PR DESCRIPTION
Replaced by invalidate_cache on the model, which end up calling env.cache.invalidate()