### PR TITLE
[15.0][FIX] auditlog rule: Control the write function in the models when executed by an onchange function

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -379,16 +379,19 @@ class AuditlogRule(models.Model):
             self = self.with_context(auditlog_disabled=True)
             rule_model = self.env["auditlog.rule"]
             fields_list = rule_model.get_auditlog_fields(self)
+            records_write = self.filtered(lambda r: not isinstance(r.id, models.NewId))
+            if not records_write:
+                return write_full.origin(self, vals, **kwargs)
             old_values = {
                 d["id"]: d
-                for d in self.sudo()
+                for d in records_write.sudo()
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d
-                for d in self.sudo()
+                for d in records_write.sudo()
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
@@ -397,7 +400,7 @@ class AuditlogRule(models.Model):
             rule_model.sudo().create_logs(
                 self.env.uid,
                 self._name,
-                self.ids,
+                records_write.ids,
                 "write",
                 old_values,
                 new_values,


### PR DESCRIPTION
Changes to fix the following issue: https://github.com/OCA/server-tools/issues/2343

The goal of these changes is to fix the issue that when you activate the audit rule for the products, and then you try to create or modify the price, an access error appears.

From what I've been able to see, this is because in version 15 added the onchange decorator in the _set_product_lst_price function. As within this function a write is being executed for the same product. This causes it to go through the logic of the AuditlogRule with an object that has the id as "NewId".  Causing the error to appear when checking the security rules.

I've modified the AuditlogRule class and modify the _make_write function, where inside there, I check if the record id is an object that instance of NewId. If instance of NewId, What it does is ignore the original logic to prevent it from executing the read function. It'll only run the write_full.origin to do the base logic. If this is not the case, and it's a normal id, it'll execute the usual logic.