### PR TITLE
[14.0][FIX]model_read_only: superuser exempt from the restriction

### DIFF
--- a/model_read_only/models/models.py
+++ b/model_read_only/models/models.py
@@ -1,6 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, exceptions, fields, models
+from odoo import SUPERUSER_ID, _, api, exceptions, fields, models
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -32,7 +32,7 @@ class BaseModel(models.AbstractModel):
 
     @api.model
     def check_access_rights(self, operation, raise_exception=True):
-        if operation != "read":
+        if operation != "read" and self.env.user.id != SUPERUSER_ID:
             model = self.env["ir.model"]._get(self._name)
             no_access = False
             for restr in model.sudo().readonly_restriction_ids:

--- a/model_read_only/tests/test_models.py
+++ b/model_read_only/tests/test_models.py
@@ -1,3 +1,4 @@
+from odoo import SUPERUSER_ID
 from odoo.exceptions import AccessError
 from odoo.tests.common import SavepointCase
 
@@ -150,4 +151,8 @@ class TestIrModel(SavepointCase):
         self.assertFalse(
             test_record.check_access_rights("write", False),
             msg="Write access right should be prevented",
+        )
+
+        self.assertTrue(
+            test_record.with_user(SUPERUSER_ID).check_access_rights("write", True),
         )


### PR DESCRIPTION
Good afternoon, the superuser should be exempt from the superuser restriction even if they belong to a group that requires this restriction.