### PR TITLE
[17.0][FIX] test.yml: prevent infinite loop of makepot commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
             include: "database_cleanup"
-            makepot: "true"
             name: Rebel test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
             include: "database_cleanup"
@@ -49,7 +48,6 @@ jobs:
           - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
             exclude: "database_cleanup"
             name: test with OCB
-            makepot: "true"
     services:
       postgres:
         image: postgres:12.0


### PR DESCRIPTION
Only run makepot once. The result will be equivalent in each of those jobs because the pot files will be generated for all the addons at once.

If there are more than one test run with different sets of modules, and in one of those modules a field is added to the base model, the makepot jobs will have different outcomes and will keep on reverting each other's changes upon subsequent test runs.

![image](https://github.com/user-attachments/assets/4b48d5ca-a97d-4775-a976-311be69eb252)
![image](https://github.com/user-attachments/assets/948b1e91-9a6a-437e-a446-02bebd2005c5)
![image](https://github.com/user-attachments/assets/1d6678e1-7e2b-4c0f-970e-27f73014c57f)
