### PR TITLE
[FIX] sentry: downgrade sentry-sdk to compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ odoorpc
 openpyxl
 openupgradelib
 pysftp
-sentry_sdk>=1.17.0
+sentry_sdk<=1.9.0
 unidecode

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk>=1.17.0",
+            "sentry_sdk<=1.9.0",
         ]
     },
     "depends": [

--- a/sentry/const.py
+++ b/sentry/const.py
@@ -77,9 +77,7 @@ def get_sentry_options():
         SentryOption("dsn", "", str.strip),
         SentryOption("transport", DEFAULT_OPTIONS["transport"], select_transport),
         SentryOption("logging_level", DEFAULT_LOG_LEVEL, get_sentry_logging),
-        SentryOption(
-            "include_local_variables", DEFAULT_OPTIONS["include_local_variables"], None
-        ),
+        SentryOption("with_locals", DEFAULT_OPTIONS["with_locals"], None),
         SentryOption(
             "max_breadcrumbs", DEFAULT_OPTIONS["max_breadcrumbs"], to_int_if_defined
         ),


### PR DESCRIPTION
Odoo requires urllib3 between 1.21.1 and 1.25.
https://github.com/odoo/odoo/blob/6ef080a4818dd0bb85aa4ef257900522d9e9fbd6/requirements.txt#L51
https://github.com/psf/requests/blob/5a1e738ea9c399c3f59977f2f98b083986d6037a/setup.py#L47

sentry-sdk > 1.9.0 required urllib3 >= 1.26.11
https://github.com/getsentry/sentry-python/blob/4f1f782fbedc9adcf1dfcd2092bb328443f09e8c/setup.py#L43

Currently, urllib3 >= 1.26.11 is causing the following error in
response.py:

``` Traceback (most recent call last):
"/home/odoo/.local/lib/python3.8/site-packages/urllib3/response.py",
line 705, in _error_catcher
    yield
  File
"/home/odoo/.local/lib/python3.8/site-packages/urllib3/response.py",
line 830, in _raw_read
    raise IncompleteRead(self._fp_bytes_read, self.length_remaining)
urllib3.exceptions.IncompleteRead: IncompleteRead(1501 bytes read, -827
more expected)
```

On the other hand, sentry 1.9.0 supports urllib3 >= 1.10.0, satisfying
odoo requirements.

This partially reverts
https://github.com/OCA/server-tools/commit/d7ae024951d30b9409104d0bf294f8e1cf05064f.
That was initially introduced to support newer versions of `sentry_sdk`, but won't be required anymore
due to this downgrade.