### PR TITLE
[16.0][FIX] fetchmail_attach_from_folder: be able to open form view even when connection fails

### DIFF
--- a/fetchmail_attach_from_folder/models/fetchmail_server.py
+++ b/fetchmail_attach_from_folder/models/fetchmail_server.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -30,7 +31,11 @@ class FetchmailServer(models.Model):
             if this.state != "done":
                 this.folders_available = _("Confirm connection first.")
                 continue
-            connection = this.connect()
+            try:
+                connection = this.connect()
+            except UserError:
+                this.folders_available = _("Confirm connection first.")
+                continue
             list_result = connection.list()
             if list_result[0] != "OK":
                 this.folders_available = _("Unable to retrieve folders.")


### PR DESCRIPTION
Background: on Outlook servers and possibly on other providers as well, connect can fail with a UserError. Before this fix this results in the form view not being able to open because the compute cannot complete. This fixes that, so that the connection error may be resolved by the user.