### PR TITLE
[16.0][FIX] upgrade_analysis: avoid call privatized 'mapped' function.

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -548,11 +548,13 @@ class UpgradeAnalysis(models.Model):
         all_local_modules = (
             self.env["ir.module.module"].search(module_domain).mapped("name")
         )
-        all_remote_modules = (
-            connection.env["ir.module.module"]
-            .browse(connection.env["ir.module.module"].search(module_domain))
-            .mapped("name")
-        )
+
+        all_remote_modules = [
+            x["name"]
+            for x in connection.env["ir.module.module"].search_read(
+                module_domain, ["name"]
+            )
+        ]
 
         start_version = connection.version
         end_version = release.major_version


### PR DESCRIPTION
FIX: bug described in #3215.
(alternative to patch solution)
 
Rational : 'mapped' function has been privatized in https://github.com/odoo/odoo/commit/a1adf8355ceb00e6b9b5cbdde00aa87c5501e922. We so replace 'mapped' by 'search_read'