### PR TITLE
[FIX] Add missing web dependency

### DIFF
--- a/onchange_helper/__manifest__.py
+++ b/onchange_helper/__manifest__.py
@@ -9,6 +9,6 @@
     "website": "https://github.com/OCA/server-tools",
     "license": "AGPL-3",
     "category": "Generic Modules",
-    "depends": ["base"],
+    "depends": ["base", "web"],
     "installable": True,
 }

--- a/onchange_helper/__manifest__.py
+++ b/onchange_helper/__manifest__.py
@@ -9,6 +9,6 @@
     "website": "https://github.com/OCA/server-tools",
     "license": "AGPL-3",
     "category": "Generic Modules",
-    "depends": ["base", "web"],
+    "depends": ["web"],
     "installable": True,
 }


### PR DESCRIPTION
Without explicit web dependency all tests fail like this:

```
File "/home/odoo/src/odoo/odoo/models.py", line 6905, in onchange
    raise NotImplementedError("onchange() is implemented in module 'web'")
NotImplementedError: onchange() is implemented in module 'web'
```
See: https://github.com/odoo/odoo/blob/a9ebd07b8028aa019e142d6809ec3aeba518a965/odoo/models.py#L6904-L6905
And: https://github.com/odoo/odoo/blob/a9ebd07b8028aa019e142d6809ec3aeba518a965/addons/web/models/models.py#L889-L1095