### PR TITLE
attachment_delete_restrict: using sudo should by pass the restriction

### DIFF
--- a/attachment_delete_restrict/models/ir_attachment.py
+++ b/attachment_delete_restrict/models/ir_attachment.py
@@ -64,6 +64,8 @@ class IrAttachment(models.Model):
             return self._raise_delete_attachment_error(allowed_users)
 
     def unlink(self):
+        if self.env.su:
+            return super().unlink()
         res_models = list(set(self.filtered("res_model").mapped("res_model")))
         if res_models:
             models = self.env["ir.model"].search([("model", "in", res_models)])

--- a/attachment_delete_restrict/tests/test_attachment_delete_restrict.py
+++ b/attachment_delete_restrict/tests/test_attachment_delete_restrict.py
@@ -17,6 +17,10 @@ class AbstractCase:
         self._allow_user()
         self.attachment.with_user(self.user).unlink()
 
+    def test_restrict_custom_user_with_sudo(self):
+        self._set_restrict_mode("custom")
+        self.attachment.with_user(self.user).sudo().unlink()
+
     def test_restrict_custom_group(self):
         self._set_restrict_mode("custom")
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
When having other module that call an unlink in a sudo mode the restriction are applied and it raise an error

Fix it by not applying the restriction in case of sudo