### PR TITLE
[REF] base_sequence_default: bump sequence only on creation

### DIFF
--- a/base_sequence_default/__manifest__.py
+++ b/base_sequence_default/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Tools",
     "website": "https://github.com/OCA/server-tools",
     "author": "Moduon, Odoo Community Association (OCA)",
-    "maintainers": ["Shide"],
+    "maintainers": ["Shide", "yajo"],
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/base_sequence_default/models/base.py
+++ b/base_sequence_default/models/base.py
@@ -1,19 +1,22 @@
 # Copyright 2023 Moduon Team S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
 
+import logging
 
 from odoo import api, models
 
 SEQUENCE_PREFIX = "base_sequence_default"
+_logger = logging.getLogger(__name__)
 
 
 class Base(models.AbstractModel):
     _inherit = "base"
 
-    @api.model
-    def default_get(self, fields_list):
+    @api.model_create_multi
+    def create(self, vals_list):
         """Produce sequenced defaults if DB is configured for that."""
-        res = super().default_get(fields_list)
+        result = super().create(vals_list)
+        # Get sequences for fields in this model
         prefix = f"{SEQUENCE_PREFIX}.{self._name}.fields."
         model_sequences = (
             self.env["ir.sequence"]
@@ -26,12 +29,17 @@ class Base(models.AbstractModel):
                 order="company_id",
             )
         )
-        sequences_by_field = {seq.code[len(prefix) :]: seq for seq in model_sequences}
-        for fname in fields_list:
-            try:
-                seq = sequences_by_field[fname]
-            except KeyError:
-                # No sequence? No problem
-                continue
-            res[fname] = seq.next_by_id()
-        return res
+        for record in result:
+            for seq in model_sequences:
+                fname = seq.code[len(prefix) :]
+                if fname not in record._fields:
+                    _logger.warning(
+                        "Ignoring sequence %s; missing field %s in model %s",
+                        seq.code,
+                        fname,
+                        self._name,
+                    )
+                    continue
+                if record[fname] in {False, "-"}:
+                    record[fname] = seq.next_by_id()
+        return result

--- a/base_sequence_default/readme/USAGE.rst
+++ b/base_sequence_default/readme/USAGE.rst
@@ -2,4 +2,6 @@ To use this module, it is necessary to:
 
 #. Follow the configuration instructions.
 #. Create a record of the model you configured.
+#. Leave empty the fields where you configured a sequence. If they are required
+   fields, set value to "-" to trigger the automatic sequence on creation.
 #. Check that the field defined in the sequence is set to the next value in the sequence.

--- a/base_sequence_default/tests/test_project_project.py
+++ b/base_sequence_default/tests/test_project_project.py
@@ -34,6 +34,10 @@ class BaseSequenceDefaultCase(TransactionCase):
 
     def test_partner_default_field(self):
         """Test that new created partner has the correct default field values."""
-        with Form(self.env["res.partner"]) as pp_form:
-            self.assertEqual(pp_form.name, "PN/001")
-            self.assertEqual(pp_form.mobile, "+34 000000001")
+        partner_f = Form(self.env["res.partner"])
+        self.assertEqual(partner_f.name, False)
+        self.assertEqual(partner_f.mobile, False)
+        partner_f.name = "-"
+        partner = partner_f.save()
+        self.assertEqual(partner.name, "PN/001")
+        self.assertEqual(partner.mobile, "+34 000000001")


### PR DESCRIPTION
Before this patch, sequence was bumped when loading defaults. That happened even before creating the record. That rendered no-gap sequences useless.

Now, sequences are executed only on record creation, when the user didn't give a default value to the sequenced fields.

To support the use case when you want a sequence on required fields, you can set a value of `-` on those fields on creation. Then, the sequence will also kick in.

@moduon MT-2715