### PR TITLE
[FIX] base_fontawesome: fixed replace files to show icons in website

### DIFF
--- a/base_fontawesome/__manifest__.py
+++ b/base_fontawesome/__manifest__.py
@@ -28,6 +28,10 @@
                 "web/static/src/libs/fontawesome/css/font-awesome.css",
                 "base_fontawesome/static/src/css/fontawesome.css",
             ),
+            "base_fontawesome/static/lib/fontawesome-5.15.4/css/all.css",
+            "base_fontawesome/static/lib/fontawesome-5.15.4/css/v4-shims.css",
+            "base_fontawesome/static/src/js/form_renderer.js",
+            "base_fontawesome/static/src/js/list_renderer.js",
         ],
         "web.report_assets_common": [
             (

--- a/base_fontawesome/static/lib/fontawesome-5.15.4/css/all.css
+++ b/base_fontawesome/static/lib/fontawesome-5.15.4/css/all.css
@@ -4612,5 +4612,5 @@ readers do not read off random characters that represent icons */
 
 .fa,
 .fas {
-  font-family: 'Font Awesome 5 Free';
+  font-family: 'Font Awesome 5 Free', 'Font Awesome 5 Brands' !important;
   font-weight: 900; }

--- a/base_fontawesome/static/src/css/fontawesome.css
+++ b/base_fontawesome/static/src/css/fontawesome.css
@@ -15,6 +15,23 @@
     font-style: normal;
     font-display: block;
 }
+@font-face {
+    font-family: "FontAwesomeBrands";
+    src: url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.eot");
+    src: url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.eot?#iefix&v=5.15.4")
+            format("embedded-opentype"),
+        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.woff2?v=5.15.4")
+            format("woff2"),
+        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.woff?v=5.15.4")
+            format("woff"),
+        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.ttf?v=5.15.4")
+            format("truetype"),
+        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.svg#fontawesome?v=5.15.4&fontawesomeregular")
+            format("svg");
+    font-weight: normal;
+    font-style: normal;
+    font-display: block;
+}
 
 .btn.fa,
 .btn.fas,


### PR DESCRIPTION
**Description:**
This pull request addresses an issue where icons were not displaying in the website module when the base_fontawesome module was installed. To reproduce the issue, follow these steps:

- Set up an Odoo environment running version 16.
- Install the base_fontawesome module.
- Install the website module.
- Access the website.
- Observe that the icons are not being displayed.

**Solution:**
To resolve this problem, we have made the following modifications:

- Updated the replace statement in the manifest file to load the custom CSS with the new version.
- Loaded the icon font of brands.
- Added the fa class to the corresponding font-family.

This should ensure that icons are displayed correctly in the Odoo website module when the base_fontawesome module is installed.

Original issue --> https://github.com/OCA/server-tools/issues/2694