### PR TITLE
[14.0][FIX] base_multi_image: adjust sudo to see images

### DIFF
--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -106,7 +106,7 @@ class Image(models.Model):
         )
 
     def _get_image_from_filestore(self):
-        return self.attachment_id.datas
+        return self.sudo().attachment_id.datas
 
     def _get_image_from_db(self):
         return self.file_db_store


### PR DESCRIPTION
There are some cases that the user don't have settings permission that they couldn't open products due to the fact that if the image of product is not added by this user, odoo returns an error that it does not be allowed to access to the product due to the image

without changes:
![image](https://github.com/OCA/server-tools/assets/77978942/31e3aabc-d39a-4ba6-b8df-ebc45ef158e9)
with changes:
![image](https://github.com/OCA/server-tools/assets/77978942/8f2dd1e6-30fe-41f2-8d4b-f02bd3cde22f)
