### PR TITLE
[17.0][FIX] auditlog: registry propagation

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -737,7 +737,8 @@ class AuditlogRule(models.Model):
         return vals_list
 
     def _update_registry(self):
-        """Update the registry after a modification on automation rules."""
+        """Force a registry reload after rule change"""
+        # this code comes from `base_automation` which has a similar need
         if self.env.registry.ready and not self.env.context.get("import_file"):
             # notify other workers
             self.env.registry.registry_invalidated = True


### PR DESCRIPTION
When a new auditlog rule is added / modified / deleted, all workers need to be notified of the change. This is done through registry signaling. The previous code was not using the proper level of signaling resulting in workers not being aware of the changes and not implementing the correct auditlog rules, because they had only invalidated their cache and not reloaded the registry.

We fix this by using the same signaling as implemented in `base_automation` which sets the the registry_invalidated field of env.registry to True to cause a full registry reload.