### PR TITLE
[18.0][FIX] module_change_auto_install: AttributeError: 'NoneType' object has no attribute 'get'

### DIFF
--- a/module_change_auto_install/patch.py
+++ b/module_change_auto_install/patch.py
@@ -53,7 +53,7 @@ def _overload_load_manifest(module, mod_path=None):
         # Specific case where a previously available module marked as auto installable
         # is NOT available in the addons path.
         # In that case, avoid to crash when trying to get 'depends' key.
-        return
+        return {}
     auto_install = res.get("auto_install", False)
 
     modules_auto_install_enabled_dict = _get_modules_dict_auto_install_config(

--- a/module_change_auto_install/patch.py
+++ b/module_change_auto_install/patch.py
@@ -53,7 +53,7 @@ def _overload_load_manifest(module, mod_path=None):
         # Specific case where a previously available module marked as auto installable
         # is NOT available in the addons path.
         # In that case, avoid to crash when trying to get 'depends' key.
-        return {}
+        return res
     auto_install = res.get("auto_install", False)
 
     modules_auto_install_enabled_dict = _get_modules_dict_auto_install_config(


### PR DESCRIPTION
```
 File "/home/odoo/src/odoo/addons/base_import_module/models/ir_module.py", line 53, in _get_icon_image
    super()._get_icon_image()
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_module.py", line 268, in _get_icon_image
    countries = self.get_module_info(module.name).get('countries', [])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'