### PR TITLE
[14.0][FIX] *: remove `lxml` from python depends

### DIFF
--- a/html_image_url_extractor/__manifest__.py
+++ b/html_image_url_extractor/__manifest__.py
@@ -12,6 +12,5 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "external_dependencies": {"python": ["lxml"]},
     "depends": ["base"],
 }

--- a/html_text/__manifest__.py
+++ b/html_text/__manifest__.py
@@ -14,6 +14,5 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "external_dependencies": {"python": ["lxml"]},
     "depends": ["base"],
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cryptography
 dataclasses
 dnspython
 josepy
-lxml
 odoorpc
 openpyxl
 openupgradelib


### PR DESCRIPTION
Such dependency is already included in Odoo requirements using a pinned
version [1]. Adding here could cause to upgrade the library to an
incompatible version.

[1] https://github.com/odoo/odoo/blob/54e58b3e47ee/requirements.txt#L23