### PR TITLE
[18.0][FIX] auto_backup: pin paramiko for compatibility with pysftp

### DIFF
--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -24,5 +24,5 @@
         "view/db_backup_view.xml",
     ],
     "installable": True,
-    "external_dependencies": {"python": ["pysftp", "cryptography"]},
+    "external_dependencies": {"python": ["paramiko<4.0.0", "pysftp", "cryptography"]},
 }

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -11,15 +11,13 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from glob import iglob
 
+import pysftp
+
 from odoo import _, api, exceptions, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.service import db
 
 _logger = logging.getLogger(__name__)
-try:
-    import pysftp
-except ImportError:  # pragma: no cover
-    _logger.debug("Cannot import pysftp")
 
 
 class DbBackup(models.Model):

--- a/auto_backup/tests/test_db_backup.py
+++ b/auto_backup/tests/test_db_backup.py
@@ -10,15 +10,13 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import PropertyMock, patch
 
+import pysftp
+
 from odoo import tools
 from odoo.exceptions import UserError
 from odoo.tests import common
 
 _logger = logging.getLogger(__name__)
-try:
-    import pysftp
-except ImportError:  # pragma: no cover
-    _logger.debug("Cannot import pysftp")
 
 
 model = "odoo.addons.auto_backup.models.db_backup"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ cryptography
 dataclasses
 odoorpc
 openupgradelib
+paramiko<4.0.0
 pysftp
 sentry_sdk>=2.0.0,<=2.22.0


### PR DESCRIPTION
paramiko 4.0.0 dropped support for DSSKey imported by pysftp. See https://github.com/paramiko/paramiko/issues/2537

```
File "/home/odoo/odoo/18.0/server-tools/auto_backup/tests/test_db_backup.py", line 9, in <module>
    import pysftp
  File "/home/odoo/.cache/pypoetry/virtualenvs/18-0-liVCuCj7-py3.12/lib/python3.12/site-packages/pysftp/__init__.py", line 14, in <module>
    from paramiko import AgentKey, RSAKey, DSSKey
ImportError: cannot import name 'DSSKey' from 'paramiko'
```

The import error was dropped silently, making the error show up as

```
File "/home/odoo/odoo/18.0/server-tools/auto_backup/tests/test_db_backup.py", line 28, in <module>
    class TestConnectionException(pysftp.ConnectionException):
                                  ^^^^^^
NameError: name 'pysftp' is not defined
```