### PR TITLE
[16.0][ADD] upgrade_analysis: add blacklist from v17

### DIFF
--- a/upgrade_analysis/blacklist.py
+++ b/upgrade_analysis/blacklist.py
@@ -1,4 +1,9 @@
-BLACKLIST_MODULES = []
+BLACKLIST_MODULES = [
+    "payment_alipay",
+    "payment_ogone",
+    "payment_payulatam",
+    "payment_payumoney",
+]
 
 # the hw_* modules are not affected by a migration as they don't
 # contain any ORM functionality, but they do start up threads that


### PR DESCRIPTION
this adds the same blacklist as in [v17](https://github.com/OCA/server-tools/blob/17.0/upgrade_analysis/blacklist.py#L1-L6) because the depreciation has been [backported](https://github.com/OCA/OCB/commit/c9072dfe798d658246ca6fc255f95eb884a6d389), leading to problems with re-running the analysis for 16/17