### PR TITLE
[17.0][FIX] tracking_manager: Fix test related to ir.actions.act_window

### DIFF
--- a/tracking_manager/tests/test_tracking_manager.py
+++ b/tracking_manager/tests/test_tracking_manager.py
@@ -194,20 +194,12 @@ class TestTrackingManager(TransactionCase):
         self.assertEqual(self.messages.body.count("Changed"), 1)
 
     def test_o2m_update_m2o_indirectly(self):
+        user = self.partner.user_ids[0]
+        action = self.env["ir.actions.act_window"].create(
+            {"name": "test", "type": "ir.actions.act_window", "res_model": user._name}
+        )
         self.partner.write(
-            {
-                "user_ids": [
-                    (
-                        Command.UPDATE,
-                        self.partner.user_ids[0].id,
-                        {
-                            "action_id": self.env["ir.actions.actions"]
-                            .create({"name": "test", "type": "ir.actions.act_window"})
-                            .id
-                        },
-                    ),
-                ]
-            }
+            {"user_ids": [(Command.UPDATE, user.id, {"action_id": action.id})]}
         )
         self.assertEqual(len(self.messages), 1)
         self.assertEqual(self.messages.body.count("Changed"), 1)


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/server-tools/pull/3112

Related to https://github.com/odoo/odoo/commit/cac20c5f2f0da7be6a75bd1281d528df7f34bfe6

Now it is necessary to have an `ir.actions.act_window` record

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa