### PR TITLE
[16.0][FIX] nsca_client, fetchmail_attach_from_folder, base_domain_inverse_function: failing tests

### DIFF
--- a/base_domain_inverse_function/tests/test_partner_domains.py
+++ b/base_domain_inverse_function/tests/test_partner_domains.py
@@ -12,7 +12,7 @@ class TestPartnerDomains(TransactionCase):
         super().setUpClass()
         cls.partner_model = cls.env["res.partner"]
         cls.partner_domains = [
-            [("display_name", "ilike", "Deco")],
+            [("display_name", "ilike", "Acme")],
             [("email", "ilike", "example.com")],
             [("country_id", "=", cls.env.ref("base.us").id)],
         ]

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -62,6 +62,10 @@ class MockConnection:
         method = getattr(self, command)
         return method(*args)
 
+    def expunge(self):
+        """Mock an IMAP4.expunge action"""
+        return ("OK", None)
+
 
 class TestMatchAlgorithms(TransactionCase):
     @classmethod

--- a/nsca_client/tests/test_nsca.py
+++ b/nsca_client/tests/test_nsca.py
@@ -17,7 +17,8 @@ class Popen:
         self.stderr = stderr
 
     # flake8: noqa: B902
-    def communicate(_input):
+    # pylint: disable=redefined-builtin
+    def communicate(input=None, timeout=None):
         return ["test"]
 
 


### PR DESCRIPTION
Fix test failures that are blocking other merge requests on 16.0:

- [ ] nsca_client: `odoo.addons.nsca_client.models.nsca_server: Popen.communicate() got an unexpected keyword argument 'input'.`
- [ ] fetchmail_attach_from_folder: `MockConnection object has no method expunge()`
- [ ] base_domain_inverse_function: relies on `Deco Addict` demo record that was [renamed](https://github.com/odoo/odoo/commit/98dcbc8d5fa946f55adcaa025eb37746fd9b99d8)
