### PR TITLE
[16.0][FIX] Missing fontawesome icons in some browsers

### DIFF
--- a/base_fontawesome/static/src/css/fontawesome.css
+++ b/base_fontawesome/static/src/css/fontawesome.css
@@ -12,23 +12,6 @@
     font-style: normal;
     font-display: block;
 }
-@font-face {
-    font-family: "FontAwesomeBrands";
-    src: url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.eot");
-    src: url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.eot?#iefix&v=5.15.4")
-            format("embedded-opentype"),
-        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.woff2?v=5.15.4")
-            format("woff2"),
-        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.woff?v=5.15.4")
-            format("woff"),
-        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.ttf?v=5.15.4")
-            format("truetype"),
-        url("../../lib/fontawesome-5.15.4/webfonts/fa-brands-400.svg#fontawesome?v=5.15.4&fontawesomeregular")
-            format("svg");
-    font-weight: normal;
-    font-style: normal;
-    font-display: block;
-}
 
 :root,
 :host {

--- a/base_fontawesome/static/src/css/fontawesome.css
+++ b/base_fontawesome/static/src/css/fontawesome.css
@@ -30,6 +30,11 @@
     font-display: block;
 }
 
+:root,
+:host {
+    --fa-style-family: "FontAwesome";
+}
+
 .btn.fa,
 .btn.fas,
 .btn.far,


### PR DESCRIPTION
Cherry-pick from 15.0 FIX #2836 

Also removed `font-face` code from previous version.

@gurneyalex @zamberjo @ozoromo