### PR TITLE
[16.0][FIX] tracking_manager: Avoid error when accessing the value of a field that we do not have access

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -6,6 +6,7 @@
 from collections import defaultdict
 
 from odoo import api, models, tools
+from odoo.exceptions import AccessError
 
 from ..tools import format_m2m
 
@@ -120,7 +121,11 @@ class Base(models.AbstractModel):
             values = initial_values.setdefault(record.id, {})
             if values is not None:
                 for fname in fnames:
-                    values.setdefault(fname, record[fname])
+                    try:
+                        values.setdefault(fname, record[fname])
+                    except AccessError:
+                        # User does not have access to the field (example with groups)
+                        continue
 
     def _tm_finalize_o2m_tracking(self):
         initial_values = self.env.cr.precommit.data.pop(

--- a/tracking_manager/tests/test_tracking_manager.py
+++ b/tracking_manager/tests/test_tracking_manager.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Akretion (https://www.akretion.com).
+# Copyright 2024 Tecnativa - Víctor Martínez
 # @author Kévin Roche <kevin.roche@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
@@ -27,7 +28,7 @@ class TestTrackingManager(TransactionCase):
             }
         )
         cls.partner_model = cls.env.ref("base.model_res_partner")
-        cls._active_tracking(["user_ids", "category_id"])
+        cls._active_tracking(["user_ids", "category_id", "child_ids"])
         cls.flush_tracking()
         cls.partner.message_ids.unlink()
 
@@ -267,3 +268,10 @@ class TestTrackingManager(TransactionCase):
         self.assertEqual(len(self.messages), 1)
         self.assertEqual(self.messages.body.count("Change"), 0)
         self.assertEqual(self.messages.body.count("Delete"), 1)
+
+    def test_o2m_update_record(self):
+        child = self.env["res.partner"].create(
+            {"name": "Test child", "parent_id": self.partner.id}
+        )
+        child.write({"parent_id": False})
+        self.assertEqual(len(self.messages), 1)


### PR DESCRIPTION
Avoid error when accessing the value of a field that we do not have access

Example use case:
- Install `hr_fleet`
- Set the `employee_ids` field of `hr.employee` as a tracking field
- Modify the user to not have permissions in Fleet
- Modify the name of an employee

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT51160