### PR TITLE
[18.0][FIX] rpc_helper: mute warning logs to keep checklog-odoo happy

### DIFF
--- a/rpc_helper/tests/test_xmlrpc.py
+++ b/rpc_helper/tests/test_xmlrpc.py
@@ -7,6 +7,7 @@ import json
 import xmlrpc
 
 from odoo.tests import common
+from odoo.tools import mute_logger
 
 
 @common.tagged("post_install", "-at_install")
@@ -46,10 +47,12 @@ class TestXMLRPC(common.HttpCase):
         self._set_disable(("all",))
         msg = "RPC call on res.partner is not allowed"
         with self.assertRaisesRegex(xmlrpc.client.Fault, msg):
-            self._rpc_call("search")
+            with mute_logger("odoo.http"):
+                self._rpc_call("search")
 
         with self.assertRaisesRegex(xmlrpc.client.Fault, msg):
-            self._rpc_call("create", vals=[{"name": "Foo"}])
+            with mute_logger("odoo.http"):
+                self._rpc_call("create", vals=[{"name": "Foo"}])
 
     def test_xmlrpc_can_search_create_blocked(self):
         self._set_disable(("create",))
@@ -57,16 +60,19 @@ class TestXMLRPC(common.HttpCase):
 
         msg = "RPC call on res.partner is not allowed"
         with self.assertRaisesRegex(xmlrpc.client.Fault, msg):
-            self._rpc_call("create", vals=[{"name": "Foo"}])
+            with mute_logger("odoo.http"):
+                self._rpc_call("create", vals=[{"name": "Foo"}])
 
     def test_xmlrpc_all_blocked__ir_model(self):
         self._set_disable_on_model(("all",))
         msg = "RPC call on res.partner is not allowed"
         with self.assertRaisesRegex(xmlrpc.client.Fault, msg):
-            self._rpc_call("search")
+            with mute_logger("odoo.http"):
+                self._rpc_call("search")
 
         with self.assertRaisesRegex(xmlrpc.client.Fault, msg):
-            self._rpc_call("create", vals=[{"name": "Foo"}])
+            with mute_logger("odoo.http"):
+                self._rpc_call("create", vals=[{"name": "Foo"}])
 
     def test_xmlrpc_can_search_create_blocked__ir_model(self):
         self._set_disable_on_model(("create",))
@@ -74,4 +80,5 @@ class TestXMLRPC(common.HttpCase):
 
         msg = "RPC call on res.partner is not allowed"
         with self.assertRaisesRegex(xmlrpc.client.Fault, msg):
-            self._rpc_call("create", vals=[{"name": "Foo"}])
+            with mute_logger("odoo.http"):
+                self._rpc_call("create", vals=[{"name": "Foo"}])


### PR DESCRIPTION
Fixes
```
INFO odoo odoo.addons.rpc_helper.tests.test_xmlrpc: Starting TestXMLRPC.test_xmlrpc_can_search_create_blocked__ir_model ...
INFO odoo werkzeug: 127.0.0.1 - - [04/Feb/2025 13:39:13] "POST /xmlrpc/2/object HTTP/1.1" 200 - 22 0.006 0.437
WARNING odoo odoo.http: RPC call on res.partner is not allowed
```

New logging is due to https://github.com/odoo/odoo/commit/a65b1d830455a577b83ac658b7c12d086f468c26