### PR TITLE
[14.0][IMP] base_exception: New Exception Type "By python code batch"

### DIFF
--- a/base_exception/models/base_exception.py
+++ b/base_exception/models/base_exception.py
@@ -31,12 +31,14 @@ class ExceptionRule(models.Model):
         selection=[
             ("by_domain", "By domain"),
             ("by_py_code", "By python code"),
+            ("by_py_code_batch", "By python code batch"),
             ("by_method", "By method"),
         ],
         string="Exception Type",
         required=True,
         default="by_py_code",
-        help="By python code: allow to define any arbitrary check\n"
+        help="By python code: allow to define any arbitrary check on a single record\n"
+        "By python code batch: allow to define any arbitrary check on all records\n"
         "By domain: limited to a selection by an odoo domain:\n"
         "           performance can be better when exceptions"
         "           are evaluated with several records\n"
@@ -60,6 +62,7 @@ class ExceptionRule(models.Model):
         for rule in self:
             if (
                 (rule.exception_type == "by_py_code" and not rule.code)
+                or (rule.exception_type == "by_py_code_batch" and not rule.code)
                 or (rule.exception_type == "by_domain" and not rule.domain)
                 or (rule.exception_type == "by_method" and not rule.method)
             ):
@@ -173,6 +176,8 @@ class BaseExceptionMethod(models.AbstractModel):
     def _detect_exceptions(self, rule):
         if rule.exception_type == "by_py_code":
             return self._detect_exceptions_by_py_code(rule)
+        elif rule.exception_type == "by_py_code_batch":
+            return self._detect_exceptions_by_py_code_batch(rule)
         elif rule.exception_type == "by_domain":
             return self._detect_exceptions_by_domain(rule)
         elif rule.exception_type == "by_method":
@@ -192,6 +197,16 @@ class BaseExceptionMethod(models.AbstractModel):
             if self._rule_eval(rule, record):
                 records_with_exception |= record
         return records_with_exception
+
+    def _detect_exceptions_by_py_code_batch(self, rule):
+        """
+        Find exceptions found on self.
+        """
+        domain = self._get_base_domain()
+        records = self.search(domain)
+        records_with_exception = self._rule_eval(rule, records)
+
+        return records_with_exception or self.browse()
 
     def _detect_exceptions_by_domain(self, rule):
         """

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -106,3 +106,31 @@ class TestBaseException(SavepointCase):
             self.po.button_confirm()
         self.assertTrue(self.po.exception_ids)
         self.assertTrue(self.po.exceptions_summary)
+
+    def test_fail_by_py_batch(self):
+        self.exception_rule.write(
+            {
+                "code": "failed = self.filtered(lambda po: not po.partner_id.zip)",
+                "exception_type": "by_py_code_batch",
+            }
+        )
+        po2 = self.po.copy()
+        pos = self.po | po2
+
+        with self.assertRaises(ValidationError):
+            pos.button_confirm()
+
+        self.assertEqual(self.po.exception_ids, self.exception_rule)
+        self.assertEqual(po2.exception_ids, self.exception_rule)
+
+        self.exception_rule.write(
+            {
+                "code": "raise Exception(sorted(self, key=lambda po: po.id))",
+            }
+        )
+
+        with self.assertRaises(UserError) as e:
+            pos.detect_exceptions()
+
+        # Ensure that the code is really called with all orders as self
+        self.assertIn(str(sorted(pos, key=lambda po: po.id)), str(e.exception))

--- a/base_exception/views/base_exception_view.xml
+++ b/base_exception/views/base_exception_view.xml
@@ -56,7 +56,7 @@
                         <page
                             name="code"
                             string="Python Code"
-                            attrs="{'invisible': [('exception_type','!=','by_py_code')], 'required': [('exception_type','=','by_py_code')]}"
+                            attrs="{'invisible': [('exception_type','not in',['by_py_code', 'by_py_code_batch'])], 'required': [('exception_type','not in',['by_py_code', 'by_py_code_batch'])]}"
                         >
                             <field
                                 name="code"
@@ -68,7 +68,7 @@
                         <page
                             name="help"
                             string="Help"
-                            attrs="{'invisible': [('exception_type','!=','by_py_code')]}"
+                            attrs="{'invisible': [('exception_type','not in',['by_py_code', 'by_py_code_batch'])]}"
                         >
                             <group>
                                 <div style="margin-top: 4px;">
@@ -76,10 +76,18 @@
                                     <p
                                     >Various fields may use Python code or Python expressions. The following variables can be used:</p>
                                     <ul>
-                                        <li><code
-                                            >self</code>: Record on which the rule is evaluated.</li>
-                                        <li>To block the exception use: <code
-                                            >failed = True</code></li>
+                                        <li>
+                                            <code
+                                            >self</code>: Record(s) on which the rule is evaluated.
+                                        </li>
+                                        <li>
+                                            To block the exception for a single record use:
+                                            <code>failed = True</code>
+                                        </li>
+                                        <li>
+                                            To block the exception for multiple records assign the failed records, e.g.
+                                            <code>failed = self.filtered(...)</code>
+                                        </li>
                                     </ul>
                                     <p
                                     >As well as all the libraries provided in safe_eval.</p>


### PR DESCRIPTION
Hello.

If a code exception is checked on a lot of records, the performance can be slow as the exception's code must be evaled for each record.
For better performance I added `by_py_code_batch` so that every record in `self` can be checked.

Almost the same as the existing type `by_method`, but now with front end code