### PR TITLE
attachment_delete_restrict: fix domain for showing custom group/user

### DIFF
--- a/attachment_delete_restrict/views/ir_model_views.xml
+++ b/attachment_delete_restrict/views/ir_model_views.xml
@@ -11,7 +11,7 @@
                         <field name="restrict_delete_attachment" />
                     </group>
                     <group
-                        attrs="{'invisible': [('restrict_delete_attachment','not in',['custom', 'restrict_custom'])]}"
+                        attrs="{'invisible': [('restrict_delete_attachment','not in',['custom', 'owner_custom'])]}"
                     >
                         <field
                             name="delete_attachment_group_ids"


### PR DESCRIPTION
The issue was introduced in the following commit: 935068b

@Kev-Roche 