### PR TITLE
[18.0][FIX] upgrade_analysis: non-stored has to be shown

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -308,13 +308,13 @@ def compare_sets(old_records, new_records):
         if column["mode"] == "create":
             column["mode"] = ""
         printkeys = printkeys_old.copy()
-        if not column["stored"]:
+        if not column["stored"] and not column["mode"]:
             printkeys.extend(["stored"])
         extra_message = ", ".join(
             [
                 k + ": " + str(column[k] or False) if k != str(column[k]) else k
                 for k in printkeys
-                if column[k]
+                if k == "stored" or column[k]
             ]
         )
         if extra_message:
@@ -332,13 +332,13 @@ def compare_sets(old_records, new_records):
         printkeys = printkeys_new.copy()
         if column["isfunction"] or column["isrelated"]:
             printkeys.extend(["isfunction", "isrelated", "stored"])
-        if not column["stored"]:
+        if not column["stored"] and not column["mode"]:
             printkeys.extend(["stored"])
         extra_message = ", ".join(
             [
                 k + ": " + str(column[k] or False) if k != str(column[k]) else k
                 for k in printkeys
-                if column[k]
+                if k == "stored" or column[k]
             ]
         )
         if extra_message:


### PR DESCRIPTION
Fixup of https://github.com/OCA/server-tools/pull/3290.

Tested:
![Selection_4472](https://github.com/user-attachments/assets/05465453-4b25-4482-8da3-ebebf0e04757)
