### PR TITLE
[13.0][FIX]base_exception: do not fail if no description

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -242,7 +242,7 @@ class BaseExceptionModel(models.AbstractModel):
                                 html.escape,
                                 (
                                     e.name,
-                                    e.description,
+                                    e.description if e.description else "",
                                     _("(Blocking exception)") if e.is_blocking else "",
                                 ),
                             )

--- a/letsencrypt/__manifest__.py
+++ b/letsencrypt/__manifest__.py
@@ -18,6 +18,6 @@
     "post_init_hook": "post_init_hook",
     "installable": True,
     "external_dependencies": {
-        "python": ["acme", "cryptography", "dnspython", "josepy"]
+        "python": ["acme", "cryptography", "dnspython", "josepy", "pyOpenSSL<23"]
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ josepy
 lxml
 openpyxl
 pygount
+pyOpenSSL<23
 pysftp
 raven
 xlrd


### PR DESCRIPTION
As the description is not a required field, we can have exception rules with no description and then the compute will fail.

cc @ForgeFlow