### PR TITLE
[16.0][FIX] tracking_manager: Avoid sending tracking o2m emails if you are subscribed to notes

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -97,12 +97,13 @@ class Base(models.AbstractModel):
                     }
                     for field_name, messages in messages_by_field.items()
                 ]
-                # use sudo as user may not have access to mail.message
-                record.sudo().message_post_with_view(
+                # We do not use message_post_with_view() because emails would be sent
+                rendered_template = self.env["ir.qweb"]._render(
                     "tracking_manager.track_o2m_m2m_template",
-                    values={"lines": messages},
-                    subtype_id=self.env.ref("mail.mt_note").id,
+                    {"lines": messages, "object": record},
+                    minimal_qcontext=True,
                 )
+                record._message_log(body=rendered_template)
 
     def _tm_prepare_o2m_tracking(self):
         fnames = self._tm_get_fields_to_track()


### PR DESCRIPTION
Avoid sending tracking o2m emails if you are subscribed to notes

Example use case:
- Enable custom tracking in `project.project`
- Activate the `task_ids` field as custom tracking
- Create a project and assign it to a user (different from ours) and make it a note follower
- Create a task in the project
- The project message of the task tracking task will not be sent to the note followers

**Before**
![antes](https://github.com/user-attachments/assets/b3b13026-6ddc-4c57-b143-4f27538eae1f)

**After**
![despues](https://github.com/user-attachments/assets/b46251f1-e802-4331-b0ad-bbe52099f747)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT50676