### PR TITLE
[18.0][FIX] tracking_manager: Solved the invalid recordset issue

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -49,6 +49,9 @@ class Base(models.AbstractModel):
         )
         for field_name, owner_field_name in self._tm_get_fields_to_notify():
             owner = self[field_name]
+            # Skip processing if the owner is not a valid Odoo recordset or is empty.
+            if not (owner and isinstance(owner, models.BaseModel)):
+                continue
             data[owner._name][owner.id][owner_field_name].append(
                 {
                     "mode": mode,


### PR DESCRIPTION
- Steps to Reproduce:
1) Go to Settings > Models, select any model (e.g., res.partner).
2) Ensure 'Active' and 'Automatic Configuration' are enabled.
3) Under Domain, change the 'Field Type' to boolean (or anything except one2many).
4) Go to the related model (e.g., Contacts), create a new record, and try to save.
- Issue:
An attribute-related error occurs on save due to the Domain field's incompatible type.
```
  File "/mnt/data/odoo-addons-dir/tracking_manager/models/models.py", line 52, in _tm_notify_owner
    data[owner._name][owner.id][owner_field_name].append(
AttributeError: 'int' object has no attribute '_name'
```
![invalid-recordset-issue-demo-2](https://github.com/user-attachments/assets/6c5c5007-cd57-4699-a7f7-3b94b56106f9)

