### PR TITLE
[16.0][FIX] auditlog: clear cache in test

### DIFF
--- a/auditlog/tests/test_multi_company.py
+++ b/auditlog/tests/test_multi_company.py
@@ -83,6 +83,7 @@ class TestMultiCompany(TransactionCase):
         # Do the write.
         with patch.object(Groups, "write", side_effect=write, autospec=True):
             group_with_user.write({"users": [Command.set(self.user2.ids)]})
+        self.group.invalidate_recordset(["users"])
         self.assertEqual(group_with_user.users, self.user2)
         # Ensure that the users of the other companies are still there.
         self.env.invalidate_all()


### PR DESCRIPTION
since https://github.com/OCA/OCB/commit/7f52166b8b3e04d7af36f127b9514ba3f557eb5c, we have another override of `res.groups#write`, so I suggest to patch the class as the ORM knows it, and be sure we call `BaseModel.write`