### PR TITLE
[16.0][FIX] session_db: Fix creation of postgres_uri in tests

### DIFF
--- a/session_db/tests/test_pg_session_store.py
+++ b/session_db/tests/test_pg_session_store.py
@@ -11,11 +11,11 @@ from odoo.addons.session_db.pg_session_store import PGSessionStore
 
 
 def _make_postgres_uri(
-    login=None, password=None, host=None, port=None, database=None, **kwargs
+    user=None, password=None, host=None, port=None, database=None, **kwargs
 ):
     uri = ["postgres://"]
-    if login:
-        uri.append(login)
+    if user:
+        uri.append(user)
         if password:
             uri.append(f":{password}")
         uri.append("@")
@@ -80,3 +80,15 @@ class TestPGSessionStore(TransactionCase):
             assert mock_execute.call_count == 1
         # when the error is resolved, it works again
         self.session_store.get("abc")
+
+    def test_make_postgres_uri(self):
+        connection_info = {
+            "host": "localhost",
+            "port": 5432,
+            "database": "test",
+            "user": "test",
+            "password": "PASSWORD",
+        }
+        assert "postgres://test:PASSWORD@localhost:5432/test" == _make_postgres_uri(
+            **connection_info
+        )


### PR DESCRIPTION
with the parameter "login" in `_make_postgres_uri()` it becomes impossible to log in with the configured database, as it has to have the name "user". This is because of passing the `connection_info` dict as keywords parameter into the function. But because `connection_info_for` called in `setUp()` reads the config file of odoo and there the database user is `db_user` the keyword parameter is discarded and `login` is not set. The `db_`-prefix is removed. So user and password are not applied to the uri/dsn and thus login to the database is not possible, if the database wants those parameters.

When I applied this change in our internal CI of solute.de, everything worked fine afterwards.

This has to be ported to 17.0 and 18.0 as well.