### PR TITLE
[14.0][backport] database_cleanup: Prevent deletion of columns added in the init method of the model.

### DIFF
--- a/database_cleanup/models/purge_columns.py
+++ b/database_cleanup/models/purge_columns.py
@@ -68,7 +68,8 @@ class CleanupPurgeWizardColumn(models.TransientModel):
     # Format: {table: [fields]}
     blacklist = {
         "wkf_instance": ["uid"],  # lp:1277899
-        "res_users": ["password", "password_crypt"],
+        "res_users": ["password", "password_crypt", "totp_secret"],
+        "res_partner": ["signup_token"],
     }
 
     @api.model

--- a/database_cleanup/readme/CONTRIBUTORS.rst
+++ b/database_cleanup/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Stefan Rijnhart <stefan@opener.amsterdam>
 * Holger Brunn <hbrunn@therp.nl>
 * Stéphane Mangin <stephane.mangin@camptocamp.com>
+* Mark Schuit <mark@gig.solutions>


### PR DESCRIPTION
purge_column:  issues with `totp_secret` field 
See issue https://github.com/OCA/server-tools/issues/2851.

Backport of from v16 https://github.com/OCA/server-tools/issues/2851