### PR TITLE
[FIX] recompute tracking when automatic_custom_tracking is set to False

### DIFF
--- a/tracking_manager/models/ir_model.py
+++ b/tracking_manager/models/ir_model.py
@@ -168,7 +168,7 @@ class IrModelFields(models.Model):
         store=True,
     )
 
-    @api.depends("native_tracking", "trackable")
+    @api.depends("native_tracking", "trackable", "model_id.automatic_custom_tracking")
     def _compute_custom_tracking(self):
         for record in self:
             if record.model_id.automatic_custom_tracking:

--- a/tracking_manager/tests/test_tracking_manager.py
+++ b/tracking_manager/tests/test_tracking_manager.py
@@ -36,6 +36,10 @@ class TestTrackingManager(SavepointCase):
         )
         cls.partner_model = cls.env.ref("base.model_res_partner")
         cls._active_tracking(["bank_ids", "category_id"])
+        bank_ids_field = cls.partner_model.field_id.filtered(
+            lambda x: x.name == "bank_ids"
+        )
+        bank_ids_field.custom_tracking = True
         cls.flush_tracking()
         cls.partner.message_ids.unlink()
 


### PR DESCRIPTION
When automatic configuration is applied on the model, it computes
fields which can be tracked based on applied domain.
But when automatic_custom_tracking is set from True to False
it does not recompute tracked fields back.

reproducable on runbot.