### PR TITLE
[13.0][FIX] auditlog: autovacuum performance

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -16,7 +16,9 @@ class AuditlogHTTPRequest(models.Model):
     name = fields.Char("Path")
     root_url = fields.Char("Root URL")
     user_id = fields.Many2one("res.users", string="User")
-    http_session_id = fields.Many2one("auditlog.http.session", string="Session")
+    http_session_id = fields.Many2one(
+        "auditlog.http.session", string="Session", index=True
+    )
     user_context = fields.Char("Context")
     log_ids = fields.One2many("auditlog.log", "http_request_id", string="Logs")
 

--- a/auditlog/models/log.py
+++ b/auditlog/models/log.py
@@ -14,8 +14,12 @@ class AuditlogLog(models.Model):
     user_id = fields.Many2one("res.users", string="User")
     method = fields.Char(size=64)
     line_ids = fields.One2many("auditlog.log.line", "log_id", string="Fields updated")
-    http_session_id = fields.Many2one("auditlog.http.session", string="Session")
-    http_request_id = fields.Many2one("auditlog.http.request", string="HTTP Request")
+    http_session_id = fields.Many2one(
+        "auditlog.http.session", string="Session", index=True
+    )
+    http_request_id = fields.Many2one(
+        "auditlog.http.request", string="HTTP Request", index=True
+    )
     log_type = fields.Selection(
         [("full", "Full log"), ("fast", "Fast log")], string="Type"
     )


### PR DESCRIPTION
Add database indices on the foreign key fields of the auditlog models.
Without these indices, the performance of the autovacuum cron are terrible
because the "ON DELETE SET NULL" trigger has to make a full table scan
on the auditlog_log and auditlog_log_line tables when
auditlog_http_session and auditlog_http_request rows are deleted.

Same as: https://github.com/OCA/server-tools/pull/2445