### PR TITLE
[17.0][FIX] upgrade_analysis: fill upgrade_path

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -88,10 +88,12 @@ class UpgradeAnalysis(models.Model):
         module = self.env["ir.module.module"].search([("name", "=", module_name)])[0]
         if module.is_odoo_module:
             if not self.upgrade_path:
-                return (
-                    "ERROR: no upgrade_path set when writing analysis of %s\n"
-                    % module_name
-                )
+                self._compute_upgrade_path()
+                if not self.upgrade_path:
+                    return (
+                        "ERROR: no upgrade_path set when writing analysis of %s\n"
+                        % module_name
+                    )
             full_path = os.path.join(self.upgrade_path, module_name, version)
         else:
             full_path = os.path.join(


### PR DESCRIPTION
For some reason, _compute_upgrade_path is not called by default if store=True.