### PR TITLE
[18.0][FIX]base_view_inheritance_extension: fix deprecation warning

### DIFF
--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -27,11 +27,8 @@ def ast_dict_update(source, update):
         raise TypeError("`update` must be an AST dict")
 
     def ast_key_eq(k1, k2):
-        # python < 3.8 uses ast.Str; python >= 3.8 uses ast.Constant
         if type(k1) is not type(k2):
             return False
-        elif isinstance(k1, ast.Str):
-            return k1.s == k2.s
         elif isinstance(k1, ast.Constant):
             return k1.value == k2.value
 


### PR DESCRIPTION
```
DeprecationWarning: ast.Str is deprecated and will be removed in Python 3.14; use ast.Constant instead
```
