### PR TITLE
[14.0][ADD] base_future_response

### DIFF
--- a/base_future_response/__init__.py
+++ b/base_future_response/__init__.py
@@ -1,0 +1,1 @@
+from . import future_response

--- a/base_future_response/__manifest__.py
+++ b/base_future_response/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 ACSONE SA/NV
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "Future Response",
+    "summary": """
+        Backport Odoo 16 FutureReponse mechanism.""",
+    "version": "14.0.1.0.0",
+    "license": "LGPL-3",
+    "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
+    "maintainers": ["sbidoul"],
+    "website": "https://github.com/OCA/server-tools",
+}

--- a/base_future_response/future_response.py
+++ b/base_future_response/future_response.py
@@ -49,16 +49,15 @@ class FutureResponse:
         )
 
 
-_original_get_request = http.root.__class__.get_request
+_original_WebRequest_init = http.WebRequest.__init__
 
 
-def get_request(self, httprequest):
-    request = _original_get_request(self, httprequest)
-    request.future_response = FutureResponse()
-    return request
+def WebRequest_init(self, httprequest):
+    _original_WebRequest_init(self, httprequest)
+    self.future_response = FutureResponse()
 
 
-http.root.__class__.get_request = get_request
+http.WebRequest.__init__ = WebRequest_init
 
 
 _original_get_response = http.root.__class__.get_response

--- a/base_future_response/future_response.py
+++ b/base_future_response/future_response.py
@@ -1,0 +1,74 @@
+# Copyright 2021 ACSONE SA/NV
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import functools
+
+import werkzeug
+from werkzeug.wrappers import Response
+
+from odoo import http
+
+
+class FutureResponse:
+    """
+    werkzeug.Response mock class that only serves as placeholder for
+    headers to be injected in the final response.
+    """
+
+    # used by werkzeug.Response.set_cookie
+    charset = "utf-8"
+    max_cookie_size = 4093
+
+    def __init__(self):
+        self.headers = werkzeug.datastructures.Headers()
+
+    @functools.wraps(werkzeug.Response.set_cookie)
+    def set_cookie(
+        self,
+        key,
+        value="",
+        max_age=None,
+        expires=None,
+        path="/",
+        domain=None,
+        secure=False,
+        httponly=False,
+        samesite=None,
+    ):
+        werkzeug.Response.set_cookie(
+            self,
+            key,
+            value=value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
+        )
+
+
+_original_get_request = http.root.__class__.get_request
+
+
+def get_request(self, httprequest):
+    request = _original_get_request(self, httprequest)
+    request.future_response = FutureResponse()
+    return request
+
+
+http.root.__class__.get_request = get_request
+
+
+_original_get_response = http.root.__class__.get_response
+
+
+def get_response(self, httprequest, result, explicit_session):
+    response = _original_get_response(self, httprequest, result, explicit_session)
+    if isinstance(response, Response):
+        response.headers.extend(http.request.future_response.headers)
+    return response
+
+
+http.root.__class__.get_response = get_response

--- a/base_future_response/readme/DESCRIPTION.rst
+++ b/base_future_response/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This is a backport of Odoo 16 ``request.future_response`` mechanism, to allow
+setting cookies in the response before the response is constructed.

--- a/base_future_response/readme/ROADMAP.rst
+++ b/base_future_response/readme/ROADMAP.rst
@@ -1,0 +1,4 @@
+This module monkey patches the request object as soon as it is imported. The patch is
+not reverted when the module is uninstalled. It should be totally harmless though, since
+it simply adds a ``future_response`` attribute to the request object, and does not
+change the response if cookies or headers are added to future_response.

--- a/setup/base_future_response/odoo/addons/base_future_response
+++ b/setup/base_future_response/odoo/addons/base_future_response
@@ -1,0 +1,1 @@
+../../../../base_future_response

--- a/setup/base_future_response/setup.py
+++ b/setup/base_future_response/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This is a backport of Odoo 16 `request.future_response` mechanism, to allow
setting cookies in the response before the response object is constructed.