### PR TITLE
[18.0][FIX] auditlog: Account Invoice Extract Cache Issue (no company set)

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -395,9 +395,7 @@ class AuditlogRule(models.Model):
             # invalidate_recordset method must be called with existing fields
             if self._name == "res.users":
                 vals = self._remove_reified_groups(vals)
-            # Prevent the cache of modified fields from being poisoned by
-            # x2many items inaccessible to the current user.
-            self.invalidate_recordset(vals.keys())
+
             result = write_full.origin(self, vals, **kwargs)
             new_values = {
                 d["id"]: d


### PR DESCRIPTION
AI Extraction throws an error when auditlog rule with Full log is enabled on account.move.line:

```
Error while reloading AI data on account.move 13399: We can't leave this document without any company. Please select a company for this document
```

## Module
audit log
https://github.com/OCA/server-tools/blame/22ed5dc4fb76971dbce0bdfd463cff5f1719c2ec/auditlog/models/rule.py#L400

## Describe the bug
When using the AI Exctraction for invoices, Odoo tries to map a purchase order. 
During this process, the auditlog triggers a cache-invalidation, so that in 
https://github.com/brain-tec/odoo/blob/2718aaa7397e38be0fcd64fe6b5ef5c0be66cfe2/addons/purchase/models/account_invoice.py#L85-L87
the reference to the purchase_id is lost. 
This happens after setting the invoice_line_ids in 
https://github.com/brain-tec/odoo/blob/2718aaa7397e38be0fcd64fe6b5ef5c0be66cfe2/addons/purchase/models/account_invoice.py#L203

## To Reproduce
**Affected versions**: 18

Steps to reproduce the behavior:
1.  upload a bill with a PO reference existing in Odoo
2.  send to AI
3.  Load the results

**Expected behavior**
No error 


This PR removes the cache invalidation. The tests ares still passing, so I guess it is no more needed in v18