### PR TITLE
[16.0][FIX] onchange_helper: Do not overwrite precomputed fields

### DIFF
--- a/onchange_helper/models/base.py
+++ b/onchange_helper/models/base.py
@@ -53,6 +53,15 @@ class Base(models.AbstractModel):
             if field not in all_values:
                 all_values[field] = record_values.get(field, False)
 
+        if not self:
+            # Precomputed fields will be computed just before creation
+            # and should not be overwritten by changed values
+            all_values = {
+                field_name: all_values[field_name]
+                for field_name in all_values
+                if not self._fields[field_name].precompute
+            }
+
         new_values = {}
         for field in onchange_fields:
             onchange_values = self.onchange(all_values, field, onchange_specs)

--- a/onchange_helper/models/base.py
+++ b/onchange_helper/models/base.py
@@ -21,19 +21,19 @@ class Base(models.AbstractModel):
         return new_values
 
     @api.model
-    def play_onchanges(self, values, onchange_fields):
+    def play_onchanges(self, values, onchange_fields, view_info=None):
         """
         :param values: dict of input value that
         :param onchange_fields: fields for which onchange methods will be
-        played
+            played
+        :param view_info: view containing the fields that should change,
+            as returned by `get_view`
+
         Order in onchange_fields is very important as onchanges methods will
         be played in that order.
         :return: changed values
         """
-        # _onchange_spec() will return onchange fields from the default view
-        # we need all fields in the dict even the empty ones
-        # otherwise 'onchange()' will not apply changes to them
-        onchange_specs = {field_name: "1" for field_name, field in self._fields.items()}
+        onchange_specs = self._onchange_spec(view_info=view_info)
         all_values = values.copy()
         # If self is a record (play onchange on existing record)
         # we take the value of the field
@@ -49,6 +49,8 @@ class Base(models.AbstractModel):
         else:
             # We get default values, they may be used in onchange
             record_values = self.default_get(self._fields.keys())
+        # we need all fields in the dict even the empty ones
+        # otherwise 'onchange()' will not apply changes to them
         for field in self._fields:
             if field not in all_values:
                 all_values[field] = record_values.get(field, False)


### PR DESCRIPTION
**Steps**:

1. Install `sale_management`
2. Create a product template `product`
3. Create a pricelist with `discount_policy = without_discount`, with a rule for the created product
4. Create a sale order `order`
5. In the Python code, play the onchanges for `product_id` for a new line having values:
    ```py
    {
        "order_id": order.id,
        "product_id": product.id,
    }
    ```

**Observed behavior**:
Error

<details><summary>Details</summary>
<pre>
File "/home/odoo/src/user/OCA/server-tools/onchange_helper/models/base.py", line 58, in play_onchanges
    onchange_values = self.onchange(all_values, field, onchange_specs)
  File "/home/odoo/src/odoo/odoo/models.py", line 6622, in onchange
    todo = [
  File "/home/odoo/src/odoo/odoo/models.py", line 6625, in <listcomp>
    if name not in done and snapshot0.has_changed(name)
  File "/home/odoo/src/odoo/odoo/models.py", line 6408, in has_changed
    return self[name] != record[name]
  File "/home/odoo/src/odoo/odoo/models.py", line 5957, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/home/odoo/src/odoo/odoo/fields.py", line 1158, in __get__
    self.recompute(record)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1370, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1343, in apply_except_missing
    func(records)
  File "/home/odoo/src/odoo/odoo/fields.py", line 1392, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/odoo/models.py", line 4241, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/odoo/fields.py", line 98, in determine
    return needle(*args)
  File "/home/odoo/src/user/OCA/sale-workflow/sale_pricelist_triple_discount/model/sale.py", line 29, in compute_discount
    res = super()._compute_discount()
  File "/home/odoo/src/odoo/addons/sale/models/sale_order_line.py", line 583, in _compute_discount
    base_price = line._get_pricelist_price_before_discount()
  File "/home/odoo/src/odoo/addons/sale/models/sale_order_line.py", line 551, in _get_pricelist_price_before_discount
    price = pricelist_rule._compute_base_price(
  File "/home/odoo/src/odoo/addons/product/models/product_pricelist_item.py", line 422, in _compute_base_price
    target_currency.ensure_one()
  File "/home/odoo/src/odoo/odoo/models.py", line 5186, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: res.currency()
</pre>
</details> 

**Expected behavior**:
The order line is created

**Additional context**:
I could not add a test case for this module due to the complexity of sale model and precomputed fields, even using fake models of https://github.com/OCA/odoo-test-helper, any suggestion is appreciated.
The only test case I managed to create is in https://github.com/OCA/product-configurator/pull/145.