### PR TITLE
[14.0][IMP] base_exception: Placeholders for exception rule description

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -1,5 +1,6 @@
 # Copyright 2011 Raphaël Valyi, Renato Lima, Guewen Baconnier, Sodexis
 # Copyright 2017 Akretion (http://www.akretion.com)
+# Copyright 2025 Raumschmiede GmbH
 # Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # Copyright 2020 Hibou Corp.
 # Copyright 2023 ACSONE SA/NV (http://acsone.eu)
@@ -90,6 +91,22 @@ class BaseExceptionModel(models.AbstractModel):
     @api.model
     def _get_popup_action(self):
         return self.env.ref("base_exception.action_exception_rule_confirm")
+
+    def _add_detected_exceptions_to_self(self):
+        return self != self._get_main_records()
+
+    def _detect_exceptions(self, rule):
+        records = super()._detect_exceptions(rule)
+        # If _get_main_records returns self, it adds the exceptions to itself in
+        # detect_exceptions. If _get_main_records does not return self, it adds the
+        # exceptions here
+        if not self._add_detected_exceptions_to_self():
+            return records
+
+        (self - records).exception_ids = [(3, rule.id)]
+        records.exception_ids = [(4, rule.id)]
+
+        return records
 
     def _check_exception(self):
         """Check exceptions

--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -52,28 +52,112 @@ class BaseExceptionModel(models.AbstractModel):
             else:
                 rec.main_exception_id = False
 
-    @api.depends("exception_ids", "ignore_exception")
+    @api.depends(
+        "exception_ids",
+        "exception_ids.name",
+        "exception_ids.description",
+        "exception_ids.description_text_type",
+        "exception_ids.is_blocking",
+        "ignore_exception",
+    )
     def _compute_exceptions_summary(self):
         for rec in self:
             if rec.exception_ids and not rec.ignore_exception:
-                rec.exceptions_summary = "<ul>%s</ul>" % "".join(
-                    [
-                        "<li>%s: <i>%s</i> <b>%s<b></li>"
-                        % tuple(
-                            map(
-                                html.escape,
-                                (
-                                    e.name,
-                                    e.description or "",
-                                    _("(Blocking exception)") if e.is_blocking else "",
-                                ),
-                            )
-                        )
-                        for e in rec.exception_ids
-                    ]
-                )
+                rec.exceptions_summary = rec._get_exceptions_summary()
             else:
                 rec.exceptions_summary = False
+
+    def _get_exceptions_summary(self):
+        self.ensure_one()
+
+        summaries = []
+        for exception in self.exception_ids:
+            summaries += self._get_exceptions_summaries_by_exception(exception)
+
+        return self._get_pretty_exceptions_summary_from_summaries(summaries)
+
+    def _get_exceptions_summaries_by_exception(self, exception):
+        self.ensure_one()
+
+        # True if the description is e.g. empty or flagged as plain description. We
+        # expect that no record is used to render the description, that's why self can
+        # be used to get the description. Even if exception.model is not self._name
+        if not exception.description_needs_rendering():
+            return [self._get_pretty_summary_for_exception(exception)]
+
+        # If the exception needs to be rendered, we have to get the records on which
+        # the exception was detected on to use them for rendering. If the exception
+        # model is self._name or the exception was detected on a sub-record whose model
+        # inherits from base.exception.method, records will the same as self.
+        records = self._get_records_for_description_rendering(exception)
+
+        summaries = []
+        for record in records:
+            # Even with rendering it can happen that multiple records return the same
+            # rendered description, e.g. if the description is plain text but its type
+            # is set to Jinja. The same description will be added multiple times to the
+            # final summary. With that the user knows that multiple sub-records have
+            # the same exception assigned and were rendered
+            summary = record._get_pretty_summary_for_exception(exception)
+            summaries.append(summary)
+
+        return summaries
+
+    def _get_records_for_description_rendering(self, exception):
+        self.ensure_one()
+
+        if exception.model == self._name:
+            # Exception needs the current record to render
+            return self
+
+        sub_record_ids = []
+        # Collect all sub-records that have the exception
+        for field in self._get_sub_exception_field_names():
+            sub_records = self.mapped(field)
+
+            if exception.model != sub_records._name:
+                continue
+
+            for sub_record in sub_records:
+                # For models that inherit from base.exception.method this is always
+                # False. Only for base.exception models it can be True
+                if sub_record._has_exception_rule_assigned(exception):
+                    sub_record_ids.append(sub_record.id)
+
+        if sub_record_ids:
+            return self.env[exception.model].browse(sub_record_ids)
+
+        # If there are no sub-records that have the exception assigned, possible
+        # because their model inherits from base.exception.method, self is returned
+        # to use it to render the description. This means it is not possible to
+        # use the same model in the description syntax as the model on which the
+        # exception was detected on
+        return self
+
+    def _get_pretty_summary_for_exception(self, exception):
+        self.ensure_one()
+
+        args = list(
+            map(
+                html.escape,
+                (
+                    exception.name,
+                    exception.render_description(self),
+                ),
+            )
+        )
+
+        if exception.is_blocking:
+            args.append(_(" <b>(Blocking exception)</b>"))
+        else:
+            args.append("")
+
+        return "%s: <i>%s</i>%s" % tuple(args)
+
+    def _get_pretty_exceptions_summary_from_summaries(self, summaries):
+        return "<ul>%s</ul>" % "".join(
+            map(lambda summary: f"<li>{summary}</li>", summaries)
+        )
 
     def _popup_exceptions(self):
         action = self._get_popup_action().sudo().read()[0]
@@ -94,6 +178,12 @@ class BaseExceptionModel(models.AbstractModel):
 
     def _add_detected_exceptions_to_self(self):
         return self != self._get_main_records()
+
+    def _has_exception_rule_assigned(self, exception):
+        # Models inheriting from base.exception have exception_ids as field. Records of
+        # this model can be checked to have exceptions. Because of this the record can
+        # be used to render the exception description
+        return exception in self.exception_ids
 
     def _detect_exceptions(self, rule):
         records = super()._detect_exceptions(rule)

--- a/base_exception/models/base_exception_method.py
+++ b/base_exception/models/base_exception_method.py
@@ -3,6 +3,7 @@
 # Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 # Copyright 2020 Hibou Corp.
 # Copyright 2023 ACSONE SA/NV (http://acsone.eu)
+# Copyright 2025 Raumschmiede GmbH
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
@@ -27,6 +28,13 @@ class BaseExceptionMethod(models.AbstractModel):
         write these exceptions on the sale order, so they are visible.
         """
         return self
+
+    def _get_sub_exception_field_names(self):
+        """
+        Use this to check exceptions on underlying records and the
+        detected exceptions need to be added to the current record
+        """
+        return []
 
     def _rule_domain(self):
         """Filter exception.rules.
@@ -64,23 +72,18 @@ class BaseExceptionMethod(models.AbstractModel):
             rules_to_add[rule_info.id] |= to_add
             if records_with_exception:
                 all_exception_ids.append(rule_info.id)
-        # Cumulate all the records to attach to the rule
-        # before linking. We don't want to call "rule.write()"
-        # which would:
-        # * write on write_date so lock the exception.rule
-        # * trigger the recomputation of "main_exception_id" on
-        #   all the sale orders related to the rule, locking them all
-        #   and preventing concurrent writes
-        # Reversing the write by writing on SaleOrder instead of
-        # ExceptionRule fixes the 2 kinds of unexpected locks.
-        # It should not result in more queries than writing on ExceptionRule:
-        # the "to remove" part generates one DELETE per rule on the relation
-        # table
-        # and the "to add" part generates one INSERT (with unnest) per rule.
+
         for rule_id, records in rules_to_remove.items():
             records.write({"exception_ids": [(3, rule_id)]})
         for rule_id, records in rules_to_add.items():
             records.write({"exception_ids": [(4, rule_id)]})
+
+        # Detect exceptions on underlying sub-records if needed. If the sub-records'
+        # model defines the current model in _get_main_records,
+        # the exceptions detected are added to the current record
+        for field in self._get_sub_exception_field_names():
+            all_exception_ids += self.mapped(field).detect_exceptions()
+
         return all_exception_ids
 
     @api.model

--- a/base_exception/models/base_exception_method.py
+++ b/base_exception/models/base_exception_method.py
@@ -60,7 +60,9 @@ class BaseExceptionMethod(models.AbstractModel):
             records_with_rule_in_exceptions = main_records.filtered(
                 lambda r, rule_id=rule_info.id: rule_id in r.exception_ids.ids
             )
-            records_with_exception = self._detect_exceptions(rule_info)
+            records_with_exception = self._detect_exceptions(
+                rule_info
+            )._get_main_records()
             to_remove = records_with_rule_in_exceptions - records_with_exception
             to_add = records_with_exception - records_with_rule_in_exceptions
             # we expect to always work on the same model type

--- a/base_exception/models/base_exception_method.py
+++ b/base_exception/models/base_exception_method.py
@@ -43,6 +43,14 @@ class BaseExceptionMethod(models.AbstractModel):
         """
         return [("model", "=", self._name), ("active", "=", True)]
 
+    def _has_exception_rule_assigned(self, exception):
+        # If a model inherits from base.exception.method, the models' records return
+        # False as the exception is not saved on them as they have no exception_ids.
+        # Because of this the records cannot be used to render the description as it
+        # is not possible to determine on which of them the exception was detected on.
+        # _detect_exceptions could be called but this is bad for performance
+        return False
+
     def detect_exceptions(self):
         """List all exception_ids applied on self
         Exception ids are also written on records

--- a/base_exception/models/exception_rule.py
+++ b/base_exception/models/exception_rule.py
@@ -5,13 +5,11 @@
 # Copyright 2023 ACSONE SA/NV (http://acsone.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import logging
+from jinja2 import Template
 
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.safe_eval import safe_eval
-
-_logger = logging.getLogger(__name__)
 
 
 class ExceptionRule(models.Model):
@@ -20,7 +18,24 @@ class ExceptionRule(models.Model):
     _order = "active desc, sequence asc"
 
     name = fields.Char("Exception Name", required=True, translate=True)
-    description = fields.Text(translate=True)
+    description = fields.Text(
+        "Description",
+        translate=True,
+        help="You can use placeholders here. Check the help text"
+        " on field Description Text Type for more information",
+    )
+    description_text_type = fields.Selection(
+        [
+            ("plain", "Text"),
+            ("jinja", "Jinja"),
+        ],
+        default="plain",
+        required=True,
+        help="Define how the text in the description field shall be handled.\n"
+        "Text: Use the description as it is without formatting it\n"
+        "Jinja: The description is parsed. {{object.field}} syntax can be used to"
+        "to define dynamic values in the description",
+    )
     sequence = fields.Integer(help="Gives the sequence order when applying the test")
     model = fields.Selection(selection=[], string="Apply on", required=True)
 
@@ -71,6 +86,53 @@ class ExceptionRule(models.Model):
         self.ensure_one()
         return safe_eval(self.domain)
 
+    def description_needs_rendering(self):
+        self.ensure_one()
+
+        return self.description and self.description_text_type != "plain"
+
+    def render_description(self, record):
+        self.ensure_one()
+
+        if not self.description:
+            return ""
+
+        if self.description_text_type == "plain":
+            return self.description
+        elif self.description_text_type == "jinja":
+            return self._render_description_by_jinja(record)
+
+    def _render_description_by_jinja(self, record):
+        self.ensure_one()
+
+        res = None
+        try:
+            res = Template(self.description).render(
+                **self._render_description_context(record)
+            )
+        except Exception as e:
+            raise UserError(
+                _(
+                    "Exception rule '%(rule)s' has an invalid Jinja description.\n"
+                    "The following error was raised while rendering it:\n\n %(error)s",
+                    rule=self.name,
+                    error=e,
+                )
+            )
+
+        return res
+
+    def _render_description_context(self, record):
+        self.ensure_one()
+
+        return {
+            "exception": self,
+            # Same as for the exception code context but no "self".
+            # self is in use by Jinja
+            "object": record,
+            "obj": record,
+        }
+
     def _get_rules_info_for_domain(self, domain):
         """returns the rules that match the domain
 
@@ -110,6 +172,7 @@ class ExceptionRule(models.Model):
             "id": self.id,
             "name": self.name,
             "description": self.description,
+            "description_text_type": self.description_text_type,
             "sequence": self.sequence,
             "model": self.model,
             "exception_type": self.exception_type,

--- a/base_exception/readme/CONTRIBUTORS.rst
+++ b/base_exception/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
 
 * Kevin Khao <kevin.khao@akretion.com>
 * Laurent Mignon <laurent.mignon@acsone.eu>
+* Joshua Lauer <joshua.lauer@raumschmiede.de>

--- a/base_exception/tests/common.py
+++ b/base_exception/tests/common.py
@@ -16,9 +16,11 @@ class TestBaseExceptionCommon(SavepointCase):
 
         cls.loader = FakeModelLoader(cls.env, cls.__module__)
         cls.loader.backup_registry()
-        from .purchase_test import ExceptionRule, LineTest, PurchaseTest
+        from .purchase_test import ExceptionRule, LineTest, LineTestMethod, PurchaseTest
 
-        cls.loader.update_registry((ExceptionRule, LineTest, PurchaseTest))
+        cls.loader.update_registry(
+            (ExceptionRule, LineTest, LineTestMethod, PurchaseTest)
+        )
 
         cls.partner = cls.env["res.partner"].create({"name": "Foo"})
         cls.po = cls.env["base.exception.test.purchase"].create(
@@ -26,6 +28,10 @@ class TestBaseExceptionCommon(SavepointCase):
                 "name": "Test base exception to basic purchase",
                 "partner_id": cls.partner.id,
                 "line_ids": [
+                    (0, 0, {"name": "line test", "amount": 120.0, "qty": 1.5}),
+                    (0, 0, {"name": "line test 2", "amount": 220.0, "qty": 1.5}),
+                ],
+                "line_method_ids": [
                     (0, 0, {"name": "line test", "amount": 120.0, "qty": 1.5}),
                     (0, 0, {"name": "line test 2", "amount": 220.0, "qty": 1.5}),
                 ],
@@ -47,6 +53,16 @@ class TestBaseExceptionCommon(SavepointCase):
                 "description": "Line must have price greater than 100",
                 "sequence": 9,
                 "model": "base.exception.test.purchase.line",
+                "code": "failed = self.amount < 100",
+                "exception_type": "by_py_code",
+            }
+        )
+        cls.sub_exception_rule_method = cls.env["exception.rule"].create(
+            {
+                "name": "Amount less than 100",
+                "description": "Method Line must have price greater than 100",
+                "sequence": 9,
+                "model": "base.exception.method.test.purchase.line",
                 "code": "failed = self.amount < 100",
                 "exception_type": "by_py_code",
             }

--- a/base_exception/tests/common.py
+++ b/base_exception/tests/common.py
@@ -26,7 +26,8 @@ class TestBaseExceptionCommon(SavepointCase):
                 "name": "Test base exception to basic purchase",
                 "partner_id": cls.partner.id,
                 "line_ids": [
-                    (0, 0, {"name": "line test", "amount": 120.0, "qty": 1.5})
+                    (0, 0, {"name": "line test", "amount": 120.0, "qty": 1.5}),
+                    (0, 0, {"name": "line test 2", "amount": 220.0, "qty": 1.5}),
                 ],
             }
         )
@@ -37,6 +38,16 @@ class TestBaseExceptionCommon(SavepointCase):
                 "sequence": 10,
                 "model": "base.exception.test.purchase",
                 "code": "if not self.partner_id.zip: failed=True",
+                "exception_type": "by_py_code",
+            }
+        )
+        cls.sub_exception_rule = cls.env["exception.rule"].create(
+            {
+                "name": "Amount less than 100",
+                "description": "Line must have price greater than 100",
+                "sequence": 9,
+                "model": "base.exception.test.purchase.line",
+                "code": "failed = self.amount < 100",
                 "exception_type": "by_py_code",
             }
         )

--- a/base_exception/tests/purchase_test.py
+++ b/base_exception/tests/purchase_test.py
@@ -13,8 +13,14 @@ class ExceptionRule(models.Model):
         selection_add=[("exception_method_no_zip", "Purchase exception no zip")]
     )
     model = fields.Selection(
-        selection_add=[("base.exception.test.purchase", "Purchase Test")],
-        ondelete={"base.exception.test.purchase": "cascade"},
+        selection_add=[
+            ("base.exception.test.purchase", "Purchase Test"),
+            ("base.exception.test.purchase.line", "Purchase Test Line"),
+        ],
+        ondelete={
+            "base.exception.test.purchase": "cascade",
+            "base.exception.test.purchase.line": "cascade",
+        },
     )
 
 
@@ -69,6 +75,9 @@ class PurchaseTest(models.Model):
     def button_cancel(self):
         self.write({"state": "cancel"})
 
+    def _get_sub_exception_field_names(self):
+        return ["line_ids"]
+
     def exception_method_no_zip(self):
         records_fail = self.env["base.exception.test.purchase"]
         for rec in self:
@@ -78,6 +87,7 @@ class PurchaseTest(models.Model):
 
 
 class LineTest(models.Model):
+    _inherit = "base.exception"
     _name = "base.exception.test.purchase.line"
     _description = "Base Exception Test Model Line"
 
@@ -85,3 +95,12 @@ class LineTest(models.Model):
     lead_id = fields.Many2one("base.exception.test.purchase", ondelete="cascade")
     qty = fields.Float()
     amount = fields.Float()
+
+    def _get_main_records(self):
+        return self.lead_id
+
+    def _detect_exceptions(self, rule):
+        records = super()._detect_exceptions(rule)
+        (self - records).exception_ids = [(3, rule.id)]
+        records.exception_ids = [(4, rule.id)]
+        return records.mapped("lead_id")

--- a/base_exception/tests/purchase_test.py
+++ b/base_exception/tests/purchase_test.py
@@ -16,10 +16,12 @@ class ExceptionRule(models.Model):
         selection_add=[
             ("base.exception.test.purchase", "Purchase Test"),
             ("base.exception.test.purchase.line", "Purchase Test Line"),
+            ("base.exception.method.test.purchase.line", "Purchase Test Method Line"),
         ],
         ondelete={
             "base.exception.test.purchase": "cascade",
             "base.exception.test.purchase.line": "cascade",
+            "base.exception.method.test.purchase.line": "cascade",
         },
     )
 
@@ -46,6 +48,9 @@ class PurchaseTest(models.Model):
     active = fields.Boolean(default=True)
     partner_id = fields.Many2one("res.partner", string="Partner")
     line_ids = fields.One2many("base.exception.test.purchase.line", "lead_id")
+    line_method_ids = fields.One2many(
+        "base.exception.method.test.purchase.line", "lead_id"
+    )
     amount_total = fields.Float(compute="_compute_amount_total", store=True)
 
     @api.depends("line_ids")
@@ -54,7 +59,7 @@ class PurchaseTest(models.Model):
             for line in record.line_ids:
                 record.amount_total += line.amount * line.qty
 
-    @api.constrains("ignore_exception", "line_ids", "state")
+    @api.constrains("ignore_exception", "line_ids", "line_method_ids", "state")
     def test_purchase_check_exception(self):
         orders = self.filtered(lambda s: s.state == "purchase")
         if orders:
@@ -76,7 +81,7 @@ class PurchaseTest(models.Model):
         self.write({"state": "cancel"})
 
     def _get_sub_exception_field_names(self):
-        return ["line_ids"]
+        return ["line_ids", "line_method_ids"]
 
     def exception_method_no_zip(self):
         records_fail = self.env["base.exception.test.purchase"]
@@ -99,8 +104,21 @@ class LineTest(models.Model):
     def _get_main_records(self):
         return self.lead_id
 
-    def _detect_exceptions(self, rule):
-        records = super()._detect_exceptions(rule)
-        (self - records).exception_ids = [(3, rule.id)]
-        records.exception_ids = [(4, rule.id)]
-        return records.mapped("lead_id")
+
+class LineTestMethod(models.Model):
+    _inherit = "base.exception.method"
+    _name = "base.exception.method.test.purchase.line"
+    _description = "Base Exception Test Model Line"
+
+    name = fields.Char()
+    lead_id = fields.Many2one("base.exception.test.purchase", ondelete="cascade")
+    qty = fields.Float()
+    amount = fields.Float()
+
+    # Models inheriting from .method must implement this field as their records
+    # are filtered based on this field
+    ignore_exception = fields.Boolean("Ignore Exceptions", copy=False)
+
+    # This model here must override _get_main_records as it has no exception_ids
+    def _get_main_records(self):
+        return self.lead_id

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -72,3 +72,51 @@ class TestBaseException(TestBaseExceptionCommon):
             self.po.button_confirm()
         self.assertEqual(self.po.exception_ids, self.exception_rule)
         self.assertTrue(self.po.exceptions_summary)
+
+    def test_exception_in_sub_records(self):
+        self.exception_rule.active = False
+        line = self.po.line_ids[0]
+        line.amount = 90
+
+        self.po.detect_exceptions()
+
+        self.assertEqual(self.po.exception_ids, self.sub_exception_rule)
+        # Even if the exception was not raised by self.po, its description must still
+        # be in the summary of it
+        self.assertIn(self.sub_exception_rule.description, self.po.exceptions_summary)
+
+        self.assertEqual(line.main_exception_id, self.sub_exception_rule)
+        self.assertEqual(line.exception_ids, self.sub_exception_rule)
+        self.assertIn(
+            self.sub_exception_rule.description,
+            line.exceptions_summary,
+        )
+        # self.po has 2 lines, the exception is detected only on the 1st line.
+        # The 2nd line must not have any exception assigned or summary set
+        self.assertFalse(self.po.line_ids[1].exception_ids)
+        self.assertFalse(self.po.line_ids[1].exceptions_summary)
+
+        self.exception_rule.active = True
+
+        self.po.detect_exceptions()
+
+        # Now both exceptions must be assigned to the record, in the right order
+        self.assertEqual(self.po.exception_ids[0], self.sub_exception_rule)
+        self.assertEqual(self.po.exception_ids[1], self.exception_rule)
+
+        self.po.line_ids[1].amount = 80
+        self.po.detect_exceptions()
+
+        self.assertEqual(line.exception_ids, self.sub_exception_rule)
+        self.assertEqual(self.po.line_ids[1].exception_ids, self.sub_exception_rule)
+        self.assertIn(
+            self.sub_exception_rule.description,
+            self.po.line_ids[1].exceptions_summary,
+        )
+
+        line.amount = 200
+        line.detect_exceptions()
+
+        # Updating sub-exceptions must update exceptions on parent
+        self.assertFalse(line.exception_ids)
+        self.assertEqual(self.po.exception_ids, self.exception_rule)

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -120,3 +120,23 @@ class TestBaseException(TestBaseExceptionCommon):
         # Updating sub-exceptions must update exceptions on parent
         self.assertFalse(line.exception_ids)
         self.assertEqual(self.po.exception_ids, self.exception_rule)
+
+    def test_exception_in_sub_record_method(self):
+        self.exception_rule.active = False
+
+        self.po.line_method_ids.amount = 90
+        # Model has no exception_ids and returns self.lead_id in _get_main_records,
+        # that's why the exceptions are added to the parent
+        self.po.line_method_ids.detect_exceptions()
+
+        self.assertEqual(self.po.exception_ids, self.sub_exception_rule_method)
+        self.assertIn(
+            self.sub_exception_rule_method.description,
+            self.po.exceptions_summary,
+        )
+
+        self.po.line_method_ids.amount = 200
+        self.po.detect_exceptions()
+        # Parent implemented line_method_ids in _get_sub_exception_field_names,
+        # that's why the exceptions were detected on child records but none was found
+        self.assertFalse(self.po.exception_ids)

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -114,6 +114,14 @@ class TestBaseException(TestBaseExceptionCommon):
             self.po.line_ids[1].exceptions_summary,
         )
 
+        desc = "Line {{line}} must have price greater than 100"
+        self.sub_exception_rule.description = desc
+        # Jinja content was not parsed, must still contain the syntax
+        self.assertIn(
+            "{{line}}",
+            self.po.exceptions_summary,
+        )
+
         line.amount = 200
         line.detect_exceptions()
 
@@ -140,3 +148,128 @@ class TestBaseException(TestBaseExceptionCommon):
         # Parent implemented line_method_ids in _get_sub_exception_field_names,
         # that's why the exceptions were detected on child records but none was found
         self.assertFalse(self.po.exception_ids)
+
+    def test_description_jinja_success(self):
+        self.maxDiff = None
+        self.exception_rule.description_text_type = "jinja"
+        desc = "{{object.partner_id.name}} has no ZIP. Model: {{exception.model}}"
+        self.exception_rule.description = desc
+        self.exception_rule.is_blocking = True
+
+        self.po.detect_exceptions()
+
+        self.assertIn(self.po.partner_id.name, self.po.exceptions_summary)
+        self.assertIn(self.po._name, self.po.exceptions_summary)
+
+        self.sub_exception_rule.description_text_type = "jinja"
+        self.sub_exception_rule.description = (
+            "Line's price {{object.amount}} is lower than 100"
+        )
+        line = self.po.line_ids[0]
+        line.amount = 90
+        self.po.detect_exceptions()
+
+        self.assertIn(str(line.amount), self.po.exceptions_summary)
+        self.assertIn(str(line.amount), line.exceptions_summary)
+
+        line2 = self.po.line_ids[1]
+        line2.amount = 80
+        self.po.detect_exceptions()
+        self.po.invalidate_cache()
+
+        # Both lines have the same exception but each line has a unique description.
+        # Summary of parent must have both descriptions
+        self.assertIn(str(line2.amount), line2.exceptions_summary)
+        self.assertNotIn(str(line.amount), line2.exceptions_summary)
+        self.assertEqual(
+            self.po.exceptions_summary,
+            "<ul>"
+            "<li>Amount less than 100: <i>Line's price 90.0 is lower than 100</i></li>"
+            "<li>Amount less than 100: <i>Line's price 80.0 is lower than 100</i></li>"
+            "<li>No ZIP code on destination: "
+            "<i>Foo has no ZIP. Model: base.exception.test.purchase</i> "
+            "<b>(Blocking exception)</b>"
+            "</li>"
+            "</ul>",
+        )
+
+        # Use a field here that only exist on base.exception.test.purchase and not on
+        # base.exception.method.test.purchase.line to assert that the passed record is
+        # self and not a method line
+        desc = "PO in state {{obj.state}} has invalid data"
+        self.sub_exception_rule_method.description = desc
+        self.sub_exception_rule_method.description_text_type = "jinja"
+
+        method_line = self.po.line_method_ids[0]
+        method_line.amount = 70
+        self.po.detect_exceptions()
+        self.po.invalidate_cache()
+
+        self.assertIn(self.sub_exception_rule_method, self.po.exception_ids)
+        self.assertIn(
+            "PO in state draft has invalid data",
+            self.po.exceptions_summary,
+        )
+
+    def test_description_jinja_error(self):
+        self.exception_rule.description = "Partner ${name.field} has no ZIP"
+        self.exception_rule.description_text_type = "jinja"
+
+        self.po.detect_exceptions()
+        # Computation does not raise an error but because Jinja syntax is wrong
+        # the syntax must still be in the summary
+        self.po._compute_exceptions_summary()
+        self.assertIn("name.field", self.po.exceptions_summary)
+
+        self.exception_rule.description = "Partner {{name.field}} has no ZIP"
+        self.po.detect_exceptions()
+        # Computation of exceptions_summary raises an error.
+        # Here because "name" is not available in the Jinja context
+        with self.assertRaises(UserError) as e:
+            self.po._compute_exceptions_summary()
+        self.assertIn("is undefined", str(e.exception))
+
+        desc = "Partner {{object.filtered(lambda o: o.name)}} has no ZIP"
+        self.exception_rule.description = desc
+
+        self.po.detect_exceptions()
+        # Jinja doesn't like lambda
+        with self.assertRaises(UserError) as e:
+            self.po._compute_exceptions_summary()
+        self.assertIn("expected token", str(e.exception))
+
+        desc = "Partner {{object.unexisting_field}} has no ZIP"
+        self.exception_rule.description = desc
+
+        # Using an non-existing field works but nothing is rendered
+        self.po.detect_exceptions()
+        self.assertIn("Partner  has no ZIP", self.po.exceptions_summary)
+
+        desc = "Partner {{object.fi.fu}} has no ZIP"
+        self.exception_rule.description = desc
+
+        self.po.detect_exceptions()
+        # But Jinja raises an error when a sub-field is used of a non-existing field
+        with self.assertRaises(UserError) as e:
+            self.po._compute_exceptions_summary()
+        self.assertIn("has no attribute 'fi'", str(e.exception))
+
+        self.exception_rule.active = False
+
+        # User expected that base.exception.method.test.purchase.line can be used as
+        # record in the description because the model on the exception is set to this.
+        # But models inheriting from base.exception.method can't be used. Must not work
+        desc = "Method Line of {{object.lead_id.name}} has invalid data"
+        self.sub_exception_rule_method.description = desc
+        self.sub_exception_rule_method.description_text_type = "jinja"
+
+        method_line = self.po.line_method_ids[0]
+        method_line.amount = 70
+        self.po.detect_exceptions()
+        with self.assertRaises(UserError) as e:
+            self.po._compute_exceptions_summary()
+
+        self.assertIn(
+            "odoo.api.base.exception.test.purchase object' has no attribute 'lead_id'",
+            str(e.exception),
+        )

--- a/base_exception/views/base_exception_view.xml
+++ b/base_exception/views/base_exception_view.xml
@@ -8,6 +8,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="description" />
+                <field name="description_text_type" />
                 <field name="model" />
                 <field name="active" widget="boolean_toggle" />
             </tree>
@@ -37,6 +38,7 @@
                         <group>
                             <field name="active" invisible="1" />
                             <field name="description" />
+                            <field name="description_text_type" />
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
Hello.

I changed the exception rules to use Jinja in exception rule descriptions.
For that I changed a bit more in the module so that for exceptions that were detected on underlying records (like in `sale_exception`) the text is still correctly added to the exceptions summary on the parent records. I adjusted the tests to cover this.

Useful for us as we have a lot of sales exceptions. Some exceptions check whether any child of a sold BOM product contains valid data. For BOMs with lots of children or BOMs in BOMs it is not helpful enough for the user to see that the 1st SO line has the exception "The product has no weight set".
With my change you can use "The product {{obj.default_code}} has no weight set" as description.


My changes do not break modules that depend on `base_exception`. I tested it on `sale_exception`. The only thing that wouldn't work in `sale_exception` is if you use the placeholders that the exceptions summary for the SO line wouldn't be correctly computed as `sale_exception` defines its own fields on the SO line.
**EDIT 2**: With the latest changes `sale_exception` will break,


~I wasn't sure whether it is better to have Jinja or a separate code field as placeholders. I like it more to write code, normal non-dev users would rather use Jinja, like in mail templates. That's why I added both to make everyone happy.
But for the Jinja stuff I added a dependency to "mail" as this provides already a function that parses Jinja. I saw in another OCA module that it was used like that. I did the same to keep it simple and consistent.
If this new dependency is not good, I could move this into a new module.~

**EDIT 2**: I removed the description code placeholders. Can't say whether they are good for the OCA module. I will add this in a separate module in our repo.


I checked which modules depend on `base_exception`. The ones I found I already adjusted to work with the new field to define which fields contain sub-records for which exceptions must be checked.
So far I found 5 modules. I already changed the code in them, but I would create the PRs to change them later after the discussion here.
**EDIT**: I already added the PR for `sales_exception`: https://github.com/OCA/sale-workflow/pull/3861. Can be used as example or for testing if you want. And for that more changes are needed. 


Everything is still more a draft. I would like to hear your opinion on the changes. Also about naming new defs and fields.


Screenshots:


Jinja in exception description:
<img width="940" height="604" alt="image" src="https://github.com/user-attachments/assets/f482240d-b122-4b33-be1b-d53c876e1382" />
**EDIT 2** Is now `{{...}}` and not `${...}` to avoid new dependency and to have the same as in later Odoo versions.

Exceptions in sales order:
<img width="1534" height="757" alt="image" src="https://github.com/user-attachments/assets/0ed621f2-b14b-446e-98f9-9498cb820025" />


