### PR TITLE
[18.0][IMP] base_time_window: Forward-port Add helper function to get next Date matching weekday

### DIFF
--- a/base_time_window/models/time_weekday.py
+++ b/base_time_window/models/time_weekday.py
@@ -52,3 +52,30 @@ class TimeWeekday(models.Model):
         result = super().unlink()
         self.env.registry.clear_cache()
         return result
+
+    def _get_next_weekday_date(self, date_from=False, include_date_from=True):
+        """Returns the next Date matching weekday
+
+        :param date_from: Date object from which we start searching for next weekday
+        :param include_date_from: Allows to return date from if it's same weekday
+        :return Date object matching the weekday
+        """
+        self.ensure_one()
+        if not date_from:
+            date_from = fields.Date.today()
+        next_weekday_delta = int(self.name) - date_from.weekday()
+        if next_weekday_delta < 0:
+            next_weekday_delta += 7
+        elif next_weekday_delta == 0 and not include_date_from:
+            next_weekday_delta += 7
+        return fields.Date.add(date_from, days=next_weekday_delta)
+
+    def _get_next_weekdays_date(self, date_from=False, include_date_from=True):
+        return min(
+            [
+                weekday._get_next_weekday_date(
+                    date_from=date_from, include_date_from=include_date_from
+                )
+                for weekday in self
+            ]
+        )

--- a/base_time_window/tests/__init__.py
+++ b/base_time_window/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_time_weekday
 from . import test_time_window_mixin
+from . import test_weekday

--- a/base_time_window/tests/test_weekday.py
+++ b/base_time_window/tests/test_weekday.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.fields import Date
+from odoo.tests.common import TransactionCase
+
+
+class TestWeekday(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        time_weekday_mapping = dict(cls.env["time.weekday"]._fields["name"].selection)
+        for val, name in time_weekday_mapping.items():
+            setattr(
+                cls,
+                name.lower(),
+                cls.env["time.weekday"].search([("name", "=", val)], limit=1),
+            )
+
+    def test_next_weekday_date(self):
+        # 2024-01-01 is Monday, next Monday (including date_from) is 2024-01-01
+        self.assertEqual(
+            self.monday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-01"),
+        )
+        # 2024-01-01 is Monday, next Monday (excluding date_from) is 2024-01-08
+        self.assertEqual(
+            self.monday._get_next_weekday_date(
+                Date.to_date("2024-01-01"), include_date_from=False
+            ),
+            Date.to_date("2024-01-08"),
+        )
+        # 2024-01-01 is Monday, next Tuesday is 2024-01-02
+        self.assertEqual(
+            self.tuesday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-02"),
+        )
+        # 2024-01-01 is Monday, next Wednesday is 2024-01-03
+        self.assertEqual(
+            self.wednesday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-03"),
+        )
+        # 2024-01-01 is Monday, next Thursday is 2024-01-04
+        self.assertEqual(
+            self.thursday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-04"),
+        )
+        # 2024-01-01 is Monday, next Friday is 2024-01-05
+        self.assertEqual(
+            self.friday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-05"),
+        )
+        # 2024-01-01 is Monday, next Saturday is 2024-01-06
+        self.assertEqual(
+            self.saturday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-06"),
+        )
+        # 2024-01-01 is Monday, next Sunday is 2024-01-07
+        self.assertEqual(
+            self.sunday._get_next_weekday_date(Date.to_date("2024-01-01")),
+            Date.to_date("2024-01-07"),
+        )


### PR DESCRIPTION
Forward-port the improvement from [#2819](https://github.com/OCA/server-tools/pull/2819) (merged in v16 after v18 migration) to restore missing functionality in `base_time_window` for v18.