### PR TITLE
[16.0][FIX] attachment_queue: adapt tests to fixed trap jobs helper

### DIFF
--- a/attachment_queue/tests/test_attachment_queue.py
+++ b/attachment_queue/tests/test_attachment_queue.py
@@ -52,9 +52,9 @@ class TestAttachmentBaseQueue(TransactionCase):
 
     def test_job_created(self):
         with trap_jobs() as trap:
-            self._create_dummy_attachment()
+            attachment = self._create_dummy_attachment()
             trap.assert_enqueued_job(
-                self.env["attachment.queue"].run_as_job,
+                attachment.run_as_job,
             )
 
     def test_aq_locked_job(self):

--- a/attachment_queue/tests/test_attachment_queue.py
+++ b/attachment_queue/tests/test_attachment_queue.py
@@ -7,6 +7,7 @@ from odoo_test_helper import FakeModelLoader
 from odoo import registry
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 from odoo.addons.queue_job.exception import RetryableJobError
 from odoo.addons.queue_job.tests.common import trap_jobs
@@ -70,7 +71,7 @@ class TestAttachmentBaseQueue(TransactionCase):
             """,
                 (attachment.id,),
             )
-            with self.assertRaises(RetryableJobError):
+            with self.assertRaises(RetryableJobError), mute_logger("odoo.sql_db"):
                 attachment.run_as_job()
 
     def test_aq_locked_button(self):
@@ -87,7 +88,7 @@ class TestAttachmentBaseQueue(TransactionCase):
             """,
                 (attachment.id,),
             )
-            with self.assertRaises(UserError):
+            with self.assertRaises(UserError), mute_logger("odoo.sql_db"):
                 attachment.button_manual_run()
 
     def test_run_ok(self):


### PR DESCRIPTION
See https://github.com/OCA/queue/pull/542

Fixes
```
 2023-06-05 11:46:37,371 253 ERROR odoo odoo.addons.attachment_queue.tests.test_attachment_queue: FAIL: TestAttachmentBaseQueue.test_job_created
Traceback (most recent call last):
  File "/__w/server-tools/server-tools/attachment_queue/tests/test_attachment_queue.py", line 56, in test_job_created
    trap.assert_enqueued_job(
  File "/opt/odoo-venv/lib/python3.10/site-packages/odoo/addons/queue_job/tests/common.py", line 212, in assert_enqueued_job
    raise AssertionError(
AssertionError: Job <attachment.queue()>.run_as_job() with properties () was not enqueued.
Actual enqueued jobs:
 * <attachment.queue(2,)>.run_as_job() with properties ()
 ```