### PR TITLE
[14.0][FIX] base_name_search_improved: avoid error search type query

### DIFF
--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -89,6 +89,11 @@ def patch_name_search():
             # Support a list of fields to search on
             all_names = _get_rec_names(self.sudo())
             base_domain = args or []
+
+            # Check type res, avoid error some model.
+            if not isinstance(res, list):
+                res = []
+
             # Try regular search on each additional search field
             for rec_name in all_names[1:]:
                 domain = [(rec_name, operator, name)]


### PR DESCRIPTION
Step to test:
1. install module `account` and `base_name_search_improved`
2. Go to Settings > Smart Searches > active model `Analytic Account` and add somefield to search
![Selection_002](https://github.com/OCA/server-tools/assets/20896369/9b582a52-e5b8-489d-a7f8-f6dcc680e2b4)
3. Create new invoice/bill and search value in analytic account. it will error.
![Selection_003](https://github.com/OCA/server-tools/assets/20896369/3de0f70c-7b6f-421f-9f25-2258d5542ef3)
![Selection_004](https://github.com/OCA/server-tools/assets/20896369/5e686084-c8bb-4c97-9aca-7b00627c8cf3)


it error because some module like `account.analytic.account` will return result to query not list.