### PR TITLE
[FIX] base_multi_image: Attribute Error

### DIFF
--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -88,12 +88,10 @@ class Image(models.Model):
             # Retrieve from remote url
             self.image_1920 = self._get_image_from_url(self.load_from)
             filename = self.load_from.split("/")[-1]
-            self.name, self.extension = os.path.splitext(filename)
+            self.name = os.path.splitext(filename)[0]
         else:
             self.image_1920 = self._get_image_from_file(self.load_from)
-            self.name, self.extension = os.path.splitext(
-                os.path.basename(self.load_from)
-            )
+            self.name = os.path.splitext(os.path.basename(self.load_from))[0]
         self.name = self._make_name_pretty(self.name)
         self.load_from = False
 
@@ -185,5 +183,5 @@ class Image(models.Model):
     @api.onchange("filename")
     def _onchange_filename(self):
         if self.filename:
-            self.name, self.extension = os.path.splitext(self.filename)
+            self.name = os.path.splitext(self.filename)[0]
             self.name = self._make_name_pretty(self.name)


### PR DESCRIPTION
This commit fixes AttributeError: 'base_multi_image.image' object has no attribute 'extension'. 

Since the `extension`  field was removed https://github.com/OCA/server-tools/pull/3010/commits/42c3340aa41c0cec973492616a8f0e7c7679604e#diff-5999d8a619a1bfa837c89c3c06f91d8a6f48b27a36d8bc08aaa08733987e149bL51 but the functionality continued to use this field, we were catching an error when trying to upload images using the url.

![image](https://github.com/user-attachments/assets/09d15d9c-5384-48b3-97b9-e9aaa8634a96)
