### PR TITLE
[16.0][FIX] excel_import_export, add empty dict to new call

### DIFF
--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -61,7 +61,7 @@ class XLSXImport(models.AbstractModel):
     @api.model
     def _get_field_type(self, model, field):
         try:
-            record = self.env[model].new()
+            record = self.env[model].new({})
             for f in field.split("/"):
                 field_type = record._fields[f].type
                 if field_type in ("one2many", "many2many"):


### PR DESCRIPTION
I implemented in account.payment import, but in this case is evaluated values as a dict, because that I think should be better to add an empty dict to general call to avoid problem with this kind of implementation

https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_payment.py#L681

@ForgeFlow