### PR TITLE
[FIX] sentry: Fix deprecated usage of text_type

### DIFF
--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk<=1.9.0",
+            "sentry_sdk",
         ]
     },
     "depends": [

--- a/sentry/logutils.py
+++ b/sentry/logutils.py
@@ -4,7 +4,6 @@
 import os.path
 import urllib.parse
 
-from sentry_sdk._compat import text_type
 from werkzeug import datastructures
 
 from .generalutils import get_environ
@@ -81,7 +80,7 @@ def fetch_git_sha(path, head=None):
             )
 
         with open(head_path, "r") as fp:
-            head = text_type(fp.read()).strip()
+            head = str(fp.read()).strip()
 
         if head.startswith("ref: "):
             head = head[5:]
@@ -110,11 +109,11 @@ def fetch_git_sha(path, head=None):
                         except ValueError:
                             continue
                         if ref == head:
-                            return text_type(revision)
+                            return str(revision)
 
         raise InvalidGitRepository(
             'Unable to find ref to head "%s" in repository' % (head,)
         )
 
     with open(revision_file) as fh:
-        return text_type(fh.read()).strip()
+        return str(fh.read()).strip()

--- a/sentry/processor.py
+++ b/sentry/processor.py
@@ -8,8 +8,6 @@ from __future__ import absolute_import
 
 import re
 
-from sentry_sdk._compat import text_type
-
 from .generalutils import string_types, varmap
 
 
@@ -53,7 +51,7 @@ class SanitizeKeysProcessor(object):
         if isinstance(item, bytes):
             item = item.decode("utf-8", "replace")
         else:
-            item = text_type(item)
+            item = str(item)
 
         item = item.lower()
         for key in self.sanitize_keys:


### PR DESCRIPTION
See original migration for reference: https://github.com/getsentry/sentry-python/commit/2d354c7e4f9536f43d64399ac749bc6218a382a0