### PR TITLE
[FIX] module_analysis: don't import twice ir.cron

### DIFF
--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -24,7 +24,6 @@
         "data/ir_config_parameter.xml",
         "data/ir_module_type.xml",
         "data/ir_module_type_rule.xml",
-        "data/ir_cron.xml",
     ],
     "external_dependencies": {
         "python": ["pygount"],


### PR DESCRIPTION
trivial PR. fix V16 migration https://github.com/OCA/server-tools/pull/2609

```
WARNING DATABASE odoo.modules.loading: File data/ir_cron.xml is imported twice in module module_analysis data 
```

CC : @florian-dacosta 