### PR TITLE
[16.0][ADD] module_auto_update: allow updates in a minimal environment

### DIFF
--- a/module_auto_update/readme/USAGE.rst
+++ b/module_auto_update/readme/USAGE.rst
@@ -19,4 +19,4 @@ in an Odoo shell session:
 
 .. code-block:: python
 
-  env['ir.module.module'].upgrade_changed_checksum()
+  env['ir.module.module'].upgrade_changed_checksum_shell()


### PR DESCRIPTION
without this, updates fail when you add columns to models that are used here, namely `res.users` and `ir.model`