### PR TITLE
[16.0][FIX] cron_daylight_saving_time_resistant: Keep test savepoint

### DIFF
--- a/cron_daylight_saving_time_resistant/models/ir_cron.py
+++ b/cron_daylight_saving_time_resistant/models/ir_cron.py
@@ -45,7 +45,7 @@ class IrCron(models.Model):
         # be 1 hour too soon) and the date will just be incremented of 1
         # hour, each hour...until the changes time really occurs...
         if job["daylight_saving_time_resistant"]:
-            with cls.pool.cursor() as job_cr:
+            with db.cursor() as job_cr:
                 try:
                     cron = api.Environment(
                         job_cr,

--- a/cron_daylight_saving_time_resistant/tests/test_dst.py
+++ b/cron_daylight_saving_time_resistant/tests/test_dst.py
@@ -29,6 +29,11 @@ class TestDST(TransactionCase):
                 {"nextcall": datetime_str, "daylight_saving_time_resistant": True}
             )
             cron.flush_recordset()
+            cron.ir_actions_server_id.flush_recordset(
+                fnames=[
+                    "model_name",
+                ],
+            )
             self.env.cr.execute("SELECT * FROM ir_cron WHERE id = %s", (cron.id,))
             job = self.env.cr.dictfetchall()[0]
             timezone_date_orig = fields.Datetime.context_timestamp(cron, cron.nextcall)


### PR DESCRIPTION
Fix the following:
> This module seems to be causing test failures in recent PRs:
> 
> ```
>  2024-03-22 11:59:44,139 390 ERROR odoo odoo.addons.cron_daylight_saving_time_resistant.tests.test_dst: ERROR: TestDST.test_cron
> Traceback (most recent call last):
>   File "/opt/odoo/odoo/sql_db.py", line 176, in __exit__
>     self.commit()
>   File "/opt/odoo/odoo/sql_db.py", line 558, in commit
>     self._savepoint.close(rollback=False)
>   File "/opt/odoo/odoo/sql_db.py", line 86, in close
>     self._close(rollback)
>   File "/opt/odoo/odoo/sql_db.py", line 94, in _close
>     self._cr.execute(SQL('RELEASE SAVEPOINT {}').format(self._name))
>   File "/opt/odoo/odoo/sql_db.py", line 321, in execute
>     res = self._obj.execute(query, params)
> psycopg2.errors.InvalidSavepointSpecification: savepoint "13b0b903-3992-11ec-965e-5f38e53695a9" does not exist
> 
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "/__w/server-tools/server-tools/cron_daylight_saving_time_resistant/tests/test_dst.py", line 71, in test_cron
>     self._check_cron_date_after_run(cron, "2021-10-30 15:00:00")
>   File "/__w/server-tools/server-tools/cron_daylight_saving_time_resistant/tests/test_dst.py", line 43, in _check_cron_date_after_run
>     registry["ir.cron"]._process_job(db, new_cr, job)
>   File "/__w/server-tools/server-tools/cron_daylight_saving_time_resistant/models/ir_cron.py", line 48, in _process_job
>     with cls.pool.cursor() as job_cr:
>   File "/opt/odoo/odoo/sql_db.py", line 178, in __exit__
>     self.close()
>   File "/opt/odoo/odoo/sql_db.py", line 540, in close
>     self.rollback()
>   File "/opt/odoo/odoo/sql_db.py", line 571, in rollback
>     self._savepoint.rollback()
>   File "/opt/odoo/odoo/sql_db.py", line 89, in rollback
>     self._cr.execute(SQL('ROLLBACK TO SAVEPOINT {}').format(self._name))
>   File "/opt/odoo/odoo/sql_db.py", line 321, in execute
>     res = self._obj.execute(query, params)
> psycopg2.errors.InvalidSavepointSpecification: savepoint "13b0b903-3992-11ec-965e-5f38e53695a9" does not exist
> ```
> 
> https://github.com/OCA/server-tools/actions/runs/8389895772/job/22977050191?pr=2887
> 
> Would you be so kind as to have a look?

_Originally posted by @StefanRijnhart in https://github.com/OCA/server-tools/issues/2578#issuecomment-2015053899_

This is causing tests failure for every `16.0`-based PR.