### PR TITLE
[18.0][IMP] upgrade_analysis: tell user which selection keys were added/removed

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -10,6 +10,7 @@
 
 import collections
 import copy
+from ast import literal_eval
 
 try:
     from odoo.addons.openupgrade_scripts import apriori
@@ -128,6 +129,26 @@ def fieldprint(old, new, field, text, reprs):
             text += f" [{old['table']}]"
         if field == "relation":
             text += " [nothing to do]"
+        if field == "selection_keys":
+            old_selection_keys = old.get("selection_keys") or ""
+            new_selection_keys = new.get("selection_keys") or ""
+            try:
+                old_selection_keys = literal_eval(old_selection_keys)
+                new_selection_keys = literal_eval(new_selection_keys)
+            except Exception:  # pylint: disable=except-pass
+                pass
+            if isinstance(old_selection_keys, tuple | list) and isinstance(
+                new_selection_keys, tuple | list
+            ):
+                removed = set(old_selection_keys) - set(new_selection_keys)
+                added = set(new_selection_keys) - set(old_selection_keys)
+                text = (
+                    f"{field} {added and ('added: ' + ', '.join(added)) or ''}"
+                    f"{added and ' ' or ''}"
+                    f"{removed and ('removed: ' + ', '.join(removed)) or ''}"
+                )
+                if added and not removed:
+                    text += " (most likely nothing to do)"
     if field != "module":
         reprs[module_map(new["module"])].append(f"{fullrepr}: {text}")
     if field == "module":

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -1,5 +1,8 @@
+from copy import deepcopy
+
 from odoo.tests import common, tagged
 
+from .. import compare, upgrade_log
 from ..odoo_patch.odoo_patch import OdooPatch
 
 
@@ -69,3 +72,48 @@ class TestUpgradeAnalysis(common.TransactionCase):
                 ]
             )
         )
+
+    def test_field_comparison(self):
+        """
+        Test we compare fields correctly
+        """
+        registry = {}
+        upgrade_log.log_model(self.env["upgrade.analysis"], registry)
+        upgrade_log.compare_registries(self.env.cr, "upgrade_analysis", {}, registry)
+        old_fields = self.env["upgrade.record"].field_dump()
+        new_fields = deepcopy(old_fields)
+
+        def assertInFieldComparison(comparison, field, needle):
+            self.assertIn(
+                needle,
+                "".join(
+                    line
+                    for line in comparison["upgrade_analysis"]
+                    if f"/ {field} (" in line
+                ),
+            )
+
+        state_field = [
+            field
+            for field in new_fields
+            if field["field"] == "state" and field["model"] == "upgrade.analysis"
+        ][0]
+
+        state_field["selection_keys"] = "['done', 'new']"
+        comparison = compare.compare_sets(old_fields, new_fields)
+        assertInFieldComparison(comparison, "state", "added: new")
+        assertInFieldComparison(comparison, "state", "removed: draft")
+
+        state_field["selection_keys"] = "['done', 'draft', 'new']"
+        comparison = compare.compare_sets(old_fields, new_fields)
+        assertInFieldComparison(comparison, "state", "added: new")
+        assertInFieldComparison(comparison, "state", "most likely nothing to do")
+        with self.assertRaises(AssertionError):
+            assertInFieldComparison(comparison, "state", "removed")
+
+        state_field["selection_keys"] = "function"
+        comparison = compare.compare_sets(old_fields, new_fields)
+        with self.assertRaises(AssertionError):
+            assertInFieldComparison(comparison, "state", "added: new")
+        with self.assertRaises(AssertionError):
+            assertInFieldComparison(comparison, "state", "removed")


### PR DESCRIPTION
currently, we just print [all keys](https://github.com/OCA/OpenUpgrade/blob/18.0/openupgrade_scripts/scripts/base/18.0.1.3/upgrade_analysis.txt#L63), which is not helpful for small selections and unmanageable for big ones like the time zone selection further below in the linked file. This formats selections as "added: key1 removed: key2, key3"