### PR TITLE
[16.0][FIX] auditlog: many2many field fill full colspan

### DIFF
--- a/auditlog/views/http_request_view.xml
+++ b/auditlog/views/http_request_view.xml
@@ -14,7 +14,7 @@
                         <field name="http_session_id" />
                     </group>
                     <group string="Logs">
-                        <field name="log_ids" nolabel="1" />
+                        <field name="log_ids" nolabel="1" colspan="2" />
                     </group>
                 </sheet>
             </form>

--- a/auditlog/views/http_session_view.xml
+++ b/auditlog/views/http_session_view.xml
@@ -12,7 +12,7 @@
                         <field name="name" />
                     </group>
                     <group string="HTTP Requests">
-                        <field name="http_request_ids" nolabel="1" />
+                        <field name="http_request_ids" nolabel="1" colspan="2" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Here is the view before:
![auditlog-before](https://github.com/OCA/server-tools/assets/48931463/938901a0-540b-4dfd-aa0f-0fea44e5b8a6)

And here after:
![auditlog-after](https://github.com/OCA/server-tools/assets/48931463/f237cb7c-4f14-49b2-a61a-97f472031736)
