### PR TITLE
[16.0] [FIX] database_cleanup: override create in batch

### DIFF
--- a/database_cleanup/models/purge_wizard.py
+++ b/database_cleanup/models/purge_wizard.py
@@ -25,7 +25,7 @@ class CleanupPurgeLine(models.AbstractModel):
     def purge(self):
         raise NotImplementedError
 
-    @api.model
+    @api.model_create_multi
     def create(self, values):
         # make sure the user trying this is actually supposed to do it
         if self.env.ref("base.group_erp_manager") not in self.env.user.groups_id:
@@ -80,7 +80,7 @@ class PurgeWizard(models.AbstractModel):
     def name_get(self):
         return [(this.id, self._description) for this in self]
 
-    @api.model
+    @api.model_create_multi
     def create(self, values):
         # make sure the user trying this is actually supposed to do it
         if self.env.ref("base.group_erp_manager") not in self.env.user.groups_id:


### PR DESCRIPTION
This suppresses the following WARNING:

```
The model odoo.addons.database_cleanup.models.purge_wizard is not overriding the
create method in batch
```

Note: There's no need to forward port this change because it has already been taken care of in the `17.0` migration https://github.com/OCA/server-tools/commit/fbb5dc1fe7167d1904fd79d67e51ab74583b040f