### PR TITLE
[FIX][12.0] cron_inactivity_period: prevent tests failing at just before midnight

### DIFF
--- a/cron_inactivity_period/tests/test_module.py
+++ b/cron_inactivity_period/tests/test_module.py
@@ -28,7 +28,7 @@ class TestModule(TransactionCase):
                 "cron_id": self.cron_job.id,
                 "type": "hour",
                 "inactivity_hour_begin": 0.0,
-                "inactivity_hour_end": 23.59,
+                "inactivity_hour_end": 23.9999,
             }
         )
         count = self._create_transient_model()


### PR DESCRIPTION
https://github.com/OCA/server-tools/actions/runs/7937135616/job/21673773074?pr=1616

```
2024-02-16 22:51:33,312 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: FAIL 
2024-02-16 22:51:33,312 1163 INFO odoo odoo.addons.cron_inactivity_period.tests.test_module: ====================================================================== 
2024-02-16 22:51:33,312 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: FAIL: test_02_no_activity_period (odoo.addons.cron_inactivity_period.tests.test_module.TestModule) 
2024-02-16 22:51:33,312 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: Traceback (most recent call last): 
2024-02-16 22:51:33,312 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: `   File "/__w/server-tools/server-tools/cron_inactivity_period/tests/test_module.py", line 36, in test_02_no_activity_period 
2024-02-16 22:51:33,313 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: `     count, 1, "Calling a cron with inactivity period should not run the cron" 
2024-02-16 22:51:33,313 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: ` AssertionError: 0 != 1 : Calling a cron with inactivity period should not run the cron 
2024-02-16 22:51:33,313 1163 INFO odoo odoo.addons.cron_inactivity_period.tests.test_module: Ran 2 tests in 0.136s 
2024-02-16 22:51:33,313 1163 ERROR odoo odoo.addons.cron_inactivity_period.tests.test_module: FAILED 
2024-02-16 22:51:33,313 1163 INFO odoo odoo.addons.cron_inactivity_period.tests.test_module:  (failures=1) 
```