### PR TITLE
[16.0][FIX] Database autobackup bugfix: exist_ok parameter does not exists in remote.makedirs() function

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -186,7 +186,7 @@ class DbBackup(models.Model):
                         with rec.sftp_connection() as remote:
                             # Directory must exist
                             try:
-                                remote.makedirs(rec.folder, exist_ok=True)
+                                remote.makedirs(rec.folder)
                             except pysftp.ConnectionException as exc:
                                 _logger.exception(
                                     "pysftp ConnectionException: %s" % exc


### PR DESCRIPTION
As said on https://github.com/OCA/server-tools/issues/3139 there is no exist_ok parameter in remote.makedirs() function.

So, with this PR the SFTP remote backup will work with no errors.

Thanks,

Ignacio
