### PR TITLE
[15.0][FIX] Missing fontawesome icons in some browsers

### DIFF
--- a/base_fontawesome/static/src/css/fontawesome.css
+++ b/base_fontawesome/static/src/css/fontawesome.css
@@ -13,6 +13,11 @@
     font-display: block;
 }
 
+:root,
+:host {
+    --fa-style-family: "FontAwesome";
+}
+
 .btn.fa,
 .btn.fas,
 .btn.far,


### PR DESCRIPTION
`fa-style-family` was not being set correctly on all browsers causing FontAwesome icons to be broken in some (most notably chrome).