### PR TITLE
[17.0][IMP] tracking_manager: add field type html support

### DIFF
--- a/tracking_manager/models/__init__.py
+++ b/tracking_manager/models/__init__.py
@@ -2,3 +2,4 @@ from . import mail_thread
 from . import ir_model
 from . import ir_model_fields
 from . import models
+from . import mail_tracking_value

--- a/tracking_manager/models/mail_tracking_value.py
+++ b/tracking_manager/models/mail_tracking_value.py
@@ -1,0 +1,27 @@
+from odoo import api, models
+from odoo.tools import html2plaintext
+
+
+class MailTracking(models.Model):
+    _inherit = "mail.tracking.value"
+
+    @api.model
+    def _create_tracking_values(
+        self, initial_value, new_value, col_name, col_info, record
+    ):
+        try:
+            return super()._create_tracking_values(
+                initial_value, new_value, col_name, col_info, record
+            )
+        except NotImplementedError:
+            if col_info["type"] == "html":
+                field = self.env["ir.model.fields"]._get(record._name, col_name)
+                values = {"field_id": field.id}
+                values.update(
+                    {
+                        "old_value_char": html2plaintext(initial_value) or "",
+                        "new_value_char": html2plaintext(new_value) or "",
+                    }
+                )
+                return values
+            raise

--- a/tracking_manager/tests/__init__.py
+++ b/tracking_manager/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_tracking_manager
+from . import test_mail_tracking_value

--- a/tracking_manager/tests/test_mail_tracking_value.py
+++ b/tracking_manager/tests/test_mail_tracking_value.py
@@ -1,0 +1,22 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestMailTracking(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.MailTracking = cls.env["mail.tracking.value"]
+
+    def test_create_tracking_values_html(self):
+        initial_value = "<p>Initial Value</p>"
+        new_value = "<p>New Value</p>"
+        col_name = "comment"
+        col_info = {"type": "html"}
+        record = self.env["res.partner"].create({"name": "Test Partner"})
+
+        values = self.MailTracking._create_tracking_values(
+            initial_value, new_value, col_name, col_info, record
+        )
+
+        self.assertEqual(values["old_value_char"], "Initial Value")
+        self.assertEqual(values["new_value_char"], "New Value")


### PR DESCRIPTION
tracking_manager enables the user to activate tracking on html fields. This leads to an error message:
![image](https://github.com/user-attachments/assets/51050c80-1c27-44eb-87bd-9aeadae6d8e2)


