### PR TITLE
[12.0][FIX] sentry: Patch odoo.service.server wsgi app

### DIFF
--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -5,6 +5,7 @@ import logging
 
 import odoo.http
 from odoo.service import wsgi_server
+from odoo.service.server import server
 from odoo.tools import config as odoo_config
 
 from . import const
@@ -100,6 +101,11 @@ def initialize_sentry(config):
         for item in exclude_loggers:
             ignore_logger(item)
 
+    # The server app is already registered so patch it here
+    if server:
+        server.app = SentryWsgiMiddleware(server.app)
+
+    # Patch the wsgi server in case of further registration
     wsgi_server.application = SentryWsgiMiddleware(wsgi_server.application)
 
     with sentry_sdk.push_scope() as scope:


### PR DESCRIPTION
Because post_load is called after odoo.service.server start
It has already registered the unpatched   odoo.service.wsgi_server.application
So patch it here too.
This enables wsgi performance reporting with sentry_traces_sample_rate

Cherry picking the fix by [paradoxxxzero](https://github.com/OCA/server-tools/commits?author=paradoxxxzero) from 14.0 to 12.0