### PR TITLE
[16.0][FIX] tracking_manager: fix specific case when the user want to track special M2M fields (attachment_ids)

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -108,7 +108,10 @@ class Base(models.AbstractModel):
                         "name": record._tm_get_field_description(field_name),
                         "messages": messages,
                     }
+                    # The if section is matter in case of specific M2M with res_id/res_model
+                    # Ex: ir.attachment
                     for field_name, messages in messages_by_field.items()
+                    if field_name in record._fields
                 ]
                 # We do not use message_post_with_view() because emails would be sent
                 rendered_template = self.env["ir.qweb"]._render(


### PR DESCRIPTION
### How to reproduce:
**Install modules:**
- Accounting
- Document (Enterprise)

**Steps:**
- Enable tracking on `account.move` and track changes on `attachment_ids`.
- Go on Document and upload a new document: traceback :boom: 

(Maybe there are others ways to reproduce)

Fix: ensure the field exists on the model.
