### PR TITLE
[18.0][FIX] base_name_search_improved: restore v16 behavior in _search_smart_search

### DIFF
--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -82,36 +82,19 @@ class Base(models.AbstractModel):
     @api.model
     def _search_smart_search(self, operator, value):
         if value and operator in ALLOWED_OPS:
-            matching_records = self.with_context(
-                force_smart_name_search=True
-            ).name_search(name=value, operator=operator)
-            if matching_records:
-                record_ids = [record[0] for record in matching_records]
-                return [("id", "in", record_ids)]
-        return [("id", "=", False)]
-
-    @api.model
-    def _search_display_name(self, operator, value):
-        domain = super()._search_display_name(operator, value)
-        if self.env.context.get(
-            "force_smart_name_search", False
-        ) or _get_use_smart_name_search(self.sudo()):
             all_names = _get_rec_names(self.sudo())
-            additional_domain = _get_name_search_domain(self.sudo())
-
+            domain = _get_name_search_domain(self.sudo())
             for word in value.split():
                 word_domain = []
                 for rec_name in all_names:
                     word_domain = (
                         word_domain and ["|"] + word_domain or word_domain
                     ) + [(rec_name, operator, word)]
-                additional_domain = (
-                    additional_domain and ["&"] + additional_domain or additional_domain
-                ) + word_domain
-
-            return expression.OR([additional_domain, domain])
-
-        return domain
+                domain = (
+                    expression.AND([domain, word_domain]) if domain else word_domain
+                )
+            return domain
+        return []
 
     @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):


### PR DESCRIPTION
In v18 `_search_smart_search` was delegating to `name_search`. This introduces an artificial limit (100 records) before other domain filters are applied, leading to incomplete results.

This PR restores the original behavior from v16:
- Build the domain directly in `_search_smart_search`.

This makes smart search consistent again with standard search and avoids missing records.