### PR TITLE
[15.0][IMP] tracking_manager: Check records not empty

### DIFF
--- a/tracking_manager/tools.py
+++ b/tracking_manager/tools.py
@@ -4,4 +4,6 @@
 
 
 def format_m2m(records):
-    return "; ".join(records.mapped("display_name"))
+    if records:
+        return "; ".join(records.mapped("display_name"))
+    return ""


### PR DESCRIPTION
Fixes empty record method calling for account use cases:

return "; ".join(records.mapped("display_name")) 
AttributeError: 'NoneType' object has no attribute 'mapped' 

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 921, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1328, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 471, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 456, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/account_asset/models/account_asset.py", line 595, in validate
    dummy, tracking_value_ids = asset._mail_track(tracked_fields, dict.fromkeys(fields))
  File "/opt/odoo/auto/addons/mail/models/models.py", line 54, in _mail_track
    tracking = self.env['mail.tracking.value'].create_tracking_values(initial_value, new_value, col_name, col_info, tracking_sequence, self._name)
File "/opt/odoo/auto/addons/tracking_manager/models/mail_tracking_value.py", line 24, in create_tracking_values 
initial_value = format_m2m(initial_value) 
File "/opt/odoo/auto/addons/tracking_manager/tools.py", line 7, in format_m2m 
return "; ".join(records.mapped("display_name")) 
Exception 
The above exception was the direct cause of the following exception: 
Traceback (most recent call last): 
File "/opt/odoo/custom/src/odoo/odoo/http.py", line 654, in _handle_exception 
return super(JsonRequest, self)._handle_exception(exception) 
File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception 
raise exception.with_traceback(None) from new_cause 
AttributeError: 'NoneType' object has no attribute 'mapped' 
```