### PR TITLE
[18.0][IMP] upgrade_analysis: clarify added/removed selection keys

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -143,9 +143,9 @@ def fieldprint(old, new, field, text, reprs):
                 removed = set(old_selection_keys) - set(new_selection_keys)
                 added = set(new_selection_keys) - set(old_selection_keys)
                 text = (
-                    f"{field} {added and ('added: ' + ', '.join(added)) or ''}"
-                    f"{added and ' ' or ''}"
-                    f"{removed and ('removed: ' + ', '.join(removed)) or ''}"
+                    f"{field} {added and ('added: [' + ', '.join(added) + ']') or ''}"
+                    f"{added and removed and ', ' or ''}"
+                    f"{removed and ('removed: [' + ', '.join(removed) + ']') or ''}"
                 )
                 if added and not removed:
                     text += " (most likely nothing to do)"

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -101,12 +101,12 @@ class TestUpgradeAnalysis(common.TransactionCase):
 
         state_field["selection_keys"] = "['done', 'new']"
         comparison = compare.compare_sets(old_fields, new_fields)
-        assertInFieldComparison(comparison, "state", "added: new")
-        assertInFieldComparison(comparison, "state", "removed: draft")
+        assertInFieldComparison(comparison, "state", "added: [new]")
+        assertInFieldComparison(comparison, "state", "removed: [draft]")
 
         state_field["selection_keys"] = "['done', 'draft', 'new']"
         comparison = compare.compare_sets(old_fields, new_fields)
-        assertInFieldComparison(comparison, "state", "added: new")
+        assertInFieldComparison(comparison, "state", "added: [new]")
         assertInFieldComparison(comparison, "state", "most likely nothing to do")
         with self.assertRaises(AssertionError):
             assertInFieldComparison(comparison, "state", "removed")
@@ -114,6 +114,6 @@ class TestUpgradeAnalysis(common.TransactionCase):
         state_field["selection_keys"] = "function"
         comparison = compare.compare_sets(old_fields, new_fields)
         with self.assertRaises(AssertionError):
-            assertInFieldComparison(comparison, "state", "added: new")
+            assertInFieldComparison(comparison, "state", "added: [new]")
         with self.assertRaises(AssertionError):
             assertInFieldComparison(comparison, "state", "removed")


### PR DESCRIPTION
It's a bit confusing if we no add commas and brackets (at least for me) 😅