### PR TITLE
[13.0][IMP]base_exception: get Validation Error message in a hook

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -66,6 +66,11 @@ class ExceptionRule(models.Model):
         self.ensure_one()
         return safe_eval(self.domain)
 
+    def _get_validation_error_message(self):
+        if not self:
+            return ""
+        return "\n".join(self.mapped("name"))
+
 
 class BaseExceptionMethod(models.AbstractModel):
     _name = "base.exception.method"
@@ -284,4 +289,5 @@ class BaseExceptionModel(models.AbstractModel):
         exception_ids = self.detect_exceptions()
         if exception_ids:
             exceptions = self.env["exception.rule"].browse(exception_ids)
-            raise ValidationError("\n".join(exceptions.mapped("name")))
+            msg = exceptions._get_validation_error_message()
+            raise ValidationError(_(msg))


### PR DESCRIPTION
Minor change here, separate the Validation Error message procurement in a separate method to inherit in other modules.

cc @ForgeFlow