### PR TITLE
[IMP] auditlog/models/rule.py: Add condition to skip logging if no fields changed in write method

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -516,10 +516,16 @@ class AuditlogRule(models.Model):
                 "http_session_id": http_session_model.current_http_session(),
             }
             vals.update(additional_log_values or {})
-            log = log_model.create(vals)
+
             diff = DictDiffer(
                 new_values.get(res_id, EMPTY_DICT), old_values.get(res_id, EMPTY_DICT)
             )
+            changed_fields = diff.changed() - set(FIELDS_BLACKLIST)
+            if not changed_fields and method == "write":
+                continue
+
+            log = log_model.create(vals)
+
             if method == "create":
                 self._create_log_line_on_create(
                     log, diff.added(), new_values, fields_to_exclude


### PR DESCRIPTION
Add a condition to check if any fields have changed before creating a log entry for the "write" method. This improves performance and reduces unnecessary log entries.