### PR TITLE
[15.0][FIX]database_cleanup: endless loop

### DIFF
--- a/database_cleanup/models/purge_tables.py
+++ b/database_cleanup/models/purge_tables.py
@@ -63,13 +63,19 @@ class CleanupPurgeLineTable(models.TransientModel):
                         constraint[0],
                         constraint[3],
                     )
-                    self.env.cr.execute(
-                        "ALTER TABLE %s DROP CONSTRAINT %s",
-                        (
-                            IdentifierAdapter(constraint[3]),
-                            IdentifierAdapter(constraint[0]),
-                        ),
+                else:
+                    self.logger.info(
+                        "Dropping constraint %s on table %s (not to be dropped)",
+                        constraint[0],
+                        constraint[3],
                     )
+                self.env.cr.execute(
+                    "ALTER TABLE %s DROP CONSTRAINT %s",
+                    (
+                        IdentifierAdapter(constraint[3]),
+                        IdentifierAdapter(constraint[0]),
+                    ),
+                )
 
             self.logger.info("Dropping table %s", line.name)
             self.env.cr.execute("DROP TABLE %s", (IdentifierAdapter(line.name),))


### PR DESCRIPTION
We have some cases where database_cleanup loop endlessly because of referential integrity. 

In my case, the issue was caused by tables having foreign keys on tables which are not in the list of tables to delete. Updating the code to drop all constraints, even on tables which are not meant to be dropped, seems to solve the issue 

___
[OUTDATED]
_Here for example, DROP TABLE is failing because some tables have foreign keys on a studio table, and the error message suggest using DROP TABLE ... CASCADE, which seems indeed to fix the problem._
```
        Start purging tables attempt n° 158
        Try to purge table: transport_vehicle
2023-07-20 07:50:32,502 347 ERROR test_error odoo.sql_db: bad query: DROP TABLE "transport_vehicle"
ERROR: cannot drop table transport_vehicle because other objects depend on it
DETAIL:  constraint x_journaux_x_studio_field_PE7Np_fkey on table x_journaux depends on table transport_vehicle
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 
        Try to purge table: transport_vehicle_type
2023-07-20 07:50:32,513 347 ERROR test_error odoo.sql_db: bad query: DROP TABLE "transport_vehicle_type"
ERROR: cannot drop table transport_vehicle_type because other objects depend on it
DETAIL:  constraint transport_vehicle_vehicle_type_id_fkey on table transport_vehicle depends on table transport_vehicle_type
constraint x_journaux_x_studio_field_mHvR3_fkey on table x_journaux depends on table transport_vehicle_type
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
```

_First introduced by https://github.com/damdam-s/server-tools/pull/1 in https://github.com/OCA/server-tools/pull/2219_

_But lost when this PR has been superseded by https://github.com/OCA/server-tools/pull/2547_