### PR TITLE
[14.0][FIX] database_cleanup: preserve spaces in quoted identifiers

### DIFF
--- a/database_cleanup/identifier_adapter.py
+++ b/database_cleanup/identifier_adapter.py
@@ -14,7 +14,7 @@ class IdentifierAdapter(ISQLQuote):
 
     def getquoted(self):
         def is_identifier_char(c):
-            return c.isalnum() or c in ["_", "$"]
+            return c.isalnum() or c in (["_", "$", " "] if self.quote else ["_", "$"])
 
         format_string = '"%s"'
         if not self.quote:

--- a/database_cleanup/tests/__init__.py
+++ b/database_cleanup/tests/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import common
 from . import test_create_indexes
+from . import test_identifier_adapter
 from . import test_purge_columns
 from . import test_purge_data
 from . import test_purge_menus

--- a/database_cleanup/tests/test_identifier_adapter.py
+++ b/database_cleanup/tests/test_identifier_adapter.py
@@ -1,0 +1,18 @@
+from odoo.tests import TransactionCase
+
+from odoo.addons.database_cleanup.identifier_adapter import IdentifierAdapter
+
+
+class TestIdentifierAdapter(TransactionCase):
+    def test_column_name_with_spaces(self):
+        """Spaces in column names are preserved except in unquoted identifiers."""
+        self.assertEqual(
+            self.env.cr.mogrify("%s", (IdentifierAdapter("snailmail_cover "),)),
+            b'"snailmail_cover "',
+        )
+        self.assertEqual(
+            self.env.cr.mogrify(
+                "%s", (IdentifierAdapter("snailmail_cover ", quote=False),)
+            ),
+            b"snailmail_cover",
+        )


### PR DESCRIPTION
Meant to drop a column with a trailing space in its name that was created by accident, but database_cleanup dropped the column by the same name without the trailing space.