### PR TITLE
[16.0][FIX] Use defined sentry_logging_level also for event_level

### DIFF
--- a/sentry/const.py
+++ b/sentry/const.py
@@ -68,8 +68,9 @@ def select_transport(name=DEFAULT_TRANSPORT):
 def get_sentry_logging(level=DEFAULT_LOG_LEVEL):
     if level not in LOG_LEVEL_MAP:
         level = DEFAULT_LOG_LEVEL
-
-    return LoggingIntegration(level=LOG_LEVEL_MAP[level], event_level=logging.WARNING)
+    return LoggingIntegration(
+        level=LOG_LEVEL_MAP[level], event_level=LOG_LEVEL_MAP[level]
+    )
 
 
 def get_sentry_options():


### PR DESCRIPTION
Before this change if sentry_logging_level is defined as error, warn messages are still shown in sentry. Because event_level is definned with logging.WARNING