### PR TITLE
[16.0][IMP] fetchmail_attach_from_folder: outlook as server_type

### DIFF
--- a/fetchmail_attach_from_folder/views/fetchmail_server.xml
+++ b/fetchmail_attach_from_folder/views/fetchmail_server.xml
@@ -9,12 +9,12 @@
             <field name="object_id" position="attributes">
                 <attribute
                     name="attrs"
-                >{'required': [('server_type', '!=', 'imap')]}</attribute>
+                >{'required': [('server_type', 'not in',('imap', 'outlook'))]}</attribute>
             </field>
             <xpath expr="//notebook" position="inside">
                 <page
                     string="Folders to monitor"
-                    attrs="{'invisible': [('server_type','!=','imap')]}"
+                    attrs="{'invisible': [('server_type','not in',('imap', 'outlook'))]}"
                 >
                     <group>
                         <field name="folders_only" />


### PR DESCRIPTION
The `microsoft_outlook` module adds the possibility to connect via OAuth. 

We add it to the visibility of the folders tab to be able to use it.

Ping @NL66278