### PR TITLE
[16][FIX] attachment_queue : fix default channel name

### DIFF
--- a/attachment_queue/models/attachment_queue.py
+++ b/attachment_queue/models/attachment_queue.py
@@ -52,7 +52,7 @@ class AttachmentQueue(models.Model):
     def _job_attrs(self):
         # Override this method to have file type specific job attributes
         self.ensure_one()
-        return {"channel": "attachment_queue"}
+        return {"channel": "root.attachment_queue"}
 
     def _schedule_jobs(self):
         for el in self:


### PR DESCRIPTION
The created channel on the module is a child of "root", so  we have to pass the channel name as `root.attachment_queue`
The consequence passing only "attachment_queue" like it is now, is that the done jobs won't be deleted by the vacuum cron.

I am not sure there is other consequences, from what I test, even without the "root" prefix, the jobs were processed with the right amount of workers configured on the root.attachment_queue channel...

@bealdav @kevinkhao 