### PR TITLE
[16.0][IMP] excel_import_export: improve error showing

### DIFF
--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -11,7 +11,7 @@ import xlrd
 import xlwt
 
 from odoo import _, api, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.float_utils import float_compare
 from odoo.tools.safe_eval import safe_eval
 
@@ -107,7 +107,17 @@ class XLSXImport(models.AbstractModel):
             # Use max_row, i.e., order_line[5], use it. Otherwise, use st.nrows
             max_end_row = st.nrows if max_row is False else (row + max_row)
             for idx in range(row, max_row and max_end_row or st.nrows):
-                cell_type = st.cell_type(idx, col)  # empty type = 0
+                try:
+                    cell_type = st.cell_type(idx, col)  # empty type = 0
+                except Exception as e:
+                    raise UserError(
+                        _(
+                            "The value for the '%(field)s' field is expected to be "
+                            "in cell %(cell_position)s, but no column exists for that "
+                            "cell in the Excel sheet. Please check your Excel file."
+                        )
+                        % {"field": _col, "cell_position": rc}
+                    ) from e
                 r_types = test_rows.get(idx, [])
                 r_types.append(cell_type)
                 test_rows[idx] = r_types


### PR DESCRIPTION
This PR improves to show the error message popup instead of showing `internal server error` for `list index out for range` when the imported excel doesn't include the required column in sheet.

@qrtl QT4615