### PR TITLE
tracking_manager: Fix tools.formatm2m

### DIFF
--- a/tracking_manager/tools.py
+++ b/tracking_manager/tools.py
@@ -4,4 +4,11 @@
 
 
 def format_m2m(records):
-    return "; ".join(records.mapped("display_name"))
+    # In some cases (I.E. account_asset/models/account_asset.py), _message_track
+    # is called with a dict of None values as initial_values.
+    # As a result, create_tracking_values would be called with None as initial_value
+    # and this format_m2m would be called with None as an argument.
+    # In such case, return "None"
+    if records:
+        return "; ".join(records.mapped("display_name"))
+    return ""


### PR DESCRIPTION
In some cases (I.E. account_asset/models/account_asset.py), `_message_track` is called with a dict of None values as initial_values.
https://github.com/odoo/enterprise/blob/14.0/account_asset/models/account_asset.py#L583
As a result, `create_tracking_values` would be called with `None` as `initial_value` and this `format_m2m` function would be called with `None` as an argument.
In such case, return `""`