### PR TITLE
[15.0][REV][FIX] Pin cryptography to keep compatibility with Odoo's pyopenssl==19.0.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -24,5 +24,5 @@
         "view/db_backup_view.xml",
     ],
     "installable": True,
-    "external_dependencies": {"python": ["pysftp", "cryptography==2.6.1"]},
+    "external_dependencies": {"python": ["pysftp"]},
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # generated from manifests external_dependencies
 acme<2.0.0
 astor
-cryptography==2.6.1
 dataclasses
 dnspython
 josepy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
+# place an upper bound on cryptography for compatibility with pyopenssl 19 in Odoo's requirements.txt
+cryptography<37
 odoo-test-helper


### PR DESCRIPTION
Reverted commit disallows to install auto_backup, when using offical Odoo 15.0 docker image, which is based on bullseye [1].
The bullseye has following python packages:

- cryptography 3.3.2 with security patches [2]
- pyopenssl 20.0.1 [3]

[1] https://github.com/odoo/docker/blob/5fb6a842747c296099d9384587cd89640eb7a615/15.0/Dockerfile#L1
[2] https://packages.debian.org/bullseye/python3-cryptography
[3] https://packages.debian.org/bullseye/python3-openssl