### PR TITLE
[16][IMP] attachment_queue automatic retry

### DIFF
--- a/attachment_synchronize/models/attachment_queue.py
+++ b/attachment_synchronize/models/attachment_queue.py
@@ -5,6 +5,8 @@ import base64
 
 from odoo import api, fields, models
 
+from odoo.addons.queue_job.exception import RetryableJobError
+
 
 class AttachmentQueue(models.Model):
     _inherit = "attachment.queue"
@@ -30,16 +32,25 @@ class AttachmentQueue(models.Model):
     def _run(self):
         res = super()._run()
         if self.file_type == "export":
-            fs = self.fs_storage_id.fs
-            folder_path = self.task_id.filepath
-            full_path = (
-                folder_path and fs.sep.join([folder_path, self.name]) or self.name
-            )
-            # create missing folders if necessary :
-            if folder_path and not fs.exists(folder_path):
-                fs.makedirs(folder_path)
-            self._write_file_to_remote(fs, full_path)
+            try:
+                fs = self.fs_storage_id.fs
+                folder_path = self.task_id.filepath
+                full_path = (
+                    folder_path and fs.sep.join([folder_path, self.name]) or self.name
+                )
+                # create missing folders if necessary :
+                if folder_path and not fs.exists(folder_path):
+                    fs.makedirs(folder_path)
+                self._write_file_to_remote(fs, full_path)
+            except TimeoutError as err:
+                raise RetryableJobError(
+                    str(err),
+                    seconds=self._timeout_retry_seconds(),
+                ) from err
         return res
+
+    def _timeout_retry_seconds(self):
+        return 60 * 60 * 4
 
     def _get_failure_emails(self):
         res = super()._get_failure_emails()


### PR DESCRIPTION
For now, when an attachment queue is processsed by a `queue.job`, there is no automatic retry in case of concurrent update because all errors are caught.
And, for the same reason, the RetryableJobError does not work.
This PR aims to restore a consistent behavior about this.
The only bad point is that, in case of RetryableJobError, the failure email will be sent anyway, even if the job will retry the attachment. It would then be kind of a false positive. I don't think to have any other choice, because at the time we send the mail, we can't really know if the job will retry or not (we do not know if the max_retries will be reached).

@kevinkhao @bealdav @SirAionTech 