### PR TITLE
[18.0][FIX] upgrade_analysis: sort added & removed keys in selection

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -140,8 +140,8 @@ def fieldprint(old, new, field, text, reprs):
             if isinstance(old_selection_keys, tuple | list) and isinstance(
                 new_selection_keys, tuple | list
             ):
-                removed = set(old_selection_keys) - set(new_selection_keys)
-                added = set(new_selection_keys) - set(old_selection_keys)
+                removed = sorted(set(old_selection_keys) - set(new_selection_keys))
+                added = sorted(set(new_selection_keys) - set(old_selection_keys))
                 text = (
                     f"{field} {added and ('added: [' + ', '.join(added) + ']') or ''}"
                     f"{added and removed and ', ' or ''}"


### PR DESCRIPTION
Fixes https://github.com/OCA/server-tools/pull/3315 by sorting the keys.