### PR TITLE
[FIX] auditlog: adapt exclude fields test to #3137

### DIFF
--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -543,9 +543,7 @@ class AuditLogRuleTestForUserFields(TransactionCase):
     def test_02_AuditlogFull_field_exclude_write_log(self):
         # Checking fields_to_exclude_ids
         self.testpartner1.with_context(tracking_disable=True).write(
-            {
-                "phone": "1234567890",
-            }
+            {"phone": "1234567890", "name": "abc"}
         )
         # Checking log is created for testpartner1
         write_log_record = self.auditlog_log.search(


### PR DESCRIPTION
In #3137 it is prevented to create auditlogs without log lines.
    
In this particular test, it is tested that no log line is created for excluded fields. We would expect therefore that no auditlog is created after #3137, but depending on the setup, an log line may be created for field `phone_sanitized` which is not an excluded field in the test.
    
To fix this, the test is adapted to write another, non excluded field so that the auditlog is created in any case.

Fixes
```
 2024-12-21 09:28:41,268 260 ERROR odoo odoo.addons.auditlog.tests.test_auditlog: ERROR: AuditLogRuleTestForUserFields.test_02_AuditlogFull_field_exclude_write_log
Traceback (most recent call last):
  File "/opt/odoo/odoo/models.py", line 6209, in ensure_one
    _id, = self._ids
ValueError: not enough values to unpack (expected 1, got 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/server-tools/server-tools/auditlog/tests/test_auditlog.py", line 557, in test_02_AuditlogFull_field_exclude_write_log
    ).ensure_one()
  File "/opt/odoo/odoo/models.py", line 6212, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: auditlog.log()
```

Backported from https://github.com/OCA/server-tools/pull/3054 by @lembregtse 