### PR TITLE
[16.0] module_analysis: pin pygount dependency

### DIFF
--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -26,7 +26,7 @@
         "data/ir_module_type_rule.xml",
     ],
     "external_dependencies": {
-        "python": ["pygount"],
+        "python": ["pygount==1.4.0"],
     },
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ odoo_test_helper
 odoorpc
 openpyxl
 openupgradelib
-pygount
+pygount==1.4.0
 pysftp
 sentry_sdk<=1.9.0
 unidecode


### PR DESCRIPTION
Fixes https://github.com/OCA/server-tools/issues/2966