### PR TITLE
[17.0][FIX] upgrade_analysis: fix constraint logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,10 @@ exclude: |
   # Ignore test files in addons
   /tests/samples/.*|
   # You don't usually want a bot to modify your legal texts
-  (LICENSE.*|COPYING.*)
+  (LICENSE.*|COPYING.*)|
+  # This folder contains patches on Odoo core which doesn't adhere to OCA's
+  # code style. Formatting/linting this leads to a much more noisy diff
+  ^upgrade_analysis/odoo_patch/odoo/
 default_language_version:
   python: python3
   node: "16.17.0"

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -1,5 +1,7 @@
 from odoo.tests import common, tagged
 
+from ..odoo_patch.odoo_patch import OdooPatch
+
 
 @tagged("post_install", "-at_install")
 class TestUpgradeAnalysis(common.TransactionCase):
@@ -44,3 +46,26 @@ class TestUpgradeAnalysis(common.TransactionCase):
 
         # TypeError: Many2many fields ir.actions.server.partner_ids and
         # ir.actions.server.partner_ids use the same table and columns
+
+    def test_odoo_patch(self):
+        """
+        Test the patched versions of Odoo's base functions
+        """
+        self.assertFalse(
+            self.env["upgrade.record"].search(
+                [
+                    ("name", "=", "base.constraint_ir_module_module_name_uniq"),
+                    ("type", "=", "xmlid"),
+                ]
+            )
+        )
+        with OdooPatch():
+            self.env["ir.model.constraint"]._reflect_model(self.IrModuleModule)
+        self.assertTrue(
+            self.env["upgrade.record"].search(
+                [
+                    ("name", "=", "base.constraint_ir_module_module_name_uniq"),
+                    ("type", "=", "xmlid"),
+                ]
+            )
+        )


### PR DESCRIPTION
In https://github.com/OCA/OpenUpgrade/pull/4606, I noticed all constraints were put down as deleted, so after some pain and misery I identified https://github.com/OCA/OCB/commit/4c9968397b0714bc90a9c94c4673bd3148db4010 as the cause of the issue, because at the point our patched function is called, the constraint exists already, so `_reflect_constraint`'s result is always falsy, and that's why we never get to log anything there.

As `log_xml_id` already takes care of not inserting duplicates, I see no harm in calling this unconditionally.