### PR TITLE
[17.0][FIX] tracking_manager: Avoid error if no record is linked (example: child_ids of res.partner)

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -89,6 +89,9 @@ class Base(models.AbstractModel):
             if not getattr(self.env[model_name], "message_post_with_source", False):
                 continue
             for record_id, messages_by_field in model_data.items():
+                # Avoid error if no record is linked (example: child_ids of res.partner)
+                if not record_id:
+                    continue
                 record = self.env[model_name].browse(record_id)
                 messages = [
                     {


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/server-tools/pull/3048

Avoid error if no record is linked (example: `child_ids` of `res.partner`)

Example use case:
- Define the `child_ids` field of `res.partner` as tracking.
- Modify contact Brandon Freeman and leave parent_id empty (Azure Interior)
- No error should be displayed

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51146