### PR TITLE
[15.0][FIX] upgrade_analysis: new modules cannot be merged/renamed in same version

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -532,7 +532,16 @@ class UpgradeAnalysis(models.Model):
 
         module_domain = [
             ("state", "=", "installed"),
-            ("name", "not in", ["upgrade_analysis", "openupgrade_records"]),
+            (
+                "name",
+                "not in",
+                [
+                    "upgrade_analysis",
+                    "openupgrade_records",
+                    "openupgrade_scripts",
+                    "openupgrade_framework",
+                ],
+            ),
         ]
 
         connection = self.config_id.get_connection()

--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -552,16 +552,19 @@ class UpgradeAnalysis(models.Model):
         module_descriptions = {}
         for module in all_modules:
             status = ""
+            is_new = False
             if module in all_local_modules and module in all_remote_modules:
                 module_description = " %s" % module
             elif module in all_local_modules:
                 module_description = " |new| %s" % module
+                is_new = True
             else:
                 module_description = " |del| %s" % module
 
-            if module in compare.apriori.merged_modules:
+            # new modules cannot be merged/renamed in same version
+            if not is_new and module in compare.apriori.merged_modules:
                 status = "Merged into %s. " % compare.apriori.merged_modules[module]
-            elif module in compare.apriori.renamed_modules:
+            elif not is_new and module in compare.apriori.renamed_modules:
                 status = "Renamed to %s. " % compare.apriori.renamed_modules[module]
             elif module in compare.apriori.renamed_modules.values():
                 status = (


### PR DESCRIPTION
**Explanation of first commit:** v14 has OCA's `10n_eu_oss` (https://github.com/OCA/account-fiscal-rule/tree/14.0/l10n_eu_oss), which is renamed in v15 to `l10n_eu_oss_oca` (https://github.com/OCA/account-fiscal-rule/tree/15.0/l10n_eu_oss_oca) due to new module Odoo's `10n_eu_oss` (https://github.com/odoo/odoo/tree/15.0/addons/l10n_eu_oss). Thus, it doesn't makes sense to have in the coverage file the row `|[new] 10n_eu_oss | |Renamed to l10n_eu_oss_oca|`.

Second commit it's obvious, we don't want OU modules appearing in the coverage file.