### PR TITLE
[18.0][FIX] upgrade_analysis: avoid caring about non stored fields

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -302,15 +302,18 @@ def compare_sets(old_records, new_records):
     for column in old_records:
         if column["field"] == "_order":
             continue
-        # we do not care about removed non stored function fields
+        # we do not care about removed non stored function/related fields
         if not column["stored"] and (column["isfunction"] or column["isrelated"]):
             continue
         if column["mode"] == "create":
             column["mode"] = ""
+        printkeys = printkeys_old.copy()
+        if not column["stored"]:
+            printkeys.extend(["stored"])
         extra_message = ", ".join(
             [
-                k + ": " + str(column[k]) if k != str(column[k]) else k
-                for k in printkeys_old
+                k + ": " + str(column[k] or False) if k != str(column[k]) else k
+                for k in printkeys
                 if column[k]
             ]
         )
@@ -321,7 +324,7 @@ def compare_sets(old_records, new_records):
     for column in new_records:
         if column["field"] == "_order":
             continue
-        # we do not care about newly added non stored function fields
+        # we do not care about newly added non stored function/related fields
         if not column["stored"] and (column["isfunction"] or column["isrelated"]):
             continue
         if column["mode"] == "create":
@@ -329,9 +332,11 @@ def compare_sets(old_records, new_records):
         printkeys = printkeys_new.copy()
         if column["isfunction"] or column["isrelated"]:
             printkeys.extend(["isfunction", "isrelated", "stored"])
+        if not column["stored"]:
+            printkeys.extend(["stored"])
         extra_message = ", ".join(
             [
-                k + ": " + str(column[k]) if k != str(column[k]) else k
+                k + ": " + str(column[k] or False) if k != str(column[k]) else k
                 for k in printkeys
                 if column[k]
             ]


### PR DESCRIPTION
Long time ago, I added https://github.com/OCA/OpenUpgrade/commit/b724b4f0d5f4813ac0d09418c66dc491d93e000b in v12. I did it because Odoo started to add computed/related stored fields in v13. But Odoo in last versions has been adding non stored fields that are not compute nor related, like https://github.com/odoo/odoo/blob/18.0/addons/account/models/account_account.py#L142 and https://github.com/odoo/odoo/blob/18.0/addons/account/models/account_move.py#L186. This kind of field adds noise in the analysis file, so let's remove them.

NOTE: Usual `company_dependent` fields and usual `translate` fields are marked as stored, so no problem with these cases.