### PR TITLE
[12.0][UPD] module_auto_update: enable test that got disabled

### DIFF
--- a/module_auto_update/tests/test_addon_hash.py
+++ b/module_auto_update/tests/test_addon_hash.py
@@ -2,13 +2,14 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 import os
-import unittest
+
+from odoo.tests import TransactionCase
 
 from .. import addon_hash
 from ..models.module import DEFAULT_EXCLUDE_PATTERNS
 
 
-class TestAddonHash(unittest.TestCase):
+class TestAddonHash(TransactionCase):
 
     def setUp(self):
         super(TestAddonHash, self).setUp()
@@ -64,4 +65,4 @@ class TestAddonHash(unittest.TestCase):
             exclude_patterns=['*.pyc', '*.pyo', '*.pot', 'static/*'],
             keep_langs=['fr_FR', 'nl'],
         )
-        self.assertEqual(checksum, 'fecb89486c8a29d1f760cbd01c1950f6e8421b14')
+        self.assertEqual(checksum, '1a98bb88cefd6cde72620ac5f45a9ef41c894291')


### PR DESCRIPTION
Found this out while fixing tests for 11.0, noticing the hash had changed but for 12.0 the hash was still the same. Turns out test didn't run at all.