### PR TITLE
[16] attachment synchronize : Improve remote file import management

### DIFF
--- a/attachment_synchronize/demo/attachment_synchronize_task_demo.xml
+++ b/attachment_synchronize/demo/attachment_synchronize_task_demo.xml
@@ -4,8 +4,44 @@
         <field name="name">TEST Import</field>
         <field name="backend_id" ref="fs_storage.default_fs_storage" />
         <field name="method_type">import</field>
+        <field name="filepath">test_import</field>
+        <field name="avoid_duplicated_files" eval="True" />
+    </record>
+
+    <record id="import_from_filestore_delete" model="attachment.synchronize.task">
+        <field name="name">TEST Import then delete</field>
+        <field name="backend_id" ref="fs_storage.default_fs_storage" />
+        <field name="method_type">import</field>
         <field name="after_import">delete</field>
         <field name="filepath">test_import</field>
+    </record>
+
+    <record id="import_from_filestore_rename" model="attachment.synchronize.task">
+        <field name="name">TEST Import then rename</field>
+        <field name="backend_id" ref="fs_storage.default_fs_storage" />
+        <field name="method_type">import</field>
+        <field name="after_import">rename</field>
+        <field name="filepath">test_import</field>
+        <field name="new_name">test-${obj.name}</field>
+    </record>
+
+    <record id="import_from_filestore_move" model="attachment.synchronize.task">
+        <field name="name">TEST Import then move</field>
+        <field name="backend_id" ref="fs_storage.default_fs_storage" />
+        <field name="method_type">import</field>
+        <field name="after_import">move</field>
+        <field name="filepath">test_import</field>
+        <field name="move_path">test_archived</field>
+    </record>
+
+    <record id="import_from_filestore_move_rename" model="attachment.synchronize.task">
+        <field name="name">TEST Import then move and rename</field>
+        <field name="backend_id" ref="fs_storage.default_fs_storage" />
+        <field name="method_type">import</field>
+        <field name="after_import">move_rename</field>
+        <field name="filepath">test_import</field>
+        <field name="move_path">test_archived</field>
+        <field name="new_name">foo.txt</field>
     </record>
 
     <record id="export_to_filestore" model="attachment.synchronize.task">

--- a/attachment_synchronize/tests/common.py
+++ b/attachment_synchronize/tests/common.py
@@ -36,6 +36,18 @@ class SyncCommon(TransactionCase):
         self._clean_testing_directory()
         self._create_test_file()
         self.task = self.env.ref("attachment_synchronize.import_from_filestore")
+        self.task_delete = self.env.ref(
+            "attachment_synchronize.import_from_filestore_delete"
+        )
+        self.task_move = self.env.ref(
+            "attachment_synchronize.import_from_filestore_move"
+        )
+        self.task_rename = self.env.ref(
+            "attachment_synchronize.import_from_filestore_rename"
+        )
+        self.task_move_rename = self.env.ref(
+            "attachment_synchronize.import_from_filestore_move_rename"
+        )
 
     def tearDown(self):
         self._clean_testing_directory()


### PR DESCRIPTION
Current problems are the following : 
1) When import multiple files from a remote server, if an error occurs after the first file, we risk loosing data, because, the first file(s) imported could have been deleted/renamed on remote server.
We need to commit after each imported file to ensure we won't loose any data.

2) If one import task fails, the whole cron stops. It means if we import files from multiple remote server and the first remote  server is unavailable, all import from all remote will be blocked.
We add a warning in the log if there is a failure for a remote but don't block the rest of the process.

@kevinkhao @bealdav @GSLabIt @sebastienbeau 

