### PR TITLE
[16.0][IMP] attachment_synchronize: add additional error hook

### DIFF
--- a/attachment_queue/models/attachment_queue.py
+++ b/attachment_queue/models/attachment_queue.py
@@ -127,6 +127,10 @@ class AttachmentQueue(models.Model):
                     self.env.ref(
                         "attachment_queue.attachment_failure_notification"
                     ).send_mail(self.id)
+                self._additional_error_hook(e)
+
+    def _additional_error_hook(self, e):
+        return True
 
     def run(self):
         """


### PR DESCRIPTION
this can be useful in case for example if you want to link an attachment.queue that raised an error, to a record. It dodges the restriction with the rollback. As a caveat, it cannot be added to the manual run button and preserve the raise and the hook in a simple way. However, chances are it will already have been run and linked to the record