### PR TITLE
[12.0][FIX] module_analysis: interpret exclude_directories as relative to module's folder

### DIFF
--- a/module_analysis/models/ir_module_module.py
+++ b/module_analysis/models/ir_module_module.py
@@ -164,7 +164,7 @@ class IrModuleModule(models.Model):
         if not path:
             return res
         for root, dirs, files in os.walk(path, followlinks=True):
-            if set(Path(root).parts) & set(exclude_directories):
+            if set(Path(root).relative_to(path).parts) & set(exclude_directories):
                 continue
             for name in files:
                 if name in exclude_files:


### PR DESCRIPTION
Backport of PR #3045.