### PR TITLE
[15.0][FIX] base_fontawesome: Moved renderers to web.assets_backend to fix dependency errors

### DIFF
--- a/base_fontawesome/__manifest__.py
+++ b/base_fontawesome/__manifest__.py
@@ -11,7 +11,7 @@
     "author": "Camptocamp,Creu Blanca,Odoo Community Association (OCA)",
     "depends": ["web"],
     "assets": {
-        "web.assets_common": [
+        "web.assets_backend": [
             (
                 "replace",
                 "web/static/lib/fontawesome/css/font-awesome.css",


### PR DESCRIPTION
This small change to `__manifest__.py` fixes these two dependecy errors related to fontawesome:
![image](https://github.com/OCA/server-tools/assets/36481318/668a9c33-8e63-478c-9d6e-7d3a70464f25)
