### PR TITLE
[FIX] module_change_auto_install : prevent to crash if a module is not present in the addons path.    

### DIFF
--- a/module_change_auto_install/patch.py
+++ b/module_change_auto_install/patch.py
@@ -49,6 +49,11 @@ def _get_modules_dict_auto_install_config(config_value):
 
 def _overload_load_manifest(module, mod_path=None):
     res = _original_load_manifest(module, mod_path=None)
+    if not res:
+        # Specific case where a previously available module marked as auto installable
+        # is NOT available in the addons path.
+        # In that case, avoid to crash when trying to get 'depends' key.
+        return
     auto_install = res.get("auto_install", False)
 
     modules_auto_install_enabled_dict = _get_modules_dict_auto_install_config(


### PR DESCRIPTION
Rational:

- Set modules_auto_install_enabled=web_no_bubble
- Create a new instance with web_no_bubble installed
- Then restart the server, removing OCA/web repo from the addons path.
For the time being, the server crashes, because 'depends' key is not available.
With that patch, the classic 'module web_no_bubble: not installable, skipped' message is displayed in the log,
but the server doesn't crash.
