### PR TITLE
[14.0] jsonifier: fix get_json_parser caching

### DIFF
--- a/jsonifier/models/ir_exports.py
+++ b/jsonifier/models/ir_exports.py
@@ -110,7 +110,8 @@ class IrExports(models.Model):
                 if line.target:
                     names = line.target.split("/")
                 function = line.instance_method_name
-                options = {"resolver": line.resolver_id, "function": function}
+                # resolver must be passed as ID to avoid cache issues
+                options = {"resolver": line.resolver_id.id, "function": function}
                 update_dict(dict_parser, names, options)
             lang_parsers[lang] = convert_dict(dict_parser)
         if list(lang_parsers.keys()) == [False]:
@@ -118,7 +119,7 @@ class IrExports(models.Model):
         else:
             parser["langs"] = lang_parsers
         if self.global_resolver_id:
-            parser["resolver"] = self.global_resolver_id
+            parser["resolver"] = self.global_resolver_id.id
         if self.language_agnostic:
             parser["language_agnostic"] = self.language_agnostic
         return parser

--- a/jsonifier/models/models.py
+++ b/jsonifier/models/models.py
@@ -102,6 +102,9 @@ class Base(models.AbstractModel):
                 value = rec._jsonify_value(field, rec[field.name])
                 resolver = field_dict.get("resolver")
                 if resolver:
+                    if isinstance(resolver, int):
+                        # cached versions of the parser are stored as integer
+                        resolver = self.env["ir.exports.resolver"].browse(resolver)
                     value, json_key = self._jsonify_record_handle_resolver(
                         rec, field, resolver, json_key
                     )
@@ -208,7 +211,9 @@ class Base(models.AbstractModel):
         if isinstance(parser, list):
             parser = convert_simple_to_full_parser(parser)
         resolver = parser.get("resolver")
-
+        if isinstance(resolver, int):
+            # cached versions of the parser are stored as integer
+            resolver = self.env["ir.exports.resolver"].browse(resolver)
         results = [{} for record in self]
         parsers = {False: parser["fields"]} if "fields" in parser else parser["langs"]
         records = self


### PR DESCRIPTION
The resolver was returned as a full recordset,
hence its cursor could diverge from the original one and get closed while the other was still active.