### PR TITLE
[16.0][IMP] tracking_manager: allow tracking readonly fields

### DIFF
--- a/tracking_manager/migrations/16.0.1.0.3/post-migration.py
+++ b/tracking_manager/migrations/16.0.1.0.3/post-migration.py
@@ -1,0 +1,21 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_model_fields SET trackable = false;
+        UPDATE ir_model_fields SET trackable = true
+            WHERE name NOT IN (
+                'activity_ids',
+                'message_ids',
+                'message_last_post',
+                'message_main_attachment',
+                'message_main_attachement_id'
+            )
+            AND store AND related IS NULL;
+        """,
+    )

--- a/tracking_manager/models/ir_model.py
+++ b/tracking_manager/models/ir_model.py
@@ -100,21 +100,27 @@ class IrModel(models.Model):
     def _default_automatic_custom_tracking_domain_rules(self):
         return {
             "product.product": [
+                ("readonly", "=", False),
                 "|",
                 ("ttype", "!=", "one2many"),
                 ("name", "in", ["barcode_ids"]),
             ],
             "sale.order": [
+                ("readonly", "=", False),
                 "|",
                 ("ttype", "!=", "one2many"),
                 ("name", "in", ["order_line"]),
             ],
             "account.move": [
+                ("readonly", "=", False),
                 "|",
                 ("ttype", "!=", "one2many"),
                 ("name", "in", ["invoice_line_ids"]),
             ],
-            "default_automatic_rule": [("ttype", "!=", "one2many")],
+            "default_automatic_rule": [
+                ("ttype", "!=", "one2many"),
+                ("readonly", "=", False),
+            ],
         }
 
     @api.depends("automatic_custom_tracking")
@@ -176,7 +182,7 @@ class IrModelFields(models.Model):
         for record in self:
             record.native_tracking = bool(record.tracking)
 
-    @api.depends("readonly", "related", "store")
+    @api.depends("related", "store")
     def _compute_trackable(self):
         blacklists = [
             "activity_ids",
@@ -185,13 +191,9 @@ class IrModelFields(models.Model):
             "message_main_attachment",
             "message_main_attachement_id",
         ]
+
         for rec in self:
-            rec.trackable = (
-                rec.name not in blacklists
-                and rec.store
-                and not rec.readonly
-                and not rec.related
-            )
+            rec.trackable = rec.name not in blacklists and rec.store and not rec.related
 
     def write(self, vals):
         custom_tracking = None


### PR DESCRIPTION
@AnizR, @Kev-Roche, @sebastienbeau 

What is the reason for the limitation that read_only fields cannot be tracked? 
When there have a look at the Odoo native tracking, there are also read_only fields with tracking enabled:
![image](https://github.com/OCA/server-tools/assets/1799080/b1e173bb-e521-4b81-899a-8883300ff477)

In our case we what to track changes on an enterprise table account.asset, where most of the fields are read_only and can only be changed by a separate wizard. But through this wizard, user changes are possible and therefore tracking might be necessary.

Are there any doubt to remove the read_only filter?
