### PR TITLE
[16.0][FIX] auditlog: patch away all write overrides in res.groups for test

### DIFF
--- a/auditlog/tests/test_multi_company.py
+++ b/auditlog/tests/test_multi_company.py
@@ -1,9 +1,8 @@
 from unittest.mock import patch
 
 from odoo.fields import Command
+from odoo.models import BaseModel
 from odoo.tests.common import TransactionCase
-
-from odoo.addons.base.models.res_users import Groups
 
 
 class TestMultiCompany(TransactionCase):
@@ -78,10 +77,12 @@ class TestMultiCompany(TransactionCase):
             present in the cache at this point, leading to the deletion of the
             value from the company that is inaccessible to the current user.
             """
-            return super(Groups, self).write(vals)
+            return BaseModel.write(self, vals)
 
         # Do the write.
-        with patch.object(Groups, "write", side_effect=write, autospec=True):
+        with patch.object(
+            self.env["res.groups"].__class__, "write", side_effect=write, autospec=True
+        ):
             group_with_user.write({"users": [Command.set(self.user2.ids)]})
         self.assertEqual(group_with_user.users, self.user2)
         # Ensure that the users of the other companies are still there.


### PR DESCRIPTION
since https://github.com/OCA/OCB/commit/7f52166b8b3e04d7af36f127b9514ba3f557eb5c, we have another override of `res.groups#write` that messes with the cache, so I suggest to patch the class as the ORM knows it, and be sure we call `BaseModel.write`