### PR TITLE
[13.0][IMP]base_exception: skip check if context is passed

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -281,6 +281,8 @@ class BaseExceptionModel(models.AbstractModel):
             ...
             self._check_exception
         """
+        if self.env.context.get("ignore_check_exception", False):
+            return True
         exception_ids = self.detect_exceptions()
         if exception_ids:
             exceptions = self.env["exception.rule"].browse(exception_ids)


### PR DESCRIPTION
It can be useful for the cases where we want to skip the check validation if we are writing via code

cc @ForgeFlow