### PR TITLE
[18.0][FIX] base_name_search_improved: prevent recursion on relational fields

### DIFF
--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -60,7 +60,7 @@ def _extend_name_results(self, domain, results, limit):
     result_count = len(results)
     if result_count < limit:
         domain += [("id", "not in", results)]
-        rec_ids = self._search(
+        rec_ids = self.with_context(skip_smart_name_search=True)._search(
             domain,
             limit=limit - result_count,
         )
@@ -93,6 +93,10 @@ class Base(models.AbstractModel):
     @api.model
     def _search_display_name(self, operator, value):
         domain = super()._search_display_name(operator, value)
+        # Avoid applying smart search logic during a recursive call.
+        if self.env.context.get("skip_smart_name_search"):
+            return domain
+
         if self.env.context.get(
             "force_smart_name_search", False
         ) or _get_use_smart_name_search(self.sudo()):


### PR DESCRIPTION
The module's enhanced search functionality can cause a RecursionError when a relational field is used in the smart search configuration. The Odoo ORM triggers this by recursively calling name_search, which results in an infinite loop.

This commit breaks the loop by using a context key ('skip_smart_name_search'). During a recursive call, the module now falls back to the standard search behavior for that specific call, ensuring system stability while keeping the enhanced functionality active for the top-level search.