### PR TITLE
[16.0][FIX] audit_log: fix regression (Add/Remove User Group)

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -387,6 +387,9 @@ class AuditlogRule(models.Model):
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
+            # invalidate_recordset method must be called with existing fields
+            if self._name == "res.users":
+                vals = self._remove_reified_groups(vals)
             # Prevent the cache of modified fields from being poisoned by
             # x2many items inaccessible to the current user.
             self.invalidate_recordset(vals.keys())

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -5,6 +5,7 @@
 from odoo.tests.common import Form, TransactionCase
 
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+from odoo.addons.base.models.res_users import name_boolean_group
 
 
 class AuditlogCommon(object):
@@ -612,3 +613,81 @@ class AuditLogRuleTestForUserFields(TransactionCase):
 
         # Removing auditlog_rule
         self.auditlog_rule.unlink()
+
+
+class AuditLogRuleTestForUserModel(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # get User model id
+        cls.user_model_id = cls.env["ir.model"].search([("model", "=", "res.users")]).id
+
+        # creating auditlog.rule
+        cls.auditlog_rule = (
+            cls.env["auditlog.rule"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": "testrule 01",
+                    "model_id": cls.user_model_id,
+                    "log_read": True,
+                    "log_create": True,
+                    "log_write": True,
+                    "log_unlink": True,
+                    "log_type": "full",
+                    "capture_record": True,
+                }
+            )
+        )
+
+        # Subscribe auditlog.rule
+        cls.auditlog_rule.subscribe()
+
+        # Create user id
+        cls.user = (
+            cls.env["res.users"]
+            .with_context(no_reset_password=True, tracking_disable=True)
+            .create(
+                {
+                    "name": "Test User",
+                    "login": "testuser",
+                }
+            )
+        )
+        cls.group = cls.env.ref("auditlog.group_auditlog_manager")
+
+        cls.auditlog_log = cls.env["auditlog.log"]
+
+    def test_01_AuditlogFull_field_group_write_log(self):
+        """Change group and check successfully created log"""
+        self.user.with_context(tracking_disable=True).write(
+            {"groups_id": [(4, self.group.id)]}
+        )
+        # Checking log is created for testpartner1
+        write_log_record = self.auditlog_log.search(
+            [
+                ("model_id", "=", self.auditlog_rule.model_id.id),
+                ("method", "=", "write"),
+                ("res_id", "=", self.user.id),
+            ]
+        ).ensure_one()
+        self.assertTrue(write_log_record)
+
+    def test_02_AuditlogFull_field_group_write_log(self):
+        """Change group and check successfully created log, but using reified fields"""
+        fname = name_boolean_group(self.group.id)
+
+        self.user.with_context(tracking_disable=True).write(
+            {
+                fname: True,
+            }
+        )
+        # Checking log is created for testpartner1
+        write_log_record = self.auditlog_log.search(
+            [
+                ("model_id", "=", self.auditlog_rule.model_id.id),
+                ("method", "=", "write"),
+                ("res_id", "=", self.user.id),
+            ]
+        ).ensure_one()
+        self.assertTrue(write_log_record)


### PR DESCRIPTION
When adding/removing a group in a user (and tracking a user or a partner), odoo sends a 'reified' val 'in_group_{group_id}'. We must convert this value into the real groups_id one.

This bug is now appearing after the merge of #2814 because of https://github.com/OCA/server-tools/blob/7d79324f01920496ad34af33b819597a63b9b55b/auditlog/models/rule.py#L395


Steps to reproduce:
1. Set a rule for re.users models
2. Go to a user and select/unselect one of the groups he belongs to (only visible in debug mode)
3. Save

![image](https://github.com/OCA/server-tools/assets/76053579/a5d8a114-3d5f-4187-a188-afb50cf0296d)
