### PR TITLE
[17.0][FW][FIX] auditlog rue: Control the write function in the models when executed by an onchange function

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -383,9 +383,12 @@ class AuditlogRule(models.Model):
             self = self.with_context(auditlog_disabled=True)
             rule_model = self.env["auditlog.rule"]
             fields_list = rule_model.get_auditlog_fields(self)
+            records_write = self.filtered(lambda r: not isinstance(r.id, models.NewId))
+            if not records_write:
+                return write_full.origin(self, vals, **kwargs)
             old_values = {
                 d["id"]: d
-                for d in self.sudo()
+                for d in records_write.sudo()
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
@@ -398,7 +401,7 @@ class AuditlogRule(models.Model):
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d
-                for d in self.sudo()
+                for d in records_write.sudo()
                 .with_context(prefetch_fields=False)
                 .read(fields_list)
             }
@@ -407,7 +410,7 @@ class AuditlogRule(models.Model):
             rule_model.sudo().create_logs(
                 self.env.uid,
                 self._name,
-                self.ids,
+                records_write.ids,
                 "write",
                 old_values,
                 new_values,


### PR DESCRIPTION
Fix the same problem that occurs in version 15.0 (https://github.com/OCA/server-tools/pull/2912) and 16 (https://github.com/OCA/server-tools/pull/2924)
