### PR TITLE
[15.0][FIX] *: remove lxml, cryptography from python depends

### DIFF
--- a/html_image_url_extractor/__manifest__.py
+++ b/html_image_url_extractor/__manifest__.py
@@ -12,6 +12,5 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "external_dependencies": {"python": ["lxml"]},
     "depends": ["base"],
 }

--- a/html_text/__manifest__.py
+++ b/html_text/__manifest__.py
@@ -14,6 +14,5 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "external_dependencies": {"python": ["lxml"]},
     "depends": ["base"],
 }

--- a/letsencrypt/__manifest__.py
+++ b/letsencrypt/__manifest__.py
@@ -17,7 +17,5 @@
     "demo": ["demo/ir_cron.xml"],
     "post_init_hook": "post_init_hook",
     "installable": True,
-    "external_dependencies": {
-        "python": ["acme<2.0.0", "cryptography", "dnspython", "josepy"]
-    },
+    "external_dependencies": {"python": ["acme<2.0.0", "dnspython", "josepy"]},
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cryptography==2.6.1
 dataclasses
 dnspython
 josepy
-lxml
 mako
 odoorpc
 openpyxl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # generated from manifests external_dependencies
 acme<2.0.0
 astor
-cryptography
 cryptography==2.6.1
 dataclasses
 dnspython


### PR DESCRIPTION
Such dependency is already included in Odoo requirements using a pinned
version [1][2]. Adding here could cause to upgrade the library to an
incompatible version.

[1] https://github.com/odoo/odoo/blob/710a2b2a7af68e8f2f249ef9fc3146f44d3266a5/requirements.txt#L18
[2] https://github.com/odoo/odoo/blob/710a2b2a7af68e8f2f249ef9fc3146f44d3266a5/requirements.txt#L3