### PR TITLE
[FIX] odoo_test_xmlrunner: set auto_install to False.

### DIFF
--- a/odoo_test_xmlrunner/README.rst
+++ b/odoo_test_xmlrunner/README.rst
@@ -179,13 +179,13 @@ Authors
 Other credits
 -------------
 
-- `Smile <https://smile.eu/fr>`__:
+-  `Smile <https://smile.eu/fr>`__:
 
-  - Martin Deconinck martin.deconinck@smile.fr
+   -  Martin Deconinck martin.deconinck@smile.fr
 
-- `Akretion <https://akretion.com>`__:
+-  `Akretion <https://akretion.com>`__:
 
-  - Florian Mounier florian.mounier@akretion.com
+   -  Florian Mounier florian.mounier@akretion.com
 
 Maintainers
 -----------

--- a/odoo_test_xmlrunner/__manifest__.py
+++ b/odoo_test_xmlrunner/__manifest__.py
@@ -10,7 +10,6 @@
     "website": "https://github.com/OCA/server-tools",
     "category": "Tools",
     "sequence": 20,
-    "auto_install": True,
     "installable": True,
     "application": False,
     "external_dependencies": {


### PR DESCRIPTION
- It doesn't make sense to make this module auto installable.
- As the module depends only on 'base' AND introduces a new external dependency to an extra library (unittest-xml-reporting) all the instances that are cloning server-tools repo will have trouble, because it will not be possible to install this module, due to missing dependency

V16 Fix of https://github.com/OCA/server-tools/issues/3156