### PR TITLE
base_contextvars: pytest workaround

### DIFF
--- a/base_contextvars/contextvars_patch.py
+++ b/base_contextvars/contextvars_patch.py
@@ -15,8 +15,16 @@ _odoo_environments_ctx = ContextVar("odoo.environments", default=())
 
 @classproperty
 def contextvars_envs(_cls):
-    # Look in _local in case we use this while the non patched context manager is active
-    return _odoo_environments_ctx.get() or getattr(_cls._local, "environments", ())
+    envs = _odoo_environments_ctx.get()
+    if not envs:
+        # Look in _local in case we use this while the non patched context manager
+        # is active
+        envs = getattr(_cls._local, "environments", ())
+        if envs:
+            # is case that an envs exist set it to context manager
+            # This can occure with pytest
+            _odoo_environments_ctx.set(envs)
+    return envs
 
 
 @classmethod  # type: ignore


### PR DESCRIPTION
@sbidoul @lmignon When running test with pytest (on shopinvader_api_address for example). I had some issue with the contextvars env (the env is not found so everything crash).
It's seem that pytest do not support it correctly base_contextvars.
After some investigation I found this workaround.

Thanks for your feedback