### PR TITLE
[14.0] sentry: add optin to not send  startup event to Sentry

### DIFF
--- a/sentry/README.rst
+++ b/sentry/README.rst
@@ -53,49 +53,54 @@ Configuration
 The following additional configuration options can be added to your Odoo
 configuration file:
 
-=============================  ====================================================================  ==========================================================
+===============================  ====================================================================  ==========================================================
         Option                                          Description                                                         Default
-=============================  ====================================================================  ==========================================================
-``sentry_dsn``                 Sentry *Data Source Name*. You can find this value in your Sentry     ``''``
-                               project configuration. Typically it looks something like this:
-                               *https://<public_key>:<secret_key>@sentry.example.com/<project id>*
-                               This is the only required option in order to use the module.
+===============================  ====================================================================  ==========================================================
+``sentry_dsn``                   Sentry *Data Source Name*. You can find this value in your Sentry     ``''``
+                                 project configuration. Typically it looks something like this:
+                                 *https://<public_key>:<secret_key>@sentry.example.com/<project id>*
+                                 This is the only required option in order to use the module.
 
-``sentry_enabled``             Whether or not Sentry logging is enabled.                             ``False``
+``sentry_enabled``               Whether or not Sentry logging is enabled.                             ``False``
 
-``sentry_logging_level``       The minimal logging level for which to send reports to Sentry.        ``warn``
-                               Possible values: *notset*, *debug*, *info*, *warn*, *error*,
-                               *critical*. It is recommended to have this set to at least *warn*,
-                               to avoid spamming yourself with Sentry events.
+``sentry_ignore_startup_event``  This is used to not send the `Starting Odoo Server` to Sentry.        ``False``
+                                 While this messages is usefull to ensure we have properly setup
+                                 sentry. We can't use `sentry_ignored_exceptions` to ignore that
+                                 event.
 
-``sentry_exclude_loggers``     A string of comma-separated logger names which should be excluded     ``werkzeug``
-                               from Sentry.
+``sentry_logging_level``         The minimal logging level for which to send reports to Sentry.        ``warn``
+                                 Possible values: *notset*, *debug*, *info*, *warn*, *error*,
+                                 *critical*. It is recommended to have this set to at least *warn*,
+                                 to avoid spamming yourself with Sentry events.
 
-``sentry_ignored_exceptions``  A string of comma-separated exceptions which should be ignored.       ``odoo.exceptions.AccessDenied,
-                               You can use a star symbol (*) at the end, to ignore all exceptions    odoo.exceptions.AccessError,
-                               from a module, eg.: *odoo.exceptions.**.                              odoo.exceptions.DeferredException,
-                                                                                                     odoo.exceptions.MissingError,
-                                                                                                     odoo.exceptions.RedirectWarning,
-                                                                                                     odoo.exceptions.UserError,
-                                                                                                     odoo.exceptions.ValidationError,
-                                                                                                     odoo.exceptions.Warning,
-                                                                                                     odoo.exceptions.except_orm``
+``sentry_exclude_loggers``       A string of comma-separated logger names which should be excluded     ``werkzeug``
+                                 from Sentry.
 
-``sentry_include_context``     If enabled, additional context data will be extracted from current    ``True``
-                               HTTP request and user session (if available). This has no effect
-                               for Cron jobs, as no request/session is available inside a Cron job.
+``sentry_ignored_exceptions``    A string of comma-separated exceptions which should be ignored.       ``odoo.exceptions.AccessDenied,
+                                 You can use a star symbol (*) at the end, to ignore all exceptions    odoo.exceptions.AccessError,
+                                 from a module, eg.: *odoo.exceptions.**.                              odoo.exceptions.DeferredException,
+                                                                                                       odoo.exceptions.MissingError,
+                                                                                                       odoo.exceptions.RedirectWarning,
+                                                                                                       odoo.exceptions.UserError,
+                                                                                                       odoo.exceptions.ValidationError,
+                                                                                                       odoo.exceptions.Warning,
+                                                                                                       odoo.exceptions.except_orm``
 
-``sentry_release``             Explicitly define a version to be sent as the release version to
-                               Sentry. Useful in conjuntion with Sentry's "Resolve in the next
-                               release"-functionality. Also useful if your production deployment
-                               does not include any Git context from which a commit might be read.
-                               Overrides *sentry_odoo_dir*.
+``sentry_include_context``       If enabled, additional context data will be extracted from current    ``True``
+                                 HTTP request and user session (if available). This has no effect
+                                 for Cron jobs, as no request/session is available inside a Cron job.
 
-``sentry_odoo_dir``            Absolute path to your Odoo installation directory. This is optional
-                               and will only be used to extract the Odoo Git commit, which will be
-                               sent to Sentry, to allow to distinguish between Odoo updates.
-                               Overridden by *sentry_release*
-=============================  ====================================================================  ==========================================================
+``sentry_release``               Explicitly define a version to be sent as the release version to
+                                 Sentry. Useful in conjuntion with Sentry's "Resolve in the next
+                                 release"-functionality. Also useful if your production deployment
+                                 does not include any Git context from which a commit might be read.
+                                 Overrides *sentry_odoo_dir*.
+
+``sentry_odoo_dir``              Absolute path to your Odoo installation directory. This is optional
+                                 and will only be used to extract the Odoo Git commit, which will be
+                                 sent to Sentry, to allow to distinguish between Odoo updates.
+                                 Overridden by *sentry_release*
+===============================  ====================================================================  ==========================================================
 
 Other `client arguments
 <https://docs.sentry.io/platforms/python/configuration/>`_ can be

--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -124,10 +124,10 @@ def initialize_sentry(config):
 
     # Patch the wsgi server in case of further registration
     wsgi_server.application = SentryWsgiMiddleware(wsgi_server.application)
-
-    with sentry_sdk.push_scope() as scope:
-        scope.set_extra("debug", False)
-        sentry_sdk.capture_message("Starting Odoo Server", "info")
+    if not config.get("sentry_ignore_startup_event", False):
+        with sentry_sdk.push_scope() as scope:
+            scope.set_extra("debug", False)
+            sentry_sdk.capture_message("Starting Odoo Server", "info")
 
     return client
 

--- a/sentry/readme/CONFIGURE.rst
+++ b/sentry/readme/CONFIGURE.rst
@@ -1,49 +1,54 @@
 The following additional configuration options can be added to your Odoo
 configuration file:
 
-=============================  ====================================================================  ==========================================================
+===============================  ====================================================================  ==========================================================
         Option                                          Description                                                         Default
-=============================  ====================================================================  ==========================================================
-``sentry_dsn``                 Sentry *Data Source Name*. You can find this value in your Sentry     ``''``
-                               project configuration. Typically it looks something like this:
-                               *https://<public_key>:<secret_key>@sentry.example.com/<project id>*
-                               This is the only required option in order to use the module.
+===============================  ====================================================================  ==========================================================
+``sentry_dsn``                   Sentry *Data Source Name*. You can find this value in your Sentry     ``''``
+                                 project configuration. Typically it looks something like this:
+                                 *https://<public_key>:<secret_key>@sentry.example.com/<project id>*
+                                 This is the only required option in order to use the module.
 
-``sentry_enabled``             Whether or not Sentry logging is enabled.                             ``False``
+``sentry_enabled``               Whether or not Sentry logging is enabled.                             ``False``
 
-``sentry_logging_level``       The minimal logging level for which to send reports to Sentry.        ``warn``
-                               Possible values: *notset*, *debug*, *info*, *warn*, *error*,
-                               *critical*. It is recommended to have this set to at least *warn*,
-                               to avoid spamming yourself with Sentry events.
+``sentry_ignore_startup_event``  This is used to not send the `Starting Odoo Server` to Sentry.        ``False``
+                                 While this messages is usefull to ensure we have properly setup
+                                 sentry. We can't use `sentry_ignored_exceptions` to ignore that
+                                 event.
 
-``sentry_exclude_loggers``     A string of comma-separated logger names which should be excluded     ``werkzeug``
-                               from Sentry.
+``sentry_logging_level``         The minimal logging level for which to send reports to Sentry.        ``warn``
+                                 Possible values: *notset*, *debug*, *info*, *warn*, *error*,
+                                 *critical*. It is recommended to have this set to at least *warn*,
+                                 to avoid spamming yourself with Sentry events.
 
-``sentry_ignored_exceptions``  A string of comma-separated exceptions which should be ignored.       ``odoo.exceptions.AccessDenied,
-                               You can use a star symbol (*) at the end, to ignore all exceptions    odoo.exceptions.AccessError,
-                               from a module, eg.: *odoo.exceptions.**.                              odoo.exceptions.DeferredException,
-                                                                                                     odoo.exceptions.MissingError,
-                                                                                                     odoo.exceptions.RedirectWarning,
-                                                                                                     odoo.exceptions.UserError,
-                                                                                                     odoo.exceptions.ValidationError,
-                                                                                                     odoo.exceptions.Warning,
-                                                                                                     odoo.exceptions.except_orm``
+``sentry_exclude_loggers``       A string of comma-separated logger names which should be excluded     ``werkzeug``
+                                 from Sentry.
 
-``sentry_include_context``     If enabled, additional context data will be extracted from current    ``True``
-                               HTTP request and user session (if available). This has no effect
-                               for Cron jobs, as no request/session is available inside a Cron job.
+``sentry_ignored_exceptions``    A string of comma-separated exceptions which should be ignored.       ``odoo.exceptions.AccessDenied,
+                                 You can use a star symbol (*) at the end, to ignore all exceptions    odoo.exceptions.AccessError,
+                                 from a module, eg.: *odoo.exceptions.**.                              odoo.exceptions.DeferredException,
+                                                                                                       odoo.exceptions.MissingError,
+                                                                                                       odoo.exceptions.RedirectWarning,
+                                                                                                       odoo.exceptions.UserError,
+                                                                                                       odoo.exceptions.ValidationError,
+                                                                                                       odoo.exceptions.Warning,
+                                                                                                       odoo.exceptions.except_orm``
 
-``sentry_release``             Explicitly define a version to be sent as the release version to
-                               Sentry. Useful in conjuntion with Sentry's "Resolve in the next
-                               release"-functionality. Also useful if your production deployment
-                               does not include any Git context from which a commit might be read.
-                               Overrides *sentry_odoo_dir*.
+``sentry_include_context``       If enabled, additional context data will be extracted from current    ``True``
+                                 HTTP request and user session (if available). This has no effect
+                                 for Cron jobs, as no request/session is available inside a Cron job.
 
-``sentry_odoo_dir``            Absolute path to your Odoo installation directory. This is optional
-                               and will only be used to extract the Odoo Git commit, which will be
-                               sent to Sentry, to allow to distinguish between Odoo updates.
-                               Overridden by *sentry_release*
-=============================  ====================================================================  ==========================================================
+``sentry_release``               Explicitly define a version to be sent as the release version to
+                                 Sentry. Useful in conjuntion with Sentry's "Resolve in the next
+                                 release"-functionality. Also useful if your production deployment
+                                 does not include any Git context from which a commit might be read.
+                                 Overrides *sentry_odoo_dir*.
+
+``sentry_odoo_dir``              Absolute path to your Odoo installation directory. This is optional
+                                 and will only be used to extract the Odoo Git commit, which will be
+                                 sent to Sentry, to allow to distinguish between Odoo updates.
+                                 Overridden by *sentry_release*
+===============================  ====================================================================  ==========================================================
 
 Other `client arguments
 <https://docs.sentry.io/platforms/python/configuration/>`_ can be


### PR DESCRIPTION
On odoo saas platform event has cost. So ignoring odoo starting as signifiant effect on platform likes odoo.sh where cron workers start before each calls or where worker restarts.