### PR TITLE
[FIX] sentry: temporarily exclude sentry_sdk>=2.23.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ dataclasses
 odoorpc
 openupgradelib
 pysftp
-sentry_sdk>=2.0.0
+sentry_sdk>=2.0.0,<=2.22.0

--- a/sentry/__manifest__.py
+++ b/sentry/__manifest__.py
@@ -17,7 +17,7 @@
     "installable": True,
     "external_dependencies": {
         "python": [
-            "sentry_sdk>=2.0.0",
+            "sentry_sdk>=2.0.0,<=2.22.0",
         ]
     },
     "depends": [


### PR DESCRIPTION
To avoid following error:
AttributeError: 'InMemoryTransport' object has no attribute 'options'