### PR TITLE
[16.0][FIX] tracking_manager: Test compatibility

### DIFF
--- a/tracking_manager/tests/test_tracking_manager.py
+++ b/tracking_manager/tests/test_tracking_manager.py
@@ -28,7 +28,7 @@ class TestTrackingManager(TransactionCase):
             }
         )
         cls.partner_model = cls.env.ref("base.model_res_partner")
-        cls._active_tracking(["user_ids", "category_id", "child_ids"])
+        cls._active_tracking(["user_ids", "category_id"])
         cls.flush_tracking()
         cls.partner.message_ids.unlink()
 
@@ -270,6 +270,7 @@ class TestTrackingManager(TransactionCase):
         self.assertEqual(self.messages.body.count("Delete"), 1)
 
     def test_o2m_update_record(self):
+        self.env.ref("base.field_res_partner__child_ids").custom_tracking = True
         child = self.env["res.partner"].create(
             {"name": "Test child", "parent_id": self.partner.id}
         )


### PR DESCRIPTION
Test compatibility

Related to https://github.com/OCA/server-tools/pull/3051/commits/b41e7ae2c77bf1c157087cc41893e134fab247f9

Do not set the `child_ids` field as tracking in the setup to avoid incorrect data in some cases

Please @pedrobaeza can you review it?

@Tecnativa TT51160