### PR TITLE
[16.0][FIX] base_remote: add more attributes to mock request

### DIFF
--- a/base_remote/tests/test_remote.py
+++ b/base_remote/tests/test_remote.py
@@ -45,7 +45,11 @@ class TestRemote(HttpCase):
                 "httprequest": type(
                     "obj",
                     (object,),
-                    {"remote_addr": self.remote_addr},
+                    {
+                        "remote_addr": self.remote_addr,
+                        "cookies": {},
+                        "path": "/",
+                    },
                 ),
             },
         )


### PR DESCRIPTION
this fixes failing tests as Odoo core accesses more properties of the request