### PR TITLE
[16.0][FIX] base_exception: confirmation wizard button typo

### DIFF
--- a/base_exception/wizard/base_exception_confirm_view.xml
+++ b/base_exception/wizard/base_exception_confirm_view.xml
@@ -23,7 +23,7 @@
                 <footer>
                     <button
                         name="action_confirm"
-                        string="_Close"
+                        string="Close"
                         colspan="1"
                         type="object"
                         class="btn-primary"


### PR DESCRIPTION
This commit addresses the incorrect text displayed for the “Close” button in the `Exception Rule Confirm Wizard`. The typo has been corrected since the 18.0 branch also.

![Screenshot 2025-06-21 at 10 36 42](https://github.com/user-attachments/assets/6e781222-953f-420e-a89a-86e566cc1ad2)
