### PR TITLE
[FIX] sentry: Fix KeyError 'request_bodies' on DEFAULT_OPTIONS

### DIFF
--- a/sentry/README.rst
+++ b/sentry/README.rst
@@ -106,7 +106,7 @@ configured by prepending the argument name with *sentry_* in your Odoo config
 file. Currently supported additional client arguments are: ``with_locals,
 max_breadcrumbs, release, environment, server_name, shutdown_timeout,
 in_app_include, in_app_exclude, default_integrations, dist, sample_rate,
-send_default_pii, http_proxy, https_proxy, request_bodies, debug,
+send_default_pii, http_proxy, https_proxy, max_request_body_size, debug,
 attach_stacktrace, ca_certs, propagate_traces, traces_sample_rate,
 auto_enabling_integrations``.
 

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk<=1.9.0",
+            "sentry_sdk",
         ]
     },
     "depends": [

--- a/sentry/const.py
+++ b/sentry/const.py
@@ -107,7 +107,9 @@ def get_sentry_options():
         SentryOption("http_proxy", DEFAULT_OPTIONS["http_proxy"], None),
         SentryOption("https_proxy", DEFAULT_OPTIONS["https_proxy"], None),
         SentryOption("ignore_exceptions", DEFAULT_IGNORED_EXCEPTIONS, split_multiple),
-        SentryOption("request_bodies", DEFAULT_OPTIONS["request_bodies"], None),
+        SentryOption(
+            "max_request_body_size", DEFAULT_OPTIONS["max_request_body_size"], None
+        ),
         SentryOption("attach_stacktrace", DEFAULT_OPTIONS["attach_stacktrace"], None),
         SentryOption("ca_certs", DEFAULT_OPTIONS["ca_certs"], None),
         SentryOption("propagate_traces", DEFAULT_OPTIONS["propagate_traces"], None),

--- a/sentry/readme/CONFIGURE.rst
+++ b/sentry/readme/CONFIGURE.rst
@@ -51,7 +51,7 @@ configured by prepending the argument name with *sentry_* in your Odoo config
 file. Currently supported additional client arguments are: ``with_locals,
 max_breadcrumbs, release, environment, server_name, shutdown_timeout,
 in_app_include, in_app_exclude, default_integrations, dist, sample_rate,
-send_default_pii, http_proxy, https_proxy, request_bodies, debug,
+send_default_pii, http_proxy, https_proxy, max_request_body_size, debug,
 attach_stacktrace, ca_certs, propagate_traces, traces_sample_rate,
 auto_enabling_integrations``.
 

--- a/sentry/static/description/index.html
+++ b/sentry/static/description/index.html
@@ -487,7 +487,7 @@ configured by prepending the argument name with <em>sentry_</em> in your Odoo co
 file. Currently supported additional client arguments are: <tt class="docutils literal">with_locals,
 max_breadcrumbs, release, environment, server_name, shutdown_timeout,
 in_app_include, in_app_exclude, default_integrations, dist, sample_rate,
-send_default_pii, http_proxy, https_proxy, request_bodies, debug,
+send_default_pii, http_proxy, https_proxy, max_request_body_size, debug,
 attach_stacktrace, ca_certs, propagate_traces, traces_sample_rate,
 auto_enabling_integrations</tt>.</p>
 <div class="section" id="example-odoo-configuration">


### PR DESCRIPTION
See original migration for reference: https://github.com/getsentry/sentry-python/commit/2b1d1cc092657ff84a0e92154ac2196a9ef795e4