### PR TITLE
[14.0][FIX] letsencrypt: PYOpenSSL 23.2.0 rejects invalid X509 version 2 set by acme

### DIFF
--- a/letsencrypt/__manifest__.py
+++ b/letsencrypt/__manifest__.py
@@ -18,6 +18,6 @@
     "post_init_hook": "post_init_hook",
     "installable": True,
     "external_dependencies": {
-        "python": ["acme", "cryptography", "dnspython", "josepy"]
+        "python": ["acme", "cryptography<23.2.0", "dnspython", "josepy"]
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # generated from manifests external_dependencies
 acme
 astor
-cryptography
+cryptography<23.2.0
 dataclasses
 dnspython
 josepy


### PR DESCRIPTION
See https://github.com/pyca/pyopenssl/commit/f4f77cc4f

Fixes
```
2023-06-05 17:06:06,409 870 ERROR odoo odoo.addons.letsencrypt.tests.test_letsencrypt: ERROR: TestLetsencrypt.test_prefer_dns_setting
Traceback (most recent call last):
  File "/__w/server-tools/server-tools/letsencrypt/tests/test_letsencrypt.py", line 140, in test_prefer_dns_setting
    self.test_dns_challenge()
  File "/opt/odoo-venv/lib/python3.6/site-packages/mock/mock.py", line 1423, in patched
    return func(*newargs, **newkeywargs)
  File "/__w/server-tools/server-tools/letsencrypt/tests/test_letsencrypt.py", line 119, in test_dns_challenge
    self.env["letsencrypt"]._cron()
  File "/__w/server-tools/server-tools/letsencrypt/models/letsencrypt.py", line 90, in _cron
    authzr = self._get_authorization_resource(client, main_domain, domains)
  File "/__w/server-tools/server-tools/letsencrypt/models/letsencrypt.py", line 260, in _get_authorization_resource
    csr = acme.crypto_util.make_csr(private_key_pem=domain_key, domains=domains)
  File "/opt/odoo-venv/lib/python3.6/site-packages/acme/crypto_util.py", line 252, in make_csr
    csr.set_version(2)
  File "/opt/odoo-venv/lib/python3.6/site-packages/OpenSSL/crypto.py", line 1017, in set_version
    "Invalid version. The only valid version for X509Req is 0."
ValueError: Invalid version. The only valid version for X509Req is 0.
```
