### PR TITLE
[IMP] views_migration_17: support alternative output directory for transformed views instead of in-place write

### DIFF
--- a/views_migration_17/README.rst
+++ b/views_migration_17/README.rst
@@ -37,7 +37,17 @@ This module is not installable, to use this module, you need to:
   odoo -d DATABASE_NAME -i MODULE_TO_MIGRATE --load=base,web,views_migration_17 --stop-after-init
 
 
-2. If success the modifications will be in the source code of your module.
+2. If successful, the modifications will be applied to the source code of your module. Alternatively, you can set the environment variable `VIEWS_MIGRATION_17_OUTPUT_DIR` to specify a different output directory for the modified views. Ensure that the user running the Odoo process has the appropriate permissions for the specified path.
+
+.. code-block:: shell
+
+  export VIEWS_MIGRATION_17_OUTPUT_DIR=/path/to/output/directory
+
+Example in a [doodba-copier-template](https://github.com/Tecnativa/doodba-copier-template) project:
+
+.. code-block:: shell
+
+  docker compose run -e VIEWS_MIGRATION_17_OUTPUT_DIR=/opt/odoo/auto/migrated_views -u odoo --rm odoo odoo -d devel -i $modules --load=base,web,views_migration_17 --stop-after-init
 
 
 Credits

--- a/views_migration_17/patch_xml_import.py
+++ b/views_migration_17/patch_xml_import.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import ast
 import logging
+import os
 import re
 
 from lxml import etree
@@ -26,6 +27,19 @@ def new_tag_record(self, rec, extra_vals=None):
 
 
 xml_import._tag_record = new_tag_record
+
+
+def write_to_file(filename, content):
+    output_folder = os.getenv("VIEWS_MIGRATION_17_OUTPUT_DIR")
+    if output_folder:
+        filename = os.path.join(output_folder, *filename.split(os.sep)[-3:])
+        try:
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
+        except PermissionError:
+            _logger.error(f"Permission denied: {filename}")
+            return
+    with open(filename, "w", encoding="utf-8") as file:
+        file.write(content)
 
 
 def _convert_ir_ui_view_modifiers(self, record_node, extra_vals=None):
@@ -131,8 +145,7 @@ def _convert_ir_ui_view_modifiers(self, record_node, extra_vals=None):
             f_arch.text = root_content.text
 
             new_xml = previous_xml.replace(arch, arch_result)
-            with file_open(self.xml_filename, "w") as file:
-                file.write(new_xml)
+            write_to_file(self.xml_filename, new_xml)
             try:
                 # test file before save
                 etree.fromstring(new_xml.encode())
@@ -147,6 +160,7 @@ def _convert_ir_ui_view_modifiers(self, record_node, extra_vals=None):
 
 
 import itertools
+import os
 
 from odoo.osv.expression import (
     AND_OPERATOR,
@@ -1545,12 +1559,3 @@ def modifier_to_domain(modifier):
             return _modifier_to_domain_ast_wrap_domain(modifier_ast)
     except Exception as e:
         raise ValueError(f"{e}: {modifier}")
-
-
-def str2bool(s):
-    s = s.lower()
-    if s in ("1", "true"):
-        return True
-    if s in ("0", "false"):
-        return False
-    raise ValueError()

--- a/views_migration_17/readme/USAGE.rst
+++ b/views_migration_17/readme/USAGE.rst
@@ -6,6 +6,14 @@ This module is not installable, to use this module, you need to:
 
   odoo -d DATABASE_NAME -i MODULE_TO_MIGRATE --load=base,web,views_migration_17 --stop-after-init
 
+2. If successful, the modifications will be applied to the source code of your module. Alternatively, you can set the environment variable `VIEWS_MIGRATION_17_OUTPUT_DIR` to specify a different output directory for the modified views. Ensure that the user running the Odoo process has the appropriate permissions for the specified path.
 
-2. If success the modifications will be in the source code of your module.
+.. code-block:: shell
 
+  export VIEWS_MIGRATION_17_OUTPUT_DIR=/path/to/output/directory
+
+Example in a [doodba-copier-template](https://github.com/Tecnativa/doodba-copier-template) project:
+
+.. code-block:: shell
+
+  docker compose run -e VIEWS_MIGRATION_17_OUTPUT_DIR=/opt/odoo/auto/migrated_views -u odoo --rm odoo odoo -d devel -i $modules --load=base,web,views_migration_17 --stop-after-init


### PR DESCRIPTION
- Introduce a new method to handle file writing that allows specifying an alternative output directory via an environment variable
- Update documentation to reflect the new output directory option.
- Remove the unused `str2bool` function

Fix #2793
More context in Tecnativa/doodba-copier-template#509

@BinhexTeam
