### PR TITLE
[14.0] tracking_manager: non trackable field should be not tracked

### DIFF
--- a/tracking_manager/__manifest__.py
+++ b/tracking_manager/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Tracking Manager",
     "summary": """This module tracks all fields of a model,
                 including one2many and many2many ones.""",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.1.0",
     "category": "Tools",
     "website": "https://github.com/OCA/server-tools",
     "author": "Akretion, Odoo Community Association (OCA)",

--- a/tracking_manager/migrations/14.0.1.1.0/pre-fix-none-trackable-field.py
+++ b/tracking_manager/migrations/14.0.1.1.0/pre-fix-none-trackable-field.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+# pylint: disable=print-used
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE ir_model_fields
+        SET custom_tracking=False
+        WHERE trackable=False
+        """
+    )

--- a/tracking_manager/models/ir_model.py
+++ b/tracking_manager/models/ir_model.py
@@ -162,12 +162,12 @@ class IrModelFields(models.Model):
         store=True,
     )
 
-    @api.depends("native_tracking")
+    @api.depends("native_tracking", "trackable")
     def _compute_custom_tracking(self):
         for record in self:
             if record.model_id.automatic_custom_tracking:
                 domain = literal_eval(record.model_id.automatic_custom_tracking_domain)
-                record.custom_tracking = bool(record.filtered_domain(domain))
+                record.custom_tracking = record.filtered_domain(domain).trackable
             else:
                 record.custom_tracking = record.native_tracking
 

--- a/tracking_manager/static/description/index.html
+++ b/tracking_manager/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
@Kev-Roche

When using automatic domain, alll field that match the doman was tracked even if their are not trackable.
This generate issue (perf and also bug) as it track none stored computed field .

Fix the bug and add a migration script to clean the data