### PR TITLE
[15.0][FIX] avoid m2m multi-company issue

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -385,6 +385,7 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
+            self.invalidate_cache(fields_list, self.ids)
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d


### PR DESCRIPTION

I add that line of code to invalidate the cache after calling the 'read' method with sudo, so that when the original 'write' method is called later, there are no data from another companies in the cache that the user executing the write does not have access to. Otherwise, this leads to a situation where, when executing a write to modify an M2M field, Odoo, before setting the new fields, will remove elements from another company to which I do not have access that have been set in that many-to-many field and because they are in cache because of the read calling with sudo.

