### PR TITLE
[16.0][IMP] upgrade_analysis: fix reinstall of sale_quotation_builder

### DIFF
--- a/upgrade_analysis/odoo_patch/addons/__init__.py
+++ b/upgrade_analysis/odoo_patch/addons/__init__.py
@@ -1,3 +1,4 @@
 from . import mrp
 from . import point_of_sale
+from . import sale_quotation_builder
 from . import stock

--- a/upgrade_analysis/odoo_patch/addons/sale_quotation_builder/__init__.py
+++ b/upgrade_analysis/odoo_patch/addons/sale_quotation_builder/__init__.py
@@ -1,0 +1,11 @@
+# flake8: noqa: B902
+from odoo.addons import sale_quotation_builder
+from ...odoo_patch import OdooPatch
+
+
+class PreInitHookPatch(OdooPatch):
+    target = sale_quotation_builder
+    method_names = ["_pre_init_sale_quotation_builder"]
+
+    def _pre_init_sale_quotation_builder(cr):
+        """Don't pre-create existing columns on reinstall"""


### PR DESCRIPTION
Fixes
```
2024-02-02 14:27:30,327 3052694 INFO ou160upgref odoo.modules.loading: Loading module sale_quotation_builder (396/454)
2024-02-02 14:27:30,490 3052694 ERROR ou160upgref odoo.sql_db: bad query:
	ALTER TABLE "sale_order"
	ADD COLUMN "website_description" text

ERROR: column "website_description" of relation "sale_order" already exists

2024-02-02 14:27:30,491 3052694 WARNING ou160upgref odoo.modules.loading: Transient module states were reset
2024-02-02 14:27:30,492 3052694 ERROR ou160upgref odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/home/odoo/odoo/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/odoo/odoo/modules/loading.py", line 488, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/odoo/odoo/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/odoo/odoo/modules/loading.py", line 195, in load_module_graph
    getattr(py_module, pre_init)(cr)
  File "/home/odoo/odoo/addons/sale_quotation_builder/__init__.py", line 17, in _pre_init_sale_quotation_builder
    cr.execute("""
  File "/home/odoo/odoo/odoo/sql_db.py", line 321, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.DuplicateColumn: column "website_description" of relation "sale_order" already exists
```

Issue introduced in https://github.com/odoo/odoo/pull/81818/files#diff-5a3036d8674fb060836fa8329f12ddfbe9dcd91702f6529ea1e05ef1ef90b992

Does not apply to 17.0.