### PR TITLE
[16.0][UPD][FIX] tracking_manager: specific O2M fields notify

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -49,13 +49,22 @@ class Base(models.AbstractModel):
         )
         for field_name, owner_field_name in self._tm_get_fields_to_notify():
             owner = self[field_name]
-            data[owner._name][owner.id][owner_field_name].append(
-                {
-                    "mode": mode,
-                    "record": self.display_name,
-                    "changes": changes,
-                }
-            )
+            model_name = target_id = False
+            if isinstance(owner, models.BaseModel):
+                model_name = owner._name
+                target_id = owner.id
+            # In case of specific O2M (ex: ir.attachment with res_id)
+            elif isinstance(owner, int) and hasattr(self, "res_model"):
+                model_name = self.res_model
+                target_id = owner
+            if model_name and target_id:
+                data[model_name][target_id][owner_field_name].append(
+                    {
+                        "mode": mode,
+                        "record": self.display_name,
+                        "changes": changes,
+                    }
+                )
 
     def _tm_get_field_description(self, field_name):
         return self._fields[field_name].get_description(self.env)["string"]


### PR DESCRIPTION
In some case, we may have some unconventionals O2M like on `ir.attachment`. The O2M relation is done on `res_id` value. This commit take them in consideration and avoid a traceback.

**How to reproduce:**
Just add a dynamic track on attachment_ids (example on `account.move`).
Then add an attachment on the `account.move`: you should see a new message into the chatter (that works perfectly)
Finally, remove this attachment: without this PR, you should see a traceback into logs. But with this PR, you should see a new message (about the unlink) in the chatter.

![image](https://github.com/user-attachments/assets/13c24069-5050-4cac-8164-ce42af436043)
