### PR TITLE
[FIX] sentry: add compatibility with sentry-sdk from debian bullseye repository

### DIFF
--- a/sentry/const.py
+++ b/sentry/const.py
@@ -77,7 +77,7 @@ def get_sentry_logging(level=DEFAULT_LOG_LEVEL):
 
 
 def get_sentry_options():
-    return [
+    res = [
         SentryOption("dsn", "", str.strip),
         SentryOption("transport", DEFAULT_OPTIONS["transport"], select_transport),
         SentryOption("logging_level", DEFAULT_LOG_LEVEL, get_sentry_logging),
@@ -116,9 +116,15 @@ def get_sentry_options():
             DEFAULT_OPTIONS["traces_sample_rate"],
             to_float_if_defined,
         ),
-        SentryOption(
-            "auto_enabling_integrations",
-            DEFAULT_OPTIONS["auto_enabling_integrations"],
-            None,
-        ),
     ]
+
+    if "auto_enabling_integrations" in DEFAULT_OPTIONS:
+        res.append(
+            SentryOption(
+                "auto_enabling_integrations",
+                DEFAULT_OPTIONS["auto_enabling_integrations"],
+                None,
+            )
+        )
+
+    return res


### PR DESCRIPTION
Debian Bullseye is used as base docker image for odoo:15.0