### PR TITLE
[16.0][FIX] sentry: Prevent capturing ignored exceptions

### DIFF
--- a/sentry/readme/CONTRIBUTORS.rst
+++ b/sentry/readme/CONTRIBUTORS.rst
@@ -3,3 +3,5 @@
 * Naglis Jonaitis <naglis@versada.eu>
 * Atte Isopuro <atte.isopuro@avoin.systems>
 * Florian Mounier <florian.mounier@akretion.com>
+* Jon Ashton <jon@monkeyinferno.com>
+* Mark Schuit <mark@gig.solutions>


### PR DESCRIPTION
With this change, any exceptions that are in the DEFAULT_IGNORE_LIST will not be captured by Sentry.