### PR TITLE
[18.0] [FIX] module_change_auto_install

### DIFF
--- a/module_change_auto_install/patch.py
+++ b/module_change_auto_install/patch.py
@@ -53,7 +53,7 @@ def _overload_load_manifest(module, mod_path=None):
         # Specific case where a previously available module marked as auto installable
         # is NOT available in the addons path.
         # In that case, avoid to crash when trying to get 'depends' key.
-        return
+        return res
     auto_install = res.get("auto_install", False)
 
     modules_auto_install_enabled_dict = _get_modules_dict_auto_install_config(

--- a/module_change_auto_install/tests/test_module.py
+++ b/module_change_auto_install/tests/test_module.py
@@ -27,3 +27,7 @@ class TestModule(TransactionCase):
     def test_config_parsing(self):
         for k, v in self._EXPECTED_RESULTS.items():
             self.assertEqual(_get_modules_dict_auto_install_config(k), v)
+
+    def test_get_module_info(self):
+        self.env["ir.module.module"].get_module_info("account").get("countries", [])
+        self.env["ir.module.module"].get_module_info("BlaBla").get("countries", [])


### PR DESCRIPTION
An error is raised when opening the Apps

AttributeError: 'NoneType' object has no attribute 'get'