### PR TITLE
[16.0][IMP] excel_import_export_demo: add hooks

### DIFF
--- a/excel_import_export_demo/__init__.py
+++ b/excel_import_export_demo/__init__.py
@@ -5,3 +5,4 @@ from . import import_export_sale_order
 from . import report_sale_order
 from . import report_crm_lead
 from . import report_action
+from .hooks import post_init_hook

--- a/excel_import_export_demo/__manifest__.py
+++ b/excel_import_export_demo/__manifest__.py
@@ -30,6 +30,7 @@
         "report_action/partner_list/report_partner_list.xml",
         "report_action/partner_list/security/ir.model.access.csv",
     ],
+    "post_init_hook": "post_init_hook",
     "installable": True,
     "development_status": "Beta",
     "maintainers": ["kittiu"],

--- a/excel_import_export_demo/hooks.py
+++ b/excel_import_export_demo/hooks.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    templates = env["xlsx.template"].search([("export_ids", "!=", False)])
+    for template in templates:
+        template.add_export_action()

--- a/excel_import_export_demo/import_export_purchase_order/actions.xml
+++ b/excel_import_export_demo/import_export_purchase_order/actions.xml
@@ -4,21 +4,6 @@
   License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).-->
 <odoo>
 
-    <record id="action_purchase_order_export_xlsx" model="ir.actions.act_window">
-        <field name="name">Export Excel</field>
-        <field name="res_model">export.xlsx.wizard</field>
-        <field name="binding_view_types">form</field>
-        <field name="view_mode">form</field>
-        <field name="target">new</field>
-        <field name="context">
-            {
-                'template_domain': [('res_model', '=', 'purchase.order'),
-                                    ('fname', '=', 'purchase_order.xlsx'),
-                                    ('gname', '=', False)],
-            }
-        </field>
-    </record>
-
     <record id="action_purchase_order_import_xlsx" model="ir.actions.act_window">
         <field name="name">Import Excel</field>
         <field name="res_model">import.xlsx.wizard</field>

--- a/excel_import_export_demo/import_export_purchase_order/templates.xml
+++ b/excel_import_export_demo/import_export_purchase_order/templates.xml
@@ -12,10 +12,6 @@
             name="import_action_id"
             eval="ref('action_purchase_order_import_xlsx')"
         />
-        <field
-            name="export_action_id"
-            eval="ref('action_purchase_order_export_xlsx')"
-        />
         <field name="input_instruction">
             {
                 '__EXPORT__': {

--- a/excel_import_export_demo/import_export_sale_order/actions.xml
+++ b/excel_import_export_demo/import_export_sale_order/actions.xml
@@ -3,23 +3,6 @@
   Copyright 2019 Ecosoft Co., Ltd.
   License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).-->
 <odoo>
-
-    <record id="action_sale_oder_export_xlsx" model="ir.actions.act_window">
-        <field name="name">Export Excel</field>
-        <field name="res_model">export.xlsx.wizard</field>
-        <field name="binding_view_types">list,form</field>
-        <field name="binding_model_id" ref="sale.model_sale_order" />
-        <field name="view_mode">form</field>
-        <field name="target">new</field>
-        <field name="context">
-            {
-                'template_domain': [('res_model', '=', 'sale.order'),
-                                    ('fname', '=', 'sale_order.xlsx'),
-                                    ('gname', '=', False)],
-            }
-        </field>
-    </record>
-
     <record id="action_sale_oder_import_xlsx" model="ir.actions.act_window">
         <field name="name">Import Excel</field>
         <field name="res_model">import.xlsx.wizard</field>
@@ -37,5 +20,4 @@
             }
         </field>
     </record>
-
 </odoo>

--- a/excel_import_export_demo/import_export_sale_order/templates.xml
+++ b/excel_import_export_demo/import_export_sale_order/templates.xml
@@ -8,8 +8,7 @@
         <field name="fname">sale_order.xlsx</field>
         <field name="name">Sale Order Template (import/export)</field>
         <field name="description">Sample Sales Order Template for testing</field>
-        <field name="import_action_id" eval="ref('action_sale_oder_export_xlsx')" />
-        <field name="export_action_id" eval="ref('action_sale_oder_import_xlsx')" />
+        <field name="import_action_id" eval="ref('action_sale_oder_import_xlsx')" />
         <field name="input_instruction">
             {
                 '__EXPORT__': {


### PR DESCRIPTION
This PR uses the excel_import_export method to generate export actions dynamically, replacing static definitions. It also reflects changes from [OCA/server-tools#3114](https://github.com/OCA/server-tools/pull/3114).

@qrtl QT4973