### PR TITLE
[15.0][FIX] excel_import_export: require attach when res_id false

### DIFF
--- a/excel_import_export/wizard/import_xlsx_wizard.py
+++ b/excel_import_export/wizard/import_xlsx_wizard.py
@@ -29,7 +29,6 @@ class ImportXLSXWizard(models.TransientModel):
     attachment_ids = fields.Many2many(
         "ir.attachment",
         string="Import File(s) (*.xlsx)",
-        required=True,
         help="You can select multiple files to import.",
     )
     state = fields.Selection(

--- a/excel_import_export/wizard/import_xlsx_wizard.xml
+++ b/excel_import_export/wizard/import_xlsx_wizard.xml
@@ -22,8 +22,8 @@
                         <field
                             name="attachment_ids"
                             widget="many2many_binary"
+                            attrs="{'invisible': [('res_id', '!=', False)], 'required': [('res_id', '=', False)]}"
                             nolabel="1"
-                            attrs="{'invisible': [('res_id', '!=', False)]}"
                         />
                     </group>
                     <group>


### PR DESCRIPTION
`attachment_ids` shouldn't required when we import with `import_file`

Step to test:
1. install module excel_import_export_demo
2. import sale order. it will require attachment_ids
![Selection_007](https://github.com/user-attachments/assets/1a60c83f-34b5-48a7-a763-dee7cd1c7372)
