### PR TITLE
[18.0][FIX] upgrade_analysis: avoid call privatized 'mapped' function. (forward port)

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -538,11 +538,13 @@ class UpgradeAnalysis(models.Model):
         all_local_modules = (
             self.env["ir.module.module"].search(module_domain).mapped("name")
         )
-        all_remote_modules = (
-            connection.env["ir.module.module"]
-            .browse(connection.env["ir.module.module"].search(module_domain))
-            .mapped("name")
-        )
+
+        all_remote_modules = [
+            x["name"]
+            for x in connection.env["ir.module.module"].search_read(
+                module_domain, ["name"]
+            )
+        ]
 
         start_version = connection.version
         end_version = release.major_version


### PR DESCRIPTION
Forward port of https://github.com/OCA/server-tools/pull/3243.