### PR TITLE
[14.0][FIX] base_model_restrict_update: button presentation

### DIFF
--- a/base_model_restrict_update/models/res_users.py
+++ b/base_model_restrict_update/models/res_users.py
@@ -22,11 +22,3 @@ class ResUsers(models.Model):
         for user in self:
             if self.env.ref("base.group_system") in user.groups_id:
                 raise UserError(_("You cannot set admin user as a readonly user."))
-
-    def toggle_unrestrict_model_update(self):
-        for record in self:
-            record.unrestrict_model_update = not record.unrestrict_model_update
-
-    def toggle_is_readonly_user(self):
-        for record in self:
-            record.is_readonly_user = not record.is_readonly_user

--- a/base_model_restrict_update/readme/CONFIGURE.rst
+++ b/base_model_restrict_update/readme/CONFIGURE.rst
@@ -1,3 +1,6 @@
 Enable the "Update Restrict Model" of specific model to restrict update from unpermitted users.
-To set a user as a permitted user to update restricted model(s), click on "Grant Update Permit" in user form.
-Optionally, to set a user as readonly user to all models, click on "Readonly User" in user form.
+To set a user as a permitted user to update restricted model(s), click on "Unrestrict
+Update" toggle button in the user form.
+
+Optionally, to set a user as read-only user to all models, click on "Read-only" toggle
+button in the user form.

--- a/base_model_restrict_update/tests/test_base_model_restrict_update.py
+++ b/base_model_restrict_update/tests/test_base_model_restrict_update.py
@@ -56,8 +56,7 @@ class TestBaseModelRestrictUpdate(SavepointCase):
         test_partner.with_user(self.permit_test_user.id).unlink()
 
     def test_04_readonly_user_update_partner(self):
-        self.permit_test_user.toggle_is_readonly_user()
-        self.assertTrue(self.permit_test_user.is_readonly_user)
+        self.permit_test_user.write({"is_readonly_user": True})
         with self.assertRaises(AccessError):
             self.test_partner.with_user(self.permit_test_user.id).update(
                 {"name": "Test Partner 2"}

--- a/base_model_restrict_update/views/res_users_views.xml
+++ b/base_model_restrict_update/views/res_users_views.xml
@@ -9,28 +9,15 @@
             <div class="oe_button_box" name="button_box" position="inside">
                 <button
                     name="toggle_unrestrict_model_update"
-                    type="object"
                     class="oe_stat_button"
-                    icon="fa-pencil"
                     attrs="{'invisible': [('is_readonly_user', '=', True)]}"
                 >
-                    <field
-                        name="unrestrict_model_update"
-                        widget="boolean_button"
-                        options='{"terminology": {"string_true": "Update Permit", "string_false": "Unpermitted"}}'
-                    />
+                    <span style="padding: 0 10px;">Unrestrict Update</span>
+                    <field name="unrestrict_model_update" widget="boolean_toggle" />
                 </button>
-                <button
-                    name="toggle_is_readonly_user"
-                    type="object"
-                    class="oe_stat_button"
-                    icon="fa-ban"
-                >
-                    <field
-                        name="is_readonly_user"
-                        widget="boolean_button"
-                        options='{"terminology": {"string_false": "Editable", "string_true": "Readonly"}}'
-                    />
+                <button name="toggle_is_readonly_user" class="oe_stat_button">
+                    <span style="padding: 0 10px;">Read-only</span>
+                    <field name="is_readonly_user" widget="boolean_toggle" />
                 </button>
             </div>
         </field>


### PR DESCRIPTION
Before this commit, button presentation of 'Grant Update Permit' and 'Readonly' were broken in the user form with the deprecation of boolean_button widget.

In this commit, we switch to use boolean_toggle for these buttons, with some other style adjustments on the buttons.

Button presentation before this update:
![image](https://github.com/OCA/server-tools/assets/7766939/2110948c-00ef-4306-a0eb-e54b4feafec9)

After update:
![image](https://github.com/OCA/server-tools/assets/7766939/47fe6f9c-c067-4bd3-a717-e77df3f879e6)

@qrtl
