### PR TITLE
[IMP] base_import_odoo: Remove mock dependancy

### DIFF
--- a/base_import_odoo/tests/test_base_import_odoo.py
+++ b/base_import_odoo/tests/test_base_import_odoo.py
@@ -1,7 +1,7 @@
 # Copyright 2017-2018 Therp BV <http://therp.nl>
 # Copyright 2020 Hunki Enterprises BV <https://hunki-enterprises.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from mock import patch
+from unittest.mock import patch
 
 from odoo.tests.common import TransactionCase, tagged
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
 cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes
 odoo_test_helper
-mock


### PR DESCRIPTION
With unittest we don't need it