### PR TITLE
[16][FIX] attachment_queue : fix empty job description

### DIFF
--- a/attachment_queue/models/attachment_queue.py
+++ b/attachment_queue/models/attachment_queue.py
@@ -96,9 +96,7 @@ class AttachmentQueue(models.Model):
             self.run()
 
     def run_as_job(self):
-        """
-        Run the process for an individual attachment queue from a async job
-        """
+        """Run the process for an individual attachment queue from a async job"""
         try:
             self._cr.execute(
                 """


### PR DESCRIPTION
@bealdav @kevinkhao @bguillot Easy one
The description of the job is currently empty because of the multi line job function description.
Here : https://github.com/OCA/queue/blob/16.0/queue_job/job.py#L744 The first line is an empty space.