### PR TITLE
[14.0][FIX] base_technical_user - Error message when no technical user

### DIFF
--- a/base_technical_user/models/models.py
+++ b/base_technical_user/models/models.py
@@ -30,7 +30,7 @@ class Base(models.AbstractModel):
         elif raise_if_missing:
             raise UserError(
                 _("The technical user is missing in the company {}").format(
-                    self.env.user.company_id.name
+                    self.env.company.name
                 )
             )
         return self_sudoer

--- a/base_technical_user/tests/test_sudo_tech.py
+++ b/base_technical_user/tests/test_sudo_tech.py
@@ -11,21 +11,28 @@ from odoo.tests import SavepointCase
 class SudoTechCase(SavepointCase):
     @classmethod
     def setUpClass(cls):
-        super(SudoTechCase, cls).setUpClass()
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.company_2 = cls.env["res.company"].create(
             {
                 "name": "Company 2 tech",
             }
         )
+        cls.company_3 = cls.env["res.company"].create(
+            {
+                "name": "Company 3 NO tech",
+                "user_tech_id": False,
+            }
+        )
         cls.user_tech = (
             cls.env["res.users"]
-            .with_context(tracking_disable=True, no_reset_password=True)
+            .with_context(no_reset_password=True)
             .create({"login": "tech", "name": "tech"})
         )
         cls.company = cls.env.ref("base.main_company")
         cls.user_tech_2 = (
             cls.env["res.users"]
-            .with_context(tracking_disable=True, no_reset_password=True)
+            .with_context(no_reset_password=True)
             .with_company(cls.company_2)
             .create({"login": "tech2", "name": "tech2", "company_id": cls.company_2.id})
         )
@@ -59,3 +66,16 @@ class SudoTechCase(SavepointCase):
         self.company_2.user_tech_id = self.user_tech_2
         self_tech = user.with_company(self.company_2).sudo_tech()
         self.assertEqual(self_tech._uid, self.user_tech_2.id)
+
+    def test_sudo_tech_company_3(self):
+        """
+        Ensure the error message is related to the
+        active company when there is no technical user.
+        """
+        user = self.env.user.with_company(self.company_3)
+        self.assertEqual(self.company_3, user.env.company)
+        self.assertNotEqual(user.env.company, user.company_id)
+        with self.assertRaises(UserError) as em:
+            user.sudo_tech(raise_if_missing=True)
+        self.assertIn(self.company_3.name, em.exception.args[0])
+        self.assertNotIn(user.company_id.name, em.exception.args[0])


### PR DESCRIPTION
When we use `record.use_tech(raise_if_missing=True)` and the technical user (`user_tech_id`) is not defined on the current company, the error message who said that field is empty should be related to the active company and not related to the default user's company.

Should be forward-ported to > `14.0`