### PR TITLE
[18.0][IMP] upgrade_analysis: don't depend on mako

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # generated from manifests external_dependencies
 astor
 dataclasses
-mako
 odoorpc
 openupgradelib

--- a/upgrade_analysis/__manifest__.py
+++ b/upgrade_analysis/__manifest__.py
@@ -22,7 +22,7 @@
     "installable": True,
     "depends": ["base"],
     "external_dependencies": {
-        "python": ["mako", "dataclasses", "odoorpc", "openupgradelib"],
+        "python": ["dataclasses", "odoorpc", "openupgradelib"],
     },
     "license": "AGPL-3",
 }

--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -10,7 +10,6 @@ import os
 from copy import deepcopy
 
 from lxml import etree
-from mako.template import Template
 
 from odoo import fields, models, release
 from odoo.exceptions import ValidationError
@@ -519,15 +518,6 @@ class UpgradeAnalysis(models.Model):
         if not module_coverage_file_folder:
             return
 
-        file_template = Template(
-            filename=os.path.join(
-                get_module_path("upgrade_analysis"),
-                "static",
-                "src",
-                "module_coverage_template.rst.mako",
-            )
-        )
-
         module_domain = [
             ("state", "=", "installed"),
             (
@@ -587,10 +577,13 @@ class UpgradeAnalysis(models.Model):
                 49, " "
             )
 
-        rendered_text = file_template.render(
-            start_version=start_version,
-            end_version=end_version,
-            module_descriptions=module_descriptions,
+        rendered_text = self.env["ir.qweb"]._render(
+            "upgrade_analysis.module_coverage",
+            values=dict(
+                start_version=start_version,
+                end_version=end_version,
+                module_descriptions=module_descriptions,
+            ),
         )
 
         file_name = "modules{}-{}.rst".format(

--- a/upgrade_analysis/templates/module_coverage_template.xml
+++ b/upgrade_analysis/templates/module_coverage_template.xml
@@ -1,4 +1,7 @@
-Module coverage ${start_version} -> ${end_version}
+<odoo>
+    <template id="module_coverage">Module coverage <t t-out="start_version" /> -> <t
+        t-out="end_version"
+    />
 ============================
 
 .. include:: coverage_legend.rst
@@ -6,7 +9,9 @@ Module coverage ${start_version} -> ${end_version}
 +---------------------------------------------------+----------------------+-------------------------------------------------+
 | Module                                            | Status               + Extra Information                               |
 +===================================================+======================+=================================================+
-% for module, extra_information in module_descriptions.items():
-|${module}|                      |${extra_information}|
+<t t-foreach="module_descriptions" t-as="module">
+|<t t-out="module" />|                      |<t t-out="module_value" />|
 +---------------------------------------------------+----------------------+-------------------------------------------------+
-% endfor
+</t>
+</template>
+</odoo>


### PR DESCRIPTION
given Odoo doesn't depend on mako any more and we have a perfectly fine templating engine built in, I propose to use that instead. The [coverage file](https://github.com/OCA/OpenUpgrade/pull/4709/files#diff-132041309318d21efdc12b1ef17729252c28b0ec8a6a66027f06c3c76d3e0cde) of the v18 migration has been created with this