### PR TITLE
[16.0] [FIX] Multi-Company issue with M2M field

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -386,7 +386,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
-            # self.invalidate_recordset()
+            self.invalidate_recordset()
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -386,6 +386,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
+            # self.invalidate_recordset()
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d

--- a/auditlog/tests/__init__.py
+++ b/auditlog/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import test_auditlog
 from . import test_autovacuum
+from . import test_multi_company

--- a/auditlog/tests/test_multi_company.py
+++ b/auditlog/tests/test_multi_company.py
@@ -1,0 +1,194 @@
+import json
+
+from odoo.tests.common import Form, TransactionCase, new_test_user
+
+
+class TestAuditlogMultiCompany(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner_model = cls.env.ref("base.model_res_partner")
+        cls.res_company = cls.env["res.company"]
+        cls.auditlog_log = cls.env["auditlog.log"]
+        cls.auditlog_rule = cls.env["auditlog.rule"]
+        cls.res_partner = cls.env["res.partner"]
+        cls.ir_rule = cls.env["ir.rule"]
+        cls.res_partner_category = cls.env["res.partner.category"]
+        cls.res_partner_category_model = cls.env["ir.model"]._get(
+            cls.res_partner_category._name
+        )
+        cls.partner_rule = cls.auditlog_rule.create(
+            {
+                "name": "Test rule for multi-company",
+                "model_id": cls.partner_model.id,
+                "log_read": False,
+                "log_create": False,
+                "log_write": True,
+                "log_unlink": False,
+                "log_type": "full",
+                "state": "subscribed",
+            }
+        )
+        cls.partner = cls.res_partner.create({"name": "Test Partner"})
+        cls.main_company = cls.env.ref("base.main_company")
+        cls.main_company_user = new_test_user(
+            cls.env,
+            login="main.company.user",
+            groups="base.group_user,base.group_partner_manager",
+            company_id=cls.main_company.id,
+            company_ids=cls.main_company.ids,
+        )
+        cls.other_company = cls.res_company.create({"name": "Other Company"})
+        cls.other_company_user = new_test_user(
+            cls.env,
+            login="other.company.user",
+            groups="base.group_user,base.group_partner_manager",
+            company_id=cls.other_company.id,
+            company_ids=cls.other_company.ids,
+        )
+        cls.category_1 = cls.res_partner_category.create({"name": "Category 1"})
+        cls.category_2 = cls.res_partner_category.create({"name": "Category 2"})
+        cls.category_3 = cls.res_partner_category.create({"name": "Category 3"})
+        cls.category_4 = cls.res_partner_category.create({"name": "Category 4"})
+        cls.env["ir.model.fields"].sudo().create(
+            [
+                {
+                    "name": "x_company_id",
+                    "field_description": "Company",
+                    "model_id": cls.res_partner_category_model.id,
+                    "ttype": "many2one",
+                    "relation": cls.res_company._name,
+                }
+            ]
+        )
+        cls.partner_domain = [
+            ("model_id", "=", cls.partner_model.id),
+            ("method", "=", "write"),
+            ("res_id", "=", cls.partner.id),
+        ]
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.partner_rule.unlink()
+        super().tearDownClass()
+
+    def _setup_multi_company(self):
+        self.ir_rule.create(
+            {
+                "name": "Multi-Company Rule",
+                "model_id": self.res_partner_category_model.id,
+                "domain_force": "['|', ('x_company_id', '=', False),"
+                " ('x_company_id', 'in', company_ids)]",
+            }
+        )
+        self.category_1.x_company_id = self.main_company
+        self.category_2.x_company_id = self.other_company
+        self.category_3.x_company_id = self.main_company
+        self.category_4.x_company_id = self.other_company
+
+    def _set_category_with_form(self, user, category):
+        with Form(self.partner.with_user(user)) as f:
+            f.category_id.add(category)
+
+    def _get_old_value(self):
+        return json.loads(
+            self.auditlog_log.search(self.partner_domain, order="id desc")[
+                0
+            ].line_ids.old_value
+        )
+
+    def _get_new_value(self):
+        return json.loads(
+            self.auditlog_log.search(self.partner_domain, order="id desc")[
+                0
+            ].line_ids.new_value
+        )
+
+    def test_10_01_multi_company_not_restricted(self):
+        self._set_category_with_form(self.main_company_user, self.category_1)
+        self.assertFalse(self._get_old_value())
+        self.assertEqual(self._get_new_value(), self.category_1.ids)
+
+        self._set_category_with_form(self.other_company_user, self.category_2)
+        self.assertEqual(self._get_old_value(), self.category_1.ids)
+        self.assertEqual(self._get_new_value(), (self.category_1 | self.category_2).ids)
+        with Form(self.partner.with_user(self.main_company_user)) as f:
+            self.assertEqual(
+                f.category_id._get_ids(), (self.category_1 | self.category_2).ids
+            )
+        with Form(self.partner.with_user(self.other_company_user)) as f:
+            self.assertEqual(
+                f.category_id._get_ids(), (self.category_1 | self.category_2).ids
+            )
+
+    def test_10_02_multi_company_not_restricted(self):
+        self.partner.with_user(self.main_company_user).category_id |= self.category_1
+        self.assertFalse(self._get_old_value())
+        self.assertEqual(self._get_new_value(), self.category_1.ids)
+
+        self.partner.with_user(self.other_company_user).category_id |= self.category_2
+        self.assertEqual(self._get_old_value(), self.category_1.ids)
+        self.assertEqual(self._get_new_value(), (self.category_1 | self.category_2).ids)
+        self.assertEqual(
+            self.partner.with_user(self.main_company_user).category_id,
+            (self.category_1 | self.category_2),
+        )
+        self.assertEqual(
+            self.partner.with_user(self.other_company_user).category_id,
+            (self.category_1 | self.category_2),
+        )
+
+    def test_20_01_multi_company_restricted(self):
+        self._setup_multi_company()
+
+        self._set_category_with_form(self.main_company_user, self.category_1)
+        self.assertFalse(self._get_old_value())
+        self.assertEqual(self._get_new_value(), self.category_1.ids)
+        self._set_category_with_form(self.main_company_user, self.category_3)
+        self.assertEqual(self._get_old_value(), self.category_1.ids)
+        self.assertEqual(self._get_new_value(), (self.category_1 | self.category_3).ids)
+
+        self._set_category_with_form(self.other_company_user, self.category_2)
+        self.assertFalse(self._get_old_value())
+        self.assertEqual(self._get_new_value(), self.category_2.ids)
+        self._set_category_with_form(self.other_company_user, self.category_4)
+        self.assertEqual(self._get_old_value(), self.category_2.ids)
+        self.assertEqual(self._get_new_value(), (self.category_2 | self.category_4).ids)
+
+        with Form(self.partner.with_user(self.main_company_user)) as f:
+            self.assertEqual(
+                f.category_id._get_ids(), (self.category_1 | self.category_3).ids
+            )
+        with Form(self.partner.with_user(self.other_company_user)) as f:
+            self.assertEqual(
+                f.category_id._get_ids(), (self.category_2 | self.category_4).ids
+            )
+
+    def test_20_02_multi_company_restricted(self):
+        self._setup_multi_company()
+
+        self.partner.with_user(self.main_company_user).category_id |= self.category_1
+        self.assertFalse(self._get_old_value())
+        self.assertEqual(self._get_new_value(), self.category_1.ids)
+        self.partner.with_user(self.main_company_user).category_id |= self.category_3
+        self.assertEqual(self._get_old_value(), self.category_1.ids)
+        self.assertEqual(self._get_new_value(), (self.category_1 | self.category_3).ids)
+
+        # self.partner.invalidate_recordset()
+        self.partner.with_user(self.other_company_user).category_id |= self.category_2
+        self.assertFalse(self._get_old_value())
+        self.assertEqual(self._get_new_value(), self.category_2.ids)
+        self.partner.with_user(self.other_company_user).category_id |= self.category_4
+        self.assertEqual(self._get_old_value(), self.category_2.ids)
+        self.assertEqual(self._get_new_value(), (self.category_2 | self.category_4).ids)
+
+        # self.partner.invalidate_recordset()
+        self.assertEqual(
+            self.partner.with_user(self.main_company_user).category_id,
+            (self.category_1 | self.category_3),
+        )
+        # self.partner.invalidate_recordset()
+        self.assertEqual(
+            self.partner.with_user(self.other_company_user).category_id,
+            (self.category_2 | self.category_4),
+        )


### PR DESCRIPTION
In a Multi-Company environment with the auditlog rule on product.template enabled, the taxes_id field gets always overwritten with the taxes chosen in the current company. The cause of this is that the old_values are read with sudo, which has access to not only the current company. When doing the actual write of the field, this cached value is taken into account, which removes them from the M2M relation. Before doing the actual write, the cache of the recordset(s) need to be cleared again.

The following method causes the problem in Odoo:
```python
    def write_real(self, records_commands_list, create=False):
        # records_commands_list = [(records, commands), ...]
        if not records_commands_list:
            return

        model = records_commands_list[0][0].browse()
        comodel = model.env[self.comodel_name].with_context(**self.context)
        cr = model.env.cr

        # determine old and new relation {x: ys}
        set = OrderedSet
        ids = set(rid for recs, cs in records_commands_list for rid in recs.ids)
        records = model.browse(ids)

        if self.store:
            # Using `record[self.name]` generates 2 SQL queries when the value
            # is not in cache: one that actually checks access rules for
            # records, and the other one fetching the actual data. We use
            # `self.read` instead to shortcut the first query.
            missing_ids = list(records.env.cache.get_missing_ids(records, self))
            if missing_ids:
                self.read(records.browse(missing_ids))

        # determine new relation {x: ys}
        old_relation = {record.id: set(record[self.name]._ids) for record in records}
        new_relation = {x: set(ys) for x, ys in old_relation.items()}
```

The **old_relation** field will be populated with all the taxes, not taken into account the current company.
So later on it will remove them.