### PR TITLE
[FIX] base_multi_image: Access Error

### DIFF
--- a/base_multi_image/models/image.py
+++ b/base_multi_image/models/image.py
@@ -62,7 +62,7 @@ class Image(models.Model):
     @tools.ormcache("self")
     def _selection_owner_ref_id(self):
         """Allow any model; after all, this field is readonly."""
-        return [(r.model, r.name) for r in self.env["ir.model"].search([])]
+        return [(r.model, r.name) for r in self.env["ir.model"].sudo().search([])]
 
     @api.depends("owner_model", "owner_id")
     def _compute_owner_ref_id(self):

--- a/base_multi_image/tests/__init__.py
+++ b/base_multi_image/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_base_multi_image

--- a/base_multi_image/tests/test_base_multi_image.py
+++ b/base_multi_image/tests/test_base_multi_image.py
@@ -1,0 +1,42 @@
+from odoo.tests import new_test_user
+from odoo.tests.common import TransactionCase
+
+
+class TestBaseMultiImage(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        # Create a non-admin user
+        self.base_user = new_test_user(
+            self.env,
+            name="Base User",
+            login="base_user",
+            groups="base.group_user",
+        )
+
+        # Create a base_multi_image.image record
+        self.image_record = self.env["base_multi_image.image"].create(
+            {
+                "name": "Test Image",
+                "owner_model": "res.partner",
+                "owner_id": self.env["res.partner"]
+                .create(
+                    {
+                        "name": "Partner",
+                    }
+                )
+                .id,
+            }
+        )
+
+    def test_selection_owner_ref_id_access(self):
+        """
+        Ensure _selection_owner_ref_id works for non-admin users.
+        """
+        base_user_env = self.env(user=self.base_user.id)
+        image = base_user_env["base_multi_image.image"].browse(self.image_record.id)
+
+        # It should not raise an AccessError
+        selection = image._selection_owner_ref_id()
+
+        self.assertIsInstance(selection, list)
+        self.assertTrue(len(selection) > 0)


### PR DESCRIPTION
I encountered an AccessError when a non-admin user tries to access a `base_multi_image` form or tree view or when any model that inherits from base_multi_image is used. This error happens because the `owner_ref_id` field computation tries to access the `ir.model` table without sufficient permissions.

To fix this, I added .sudo() to the `_selection_owner_ref_id` method to ensure the system has the necessary access rights to read from ir.model, regardless of the user's permissions.