### PR TITLE
[16.0][FIX] module_analysis : tests compatibility with pip install

### DIFF
--- a/module_analysis/tests/test_module.py
+++ b/module_analysis/tests/test_module.py
@@ -6,12 +6,18 @@ from odoo.tests.common import TransactionCase
 
 
 class TestModule(TransactionCase):
-    def setUp(self):
-        super().setUp()
-        self.IrModuleModule = self.env["ir.module.module"]
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.IrModuleModule = cls.env["ir.module.module"]
+        # Remove lib because it breaks tests in case of installation of modules with
+        # pip
+        cls.env["ir.config_parameter"].set_param(
+            "module_analysis.exclude_directories", "demo,test,tests,doc,description"
+        )
+        cls.IrModuleModule.cron_analyse_code()
 
     def test_installed_modules(self):
-        self.IrModuleModule.cron_analyse_code()
         installed_modules = self.IrModuleModule.search(
             [("state", "=", "installed"), ("name", "not like", "_test")]
         )


### PR DESCRIPTION
Hello,

module_analysis tests presently fails if, any addons in server-tools, has a dependency which is not from server-tools repository or a native odoo module. 16.0 branch is still green, because, for now, no module has dependency from an other OCA repo.
We can see it in this PR : https://github.com/OCA/server-tools/pull/2560 (https://github.com/OCA/server-tools/actions/runs/5012100788/jobs/8983650830?pr=2560#step:8:3636)
We can also see it is in v15 : https://github.com/OCA/server-tools/pull/2570

The problem is the following, the folder "lib" is exluded by default by the module : https://github.com/OCA/server-tools/blob/16.0/module_analysis/data/ir_config_parameter.xml#L10
And as the OCA CI use pip to install dependencies outside of its own repo, the installed odoo modules are in a subfolder of "/opt/odoo-venv/lib".
So all of these modules are totally excluded and the test fails.

My fix is quite simple, the module just stop ignoring the lib folder.
I think we can have this quick fix. Maybe later on the module should be improved to work with these pip installed modules by default...

@legalsylvain What do you think of the fix ?
@pedrobaeza @victoralmau It may interest you also since you were trying to fix these same tests in v15
@kevinkhao FYI