### PR TITLE
[18.0][ADD] upgrade_analysis: be more helpful for v18 property conversion

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -139,7 +139,10 @@ def report_generic(new, old, attrs, reprs):
         elif attr == "stored":
             if old[attr] != new[attr]:
                 if new["stored"]:
-                    text = "is now stored"
+                    if new.get("isproperty") and old.get("isproperty"):
+                        text = "needs conversion to v18-style company dependent"
+                    else:
+                        text = "is now stored"
                 else:
                     text = "not stored anymore"
                 fieldprint(old, new, "", text, reprs)


### PR DESCRIPTION
given the global change of how properties work in v18, it's helpful to see what to do in the analysis file already. The change looks like [that](https://github.com/OCA/OpenUpgrade/pull/4709/commits/5409ce0867c7821a9231c85f798d5d162060ca42) in the analysis file