### PR TITLE
[14.0][FIX] utf-8 cached backup error auto_backup

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -159,9 +159,9 @@ class DbBackup(models.Model):
                     pass
 
                 with open(os.path.join(rec.folder, filename), "wb") as destiny:
-                    # Copy the cached backup
-                    if backup:
-                        with open(backup) as cached:
+                    # Copy the cached backup, ensuring that it is in the same format
+                    if backup and backup.endswith(rec.backup_format):
+                        with open(backup, "rb") as cached:
                             shutil.copyfileobj(cached, destiny)
                     # Generate new backup
                     else:


### PR DESCRIPTION
Error in backup process:

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xeb in position 14: invalid continuation byte`

How to replicate:
1. create one backup with filestore
2. create another backup without filestore
3. wait cron execution

Second error: the second backup is a copy of the first one, regardless of the type. So the second backup, of the type "dump", is a copy of the "zip" file without the correct extension.