### PR TITLE
[14.0][FIX] attachment_unindex_content: Add WHERE clause to UPDATE query

### DIFF
--- a/attachment_unindex_content/hooks.py
+++ b/attachment_unindex_content/hooks.py
@@ -1,3 +1,5 @@
 def post_init_hook(cr, registry):
     """Clear the indexed data for records already in database"""
-    cr.execute("UPDATE ir_attachment SET index_content=NULL")
+    cr.execute(
+        "UPDATE ir_attachment SET index_content=NULL WHERE index_content IS NOT NULL"
+    )


### PR DESCRIPTION
Adding the WHERE clause, the query will only update rows where index_content is not NULL, reducing the number of unnecessary updates. If most values are already NULL, the speed execution is significantly improved; less than an hour for my test-case with an ir_attachment table of 300 GB. 
I used a SQL pre-script in order to batch the updates  (batches of 10k records) before installing this specific attachment_unindex_content module and it really improved the global installation time needed.