### PR TITLE
[FIX] sentry: Fix DeprecationWarning for sentry_sdk.push_scope

### DIFF
--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk<=1.9.0",
+            "sentry_sdk",
         ]
     },
     "depends": [

--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -142,7 +142,7 @@ def initialize_sentry(config):
     # Patch the wsgi server in case of further registration
     odoo.http.Application = SentryWsgiMiddleware(odoo.http.Application)
 
-    with sentry_sdk.push_scope() as scope:
+    with sentry_sdk.new_scope() as scope:
         scope.set_extra("debug", False)
         sentry_sdk.capture_message("Starting Odoo Server", "info")
 


### PR DESCRIPTION
See: https://docs.sentry.io/platforms/python/migration/1.x-to-2.x\#scope-pushing