### PR TITLE
[16.0][FIX] session_db: missing argument max_lifetime in PGSessionStore.vacuum()

### DIFF
--- a/session_db/pg_session_store.py
+++ b/session_db/pg_session_store.py
@@ -142,11 +142,11 @@ class PGSessionStore(sessions.SessionStore):
 
     @with_lock
     @with_cursor
-    def vacuum(self):
+    def vacuum(self, max_lifetime=http.SESSION_LIFETIME):
         self._cr.execute(
             "DELETE FROM http_sessions "
             "WHERE now() at time zone 'UTC' - write_date > %s",
-            (f"{http.SESSION_LIFETIME} seconds",),
+            (f"{max_lifetime} seconds",),
         )
 
 


### PR DESCRIPTION
Fixes the issue "PGSessionStore.vacuum() got an unexpected keyword argument 'max_lifetime'" when autovacuum gets executed.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>
