### PR TITLE
[17.0][FIX] module_analysis: pin pygount

### DIFF
--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -27,7 +27,7 @@
         "data/ir_cron.xml",
     ],
     "external_dependencies": {
-        "python": ["pygount"],
+        "python": ["pygount==1.4.0"],
     },
     "installable": True,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ dataclasses
 mako
 odoorpc
 openupgradelib
-pygount
+pygount==1.4.0
 sentry_sdk<=1.9.0


### PR DESCRIPTION
Same fix as applied to 16.0 yesterday: #2967 as the same bug happens in the 17.0 branch. Here for instance:
https://github.com/OCA/server-tools/actions/runs/13928897997/job/38980680565#step:8:335

Pin the pygount dependency to 1.4.0 to avoid chardet version clash

Fixes https://github.com/OCA/server-tools/issues/2966

cc @legalsylvain @StefanRijnhart @pedrobaeza 