### PR TITLE
[16][FIX] autovacuum_message_attachment : fix inheriting_model feature

### DIFF
--- a/autovacuum_message_attachment/models/ir_attachment.py
+++ b/autovacuum_message_attachment/models/ir_attachment.py
@@ -21,8 +21,8 @@ class IrAttachment(models.Model):
         if rule.inheriting_model:
             inheriting_model = self.env[rule.inheriting_model]
             attachment_link = inheriting_model._inherits.get("ir.attachment")
-            att_ids = inheriting_model.search(create_date_domain).mapped(
-                attachment_link + ".ids"
+            att_ids = (
+                inheriting_model.search(create_date_domain).mapped(attachment_link).ids
             )
             domains.append([("id", "in", att_ids)])
         if rule.filename_pattern:


### PR DESCRIPTION
I did not  see this mistake during migration.  I am not sure this feature was ever working in the past version...
I fixed it anyway, it should be fine now !

@etobella @thomaspaulb 