### PR TITLE
[18.0][FIX] base_cron_exclusion: remove numbercall condition from ir_cron select clause

### DIFF
--- a/base_cron_exclusion/models/ir_cron.py
+++ b/base_cron_exclusion/models/ir_cron.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ class IrCron(models.Model):
         for item in self:
             if item in item.mutually_exclusive_cron_ids:
                 raise ValidationError(
-                    _(
+                    self.env._(
                         "You can not mutually exclude a scheduled actions with "
                         "itself."
                     )

--- a/base_cron_exclusion/models/ir_cron.py
+++ b/base_cron_exclusion/models/ir_cron.py
@@ -50,8 +50,7 @@ class IrCron(models.Model):
             lock_cr.execute(
                 """SELECT *
                                FROM ir_cron
-                               WHERE numbercall != 0
-                                  AND active
+                               WHERE active
                                   AND id IN %s
                                FOR UPDATE NOWAIT""",
                 (locked_ids,),


### PR DESCRIPTION
- `numbercall` and `doall` have been removed in commit https://github.com/odoo/odoo/pull/151628/commits/3a9949ad, but in the process of moving to version 18.0 in this PR I missed this change. https://github.com/OCA/server-tools/pull/3059
- also take this opportunity to replace `_` with `self.env._` to improve the old PR above