### PR TITLE
[15.0][FIX] database_cleanup: Prevent deletion of columns added in the init method of the model

### DIFF
--- a/database_cleanup/README.rst
+++ b/database_cleanup/README.rst
@@ -82,6 +82,7 @@ Contributors
 * Holger Brunn <hbrunn@therp.nl>
 * Stéphane Mangin <stephane.mangin@camptocamp.com>
 * Andrea Stirpe
+* Mark Schuit <mark@gig.solutions>
 
 Maintainers
 ~~~~~~~~~~~

--- a/database_cleanup/models/purge_columns.py
+++ b/database_cleanup/models/purge_columns.py
@@ -68,7 +68,8 @@ class CleanupPurgeWizardColumn(models.TransientModel):
     # Format: {table: [fields]}
     blacklist = {
         "wkf_instance": ["uid"],  # lp:1277899
-        "res_users": ["password", "password_crypt"],
+        "res_users": ["password", "password_crypt", "totp_secret"],
+        "res_partner": ["signup_token"],
     }
 
     @api.model

--- a/database_cleanup/readme/CONTRIBUTORS.rst
+++ b/database_cleanup/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Holger Brunn <hbrunn@therp.nl>
 * Stéphane Mangin <stephane.mangin@camptocamp.com>
 * Andrea Stirpe
+* Mark Schuit <mark@gig.solutions>

--- a/database_cleanup/static/description/index.html
+++ b/database_cleanup/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -399,9 +398,7 @@ group. Go through the modules, models, columns and tables
 entries under this menu (in that order) and find out if there is orphaned data
 in your database. You can either delete entries by line, or sweep all entries
 in one big step (if you are <em>really</em> confident).</p>
-<a class="reference external image-reference" href="https://runbot.odoo-community.org/runbot/149/11.0">
-<img alt="Try me on Runbot" src="https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas" />
-</a>
+<a class="reference external image-reference" href="https://runbot.odoo-community.org/runbot/149/11.0"><img alt="Try me on Runbot" src="https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas" /></a>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -426,14 +423,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</li>
 <li>Stéphane Mangin &lt;<a class="reference external" href="mailto:stephane.mangin&#64;camptocamp.com">stephane.mangin&#64;camptocamp.com</a>&gt;</li>
 <li>Andrea Stirpe</li>
+<li>Mark Schuit &lt;<a class="reference external" href="mailto:mark&#64;gig.solutions">mark&#64;gig.solutions</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Cherry-pick of #2852 (backported for 14.0 in #2993), but with proper commit message.

With Odoo 16.0, running the "Purge columns" database cleanup, a field called totp_secret shows up for purging when the auth_totp module is installed. This field seems to be defined as a computed non-stored field
(https://github.com/odoo/odoo/blob/93aa48c972889f941b97a60738d33f571204bb2c/addons/auth_totp/models/res_users.py#L24), but also has a query referring to it.
(https://github.com/odoo/odoo/blob/93aa48c972889f941b97a60738d33f571204bb2c/addons/auth_totp/models/res_users.py#L160)

The totp_secret field would have to be defined as stored=True, but it is not defined as such. Instead, it's added in res.users init method:
https://github.com/odoo/odoo/blob/93aa48c972889f941b97a60738d33f571204bb2c/addons/auth_totp/models/res_users.py#L32

The solution is to add the "totp_secret" field to the blacklisted fields of res.users.

@Tecnativa 