### PR TITLE
[14.0][FIX] configuration_helper after change in odoo core

### DIFF
--- a/configuration_helper/models/config.py
+++ b/configuration_helper/models/config.py
@@ -40,7 +40,7 @@ class AbstractConfigSettings(models.AbstractModel):
             kwargs["related"] = "company_id." + field_key
             kwargs["readonly"] = False
             field_key = re.sub("^" + self._prefix, "", field_key)
-            self._add_field(field_key, field.new(**kwargs))
+            self._add_field(field_key, type(field)(**kwargs))
         cls._proper_fields = set(cls._fields)
 
         self._add_inherited_fields()


### PR DESCRIPTION
The `new` function was removed from the fields.py implementation from this commit:

* https://github.com/odoo/odoo/commit/a08b2bac0b2e8e3e560668302e58caea65ea7d28