### PR TITLE
[16.0][IMP] fetchmail_attach_from_folder: Read e-mails are excluded

### DIFF
--- a/fetchmail_attach_from_folder/views/fetchmail_server.xml
+++ b/fetchmail_attach_from_folder/views/fetchmail_server.xml
@@ -103,6 +103,7 @@
                                     <field name="active" />
                                     <field name="archive_path" />
                                     <field name="delete_matching" />
+                                    <field name="fetch_unseen_only" />
                                     <field name="msg_state" />
                                 </group>
                             </group>

--- a/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
+++ b/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
@@ -42,7 +42,7 @@ class AttachMailManually(models.TransientModel):
         folder = folder_model.browse([folder_id])
         connection = folder.server_id.connect()
         connection.select(folder.path)
-        criteria = "FLAGGED" if folder.flag_nonmatching else "UNDELETED"
+        criteria = "FLAGGED" if folder.flag_nonmatching else folder.get_criteria()
         msgids = folder.get_msgids(connection, criteria)
         for msgid in msgids[0].split():
             mail_message, message_org = folder.fetch_msg(connection, msgid)


### PR DESCRIPTION
If you have a folder with a large number of emails, `fetch_mail` is executed for all of them.

We add the flag to read only the unread ones. In this way a lot of load is released on the server.