### PR TITLE
[18.0][FIX] sentry: event dropped if include_context key not present

### DIFF
--- a/database_size/README.rst
+++ b/database_size/README.rst
@@ -65,25 +65,26 @@ Size.
 
 The data that is gathered and that is displayed are:
 
-- Model Name - The name of the model to which the data is related
-- Estimated Rows - The number of estimated rows according to the
-  Postgresql query planner. For performance reasons, taking the data
-  from the planner is preferred over doing an actual count, although the
-  results may be imprecise.
-- Bare Table Size - The disk usage of the model table without indexes
-  etc.
-- Index Size - The disk usage of the indexes in the model table.
-- Many2many Tables Size - The disk usage of related many2many tables,
-  including their indexes. To prevent double counts, many2many tables
-  are only correlated with one of their tables (the largest of the two).
-- Attachment Size - The disk usage of the attachments linked to the
-  model records. Because Odoo will deduplicate attachments by content,
-  attachments with the same content may be counted double in the
-  attachment size of other models, but will not be counted double when
-  linked to records of the same model more than once.
-- Total Table Size - Bare Table Size + Index Size
-- Total Database Size - Total Table Size + Many2many Tables Size
-- Total Model Size - Total Database Size + Attachment Size
+-  Model Name - The name of the model to which the data is related
+-  Estimated Rows - The number of estimated rows according to the
+   Postgresql query planner. For performance reasons, taking the data
+   from the planner is preferred over doing an actual count, although
+   the results may be imprecise.
+-  Bare Table Size - The disk usage of the model table without indexes
+   etc.
+-  Index Size - The disk usage of the indexes in the model table.
+-  Many2many Tables Size - The disk usage of related many2many tables,
+   including their indexes. To prevent double counts, many2many tables
+   are only correlated with one of their tables (the largest of the
+   two).
+-  Attachment Size - The disk usage of the attachments linked to the
+   model records. Because Odoo will deduplicate attachments by content,
+   attachments with the same content may be counted double in the
+   attachment size of other models, but will not be counted double when
+   linked to records of the same model more than once.
+-  Total Table Size - Bare Table Size + Index Size
+-  Total Database Size - Total Table Size + Many2many Tables Size
+-  Total Model Size - Total Database Size + Attachment Size
 
 If you click on individual records, you can inspect the sizes of each
 index and many2many table.
@@ -127,7 +128,7 @@ Authors
 Contributors
 ------------
 
-- Stefan Rijnhart <stefan@opener.amsterdam>
+-  Stefan Rijnhart <stefan@opener.amsterdam>
 
 Maintainers
 -----------

--- a/database_size/static/description/index.html
+++ b/database_size/static/description/index.html
@@ -412,14 +412,15 @@ Size.</p>
 <li>Model Name - The name of the model to which the data is related</li>
 <li>Estimated Rows - The number of estimated rows according to the
 Postgresql query planner. For performance reasons, taking the data
-from the planner is preferred over doing an actual count, although the
-results may be imprecise.</li>
+from the planner is preferred over doing an actual count, although
+the results may be imprecise.</li>
 <li>Bare Table Size - The disk usage of the model table without indexes
 etc.</li>
 <li>Index Size - The disk usage of the indexes in the model table.</li>
 <li>Many2many Tables Size - The disk usage of related many2many tables,
 including their indexes. To prevent double counts, many2many tables
-are only correlated with one of their tables (the largest of the two).</li>
+are only correlated with one of their tables (the largest of the
+two).</li>
 <li>Attachment Size - The disk usage of the attachments linked to the
 model records. Because Odoo will deduplicate attachments by content,
 attachments with the same content may be counted double in the

--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -53,7 +53,7 @@ def before_send(event, hint):
         if qualified_name in const.DEFAULT_IGNORED_EXCEPTIONS:
             return None
 
-    if event.setdefault("tags", {})["include_context"]:
+    if event.setdefault("tags", {}).get("include_context"):
         cxtest = get_extra_context(odoo.http.request)
         info_request = ["tags", "user", "extra", "request"]
 

--- a/sentry/tests/test_client.py
+++ b/sentry/tests/test_client.py
@@ -13,7 +13,7 @@ from odoo.tests import TransactionCase
 from odoo.tools import config
 
 from ..const import to_int_if_defined
-from ..hooks import initialize_sentry
+from ..hooks import before_send, initialize_sentry
 
 GIT_SHA = "d670460b4b4aece5915caf5c68d12f560a9fe3e4"
 RELEASE = "test@1.2.3"
@@ -44,12 +44,13 @@ class InMemoryTransport(HttpTransport):
         self.envelopes.append(envelope)
 
     def has_event(self, event_level, event_msg):
-        for event in self.envelopes:
+        for envelope in self.envelopes:
+            event = envelope.get_event()
             if (
-                event.get_event().get("level") == event_level
-                and event.get_event().get("logentry", {}).get("message") == event_msg
+                event.get("level") == event_level
+                and event.get("logentry", {}).get("message") == event_msg
             ):
-                return True
+                return event
         return False
 
     def flush(self, *args, **kwargs):
@@ -146,6 +147,22 @@ class TestClientSetup(TransactionCase):
         self.log(level, msg, exc_info)
         level = "error"
         self.assertEventCaptured(self.client, level, msg)
+
+    def test_capture_events_no_tags(self):
+        """Our 'before_send' can handle events without tags"""
+        level, msg = logging.ERROR, "Test event, can be ignored exception"
+        try:
+            raise TestException(msg)
+        except TestException:
+            exc_info = sys.exc_info()
+        self.log(level, msg, exc_info)
+        level = "error"
+        event = self.client.transport.has_event(level, msg)
+        self.assertTrue(event)
+        # Offer an event without tags to the before_send hook
+        if "tags" in event:
+            del event["tags"]
+        self.assertTrue(before_send(event, {}))
 
     def test_ignore_exceptions(self):
         self.patch_config(


### PR DESCRIPTION
In our (Odoo.sh) setup, we were missing almost all events after migrating to Odoo 18. With this fix, the events were back.

Fixes

```
  File "/home/odoo/.local/lib/python3.12/site-packages/sentry_sdk/client.py", line 595, in _prepare_event
    new_event = before_send(event, hint or {})
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/oca-server-tools/sentry/hooks.py", line 66, in before_send
    if event.setdefault("tags", {})["include_context"]:
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'include_context'
2025-07-08 14:45:45,907 14296 INFO quatra-18-0-development-21441249 sentry_sdk.errors: before send dropped event
```

NB. This error is only logged when running Sentry in debug mode, otherwise events are dropped silently.