### PR TITLE
[FIX] sentry: Fix KeyError 'with_locals' on DEFAULT_OPTIONS

### DIFF
--- a/sentry/README.rst
+++ b/sentry/README.rst
@@ -103,7 +103,7 @@ configuration file:
 Other `client arguments
 <https://docs.sentry.io/platforms/python/configuration/>`_ can be
 configured by prepending the argument name with *sentry_* in your Odoo config
-file. Currently supported additional client arguments are: ``with_locals,
+file. Currently supported additional client arguments are: ``include_local_variables,
 max_breadcrumbs, release, environment, server_name, shutdown_timeout,
 in_app_include, in_app_exclude, default_integrations, dist, sample_rate,
 send_default_pii, http_proxy, https_proxy, request_bodies, debug,

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk<=1.9.0",
+            "sentry_sdk",
         ]
     },
     "depends": [

--- a/sentry/const.py
+++ b/sentry/const.py
@@ -81,7 +81,9 @@ def get_sentry_options():
         SentryOption("dsn", "", str.strip),
         SentryOption("transport", DEFAULT_OPTIONS["transport"], select_transport),
         SentryOption("logging_level", DEFAULT_LOG_LEVEL, get_sentry_logging),
-        SentryOption("with_locals", DEFAULT_OPTIONS["with_locals"], None),
+        SentryOption(
+            "include_local_variables", DEFAULT_OPTIONS["include_local_variables"], None
+        ),
         SentryOption(
             "max_breadcrumbs", DEFAULT_OPTIONS["max_breadcrumbs"], to_int_if_defined
         ),

--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -97,6 +97,11 @@ def initialize_sentry(config):
             "Its not neccesary send it, will use `HttpTranport` by default.",
             DeprecationWarning,
         )
+    if config.get("sentry_with_locals"):
+        warnings.warn(
+            "`with_locals` has been deprecated.  "
+            "Use `include_local_variables` instead."
+        )
     options = {}
     for option in const.get_sentry_options():
         value = config.get("sentry_%s" % option.key, option.default)

--- a/sentry/readme/CONFIGURE.rst
+++ b/sentry/readme/CONFIGURE.rst
@@ -48,7 +48,7 @@ configuration file:
 Other `client arguments
 <https://docs.sentry.io/platforms/python/configuration/>`_ can be
 configured by prepending the argument name with *sentry_* in your Odoo config
-file. Currently supported additional client arguments are: ``with_locals,
+file. Currently supported additional client arguments are: ``include_local_variables,
 max_breadcrumbs, release, environment, server_name, shutdown_timeout,
 in_app_include, in_app_exclude, default_integrations, dist, sample_rate,
 send_default_pii, http_proxy, https_proxy, request_bodies, debug,

--- a/sentry/static/description/index.html
+++ b/sentry/static/description/index.html
@@ -484,7 +484,7 @@ Overridden by <em>sentry_release</em></td>
 </table>
 <p>Other <a class="reference external" href="https://docs.sentry.io/platforms/python/configuration/">client arguments</a> can be
 configured by prepending the argument name with <em>sentry_</em> in your Odoo config
-file. Currently supported additional client arguments are: <tt class="docutils literal">with_locals,
+file. Currently supported additional client arguments are: <tt class="docutils literal">include_local_variables,
 max_breadcrumbs, release, environment, server_name, shutdown_timeout,
 in_app_include, in_app_exclude, default_integrations, dist, sample_rate,
 send_default_pii, http_proxy, https_proxy, request_bodies, debug,


### PR DESCRIPTION
See original migration for reference: https://github.com/getsentry/sentry-python/commit/888c0e19e6c9b489e63b8299e41705ddf0abb080