### PR TITLE
[FIX] auditlog: Ensure unit tests unpatch methods.

### DIFF
--- a/auditlog/tests/__init__.py
+++ b/auditlog/tests/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import common
 from . import test_auditlog
 from . import test_autovacuum
 from . import test_multi_company

--- a/auditlog/tests/common.py
+++ b/auditlog/tests/common.py
@@ -1,0 +1,26 @@
+from odoo.tests.common import TransactionCase
+
+
+class AuditLogRuleCommon(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.models = set()
+
+    @classmethod
+    def create_rule(cls, vals):
+        rule = cls.env["auditlog.rule"].with_context(tracking_disable=True).create(vals)
+        # Keep track of patched models
+        cls.models |= {rule.model_id.model}
+        return rule
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.env["auditlog.rule"].search([]).unsubscribe()
+        # Assert no patched methods remain
+        for model in cls.models:
+            for method in ["create", "read", "write", "unlink"]:
+                assert not hasattr(
+                    getattr(cls.env[model], method), "origin"
+                ), f"{model} {method} still patched"
+        super().tearDownClass()

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -2,10 +2,10 @@
 # © 2018 Pieter Paulussen <pieter_paulussen@me.com>
 # © 2021 Stefan Rijnhart <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.tests.common import TransactionCase
-
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.addons.base.models.res_users import name_boolean_group
+
+from .common import AuditLogRuleCommon
 
 
 class AuditlogCommon:
@@ -271,11 +271,11 @@ class AuditlogCommon:
         )
 
 
-class TestAuditlogFull(TransactionCase, AuditlogCommon):
+class TestAuditlogFull(AuditLogRuleCommon, AuditlogCommon):
     def setUp(self):
         super().setUp()
         self.groups_model_id = self.env.ref("base.model_res_groups").id
-        self.groups_rule = self.env["auditlog.rule"].create(
+        self.groups_rule = self.create_rule(
             {
                 "name": "testrule for groups",
                 "model_id": self.groups_model_id,
@@ -292,11 +292,11 @@ class TestAuditlogFull(TransactionCase, AuditlogCommon):
         super().tearDown()
 
 
-class TestAuditlogFast(TransactionCase, AuditlogCommon):
+class TestAuditlogFast(AuditLogRuleCommon, AuditlogCommon):
     def setUp(self):
         super().setUp()
         self.groups_model_id = self.env.ref("base.model_res_groups").id
-        self.groups_rule = self.env["auditlog.rule"].create(
+        self.groups_rule = self.create_rule(
             {
                 "name": "testrule for groups",
                 "model_id": self.groups_model_id,
@@ -313,14 +313,10 @@ class TestAuditlogFast(TransactionCase, AuditlogCommon):
         super().tearDown()
 
 
-class TestFieldRemoval(TransactionCase):
+class TestFieldRemoval(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
-        # Clear all existing logging lines
-        existing_audit_logs = cls.env["auditlog.log"].search([])
-        existing_audit_logs.unlink()
 
         # Create a test model to remove
         cls.test_model = (
@@ -348,18 +344,16 @@ class TestFieldRemoval(TransactionCase):
             )
         )
         # Setup auditlog rule
-        cls.auditlog_rule = cls.env["auditlog.rule"].create(
-            [
-                {
-                    "name": "test.model",
-                    "model_id": cls.test_model.id,
-                    "log_type": "fast",
-                    "log_read": False,
-                    "log_create": True,
-                    "log_write": True,
-                    "log_unlink": False,
-                }
-            ]
+        cls.auditlog_rule = cls.create_rule(
+            {
+                "name": "test.model",
+                "model_id": cls.test_model.id,
+                "log_type": "fast",
+                "log_read": False,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": False,
+            }
         )
 
         cls.auditlog_rule.subscribe()
@@ -407,11 +401,11 @@ class TestFieldRemoval(TransactionCase):
         self.assertFalse(self.auditlog_rule.model_id)
 
 
-class TestAuditlogFullCaptureRecord(TransactionCase, AuditlogCommon):
+class TestAuditlogFullCaptureRecord(AuditLogRuleCommon, AuditlogCommon):
     def setUp(self):
         super().setUp()
         self.groups_model_id = self.env.ref("base.model_res_groups").id
-        self.groups_rule = self.env["auditlog.rule"].create(
+        self.groups_rule = self.create_rule(
             {
                 "name": "testrule for groups with capture unlink record",
                 "model_id": self.groups_model_id,
@@ -429,7 +423,7 @@ class TestAuditlogFullCaptureRecord(TransactionCase, AuditlogCommon):
         super().tearDown()
 
 
-class AuditLogRuleTestForUserFields(TransactionCase):
+class AuditLogRuleTestForUserFields(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -470,21 +464,17 @@ class AuditLogRuleTestForUserFields(TransactionCase):
         cls.users_to_exclude_ids = cls.user.id
 
         # creating auditlog.rule
-        cls.auditlog_rule = (
-            cls.env["auditlog.rule"]
-            .with_context(tracking_disable=True)
-            .create(
-                {
-                    "name": "testrule 01",
-                    "model_id": cls.contact_model_id,
-                    "log_read": True,
-                    "log_create": True,
-                    "log_write": True,
-                    "log_unlink": True,
-                    "log_type": "full",
-                    "capture_record": True,
-                }
-            )
+        cls.auditlog_rule = cls.create_rule(
+            {
+                "name": "testrule 01",
+                "model_id": cls.contact_model_id,
+                "log_read": True,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": True,
+                "log_type": "full",
+                "capture_record": True,
+            }
         )
 
         # Updating phone in fields_to_exclude_ids
@@ -536,9 +526,6 @@ class AuditLogRuleTestForUserFields(TransactionCase):
 
         # Checking log lines not created for phone
         self.assertTrue("phone" not in field_names)
-
-        # Removing created log record
-        create_log_record.unlink()
 
     def test_02_AuditlogFull_field_exclude_write_log(self):
         # Checking fields_to_exclude_ids
@@ -617,11 +604,8 @@ class AuditLogRuleTestForUserFields(TransactionCase):
         # Checking log lines are created
         self.assertTrue(delete_log_record)
 
-        # Removing auditlog_rule
-        self.auditlog_rule.unlink()
 
-
-class AuditLogRuleTestForUserModel(TransactionCase):
+class AuditLogRuleTestForUserModel(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -629,21 +613,17 @@ class AuditLogRuleTestForUserModel(TransactionCase):
         cls.user_model_id = cls.env["ir.model"].search([("model", "=", "res.users")]).id
 
         # creating auditlog.rule
-        cls.auditlog_rule = (
-            cls.env["auditlog.rule"]
-            .with_context(tracking_disable=True)
-            .create(
-                {
-                    "name": "testrule 01",
-                    "model_id": cls.user_model_id,
-                    "log_read": True,
-                    "log_create": True,
-                    "log_write": True,
-                    "log_unlink": True,
-                    "log_type": "full",
-                    "capture_record": True,
-                }
-            )
+        cls.auditlog_rule = cls.create_rule(
+            {
+                "name": "testrule 01",
+                "model_id": cls.user_model_id,
+                "log_read": True,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": True,
+                "log_type": "full",
+                "capture_record": True,
+            }
         )
 
         # Create user id
@@ -698,7 +678,7 @@ class AuditLogRuleTestForUserModel(TransactionCase):
         self.assertTrue(write_log_record)
 
 
-class AuditlogFast_excluded_fields(TransactionCase):
+class AuditlogFast_excluded_fields(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -714,21 +694,17 @@ class AuditlogFast_excluded_fields(TransactionCase):
             .id
         )
         # creating auditlog.rule
-        cls.auditlog_rule = (
-            cls.env["auditlog.rule"]
-            .with_context(tracking_disable=True)
-            .create(
-                {
-                    "name": "testrule 01",
-                    "model_id": cls.contact_model_id,
-                    "log_read": True,
-                    "log_create": True,
-                    "log_write": True,
-                    "log_unlink": True,
-                    "log_type": "fast",
-                    "capture_record": True,
-                }
-            )
+        cls.auditlog_rule = cls.create_rule(
+            {
+                "name": "testrule 01",
+                "model_id": cls.contact_model_id,
+                "log_read": True,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": True,
+                "log_type": "fast",
+                "capture_record": True,
+            }
         )
 
         # Updating phone in fields_to_exclude_ids

--- a/auditlog/tests/test_autovacuum.py
+++ b/auditlog/tests/test_autovacuum.py
@@ -2,14 +2,14 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import time
 
-from odoo.tests.common import TransactionCase
+from .common import AuditLogRuleCommon
 
 
-class TestAuditlogAutovacuum(TransactionCase):
+class TestAuditlogAutovacuum(AuditLogRuleCommon):
     def setUp(self):
         super().setUp()
         self.groups_model_id = self.env.ref("base.model_res_groups").id
-        self.groups_rule = self.env["auditlog.rule"].create(
+        self.groups_rule = self.create_rule(
             {
                 "name": "testrule for groups",
                 "model_id": self.groups_model_id,

--- a/auditlog/tests/test_multi_company.py
+++ b/auditlog/tests/test_multi_company.py
@@ -2,16 +2,14 @@ from unittest.mock import patch
 
 from odoo.fields import Command
 from odoo.models import BaseModel
-from odoo.tests.common import TransactionCase
+
+from .common import AuditLogRuleCommon
 
 
-class TestMultiCompany(TransactionCase):
+class TestMultiCompany(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Disarm any existing auditing rules.
-        cls.env["auditlog.rule"].search([]).unlink()
-        cls.env["auditlog.log"].search([]).unlink()
         # Set up a group with two share users from different companies
         cls.company1 = cls.env["res.company"].create({"name": "c1"})
         cls.company2 = cls.env["res.company"].create({"name": "c2"})
@@ -94,21 +92,17 @@ class TestMultiCompany(TransactionCase):
 
     def test_group_set_users_with_auditlog(self):
         """Repeat the test above with an auditlog on the groups model"""
-        rule = (
-            self.env["auditlog.rule"]
-            .sudo()
-            .create(
-                {
-                    "name": "Test rule for groups",
-                    "model_id": self.env["ir.model"]._get("res.groups").id,
-                    "log_read": False,
-                    "log_create": False,
-                    "log_write": True,
-                    "log_unlink": False,
-                    "log_type": "full",
-                    "state": "subscribed",
-                }
-            )
+        rule = self.create_rule(
+            {
+                "name": "TestMultiCompany",
+                "model_id": self.env["ir.model"]._get("res.groups").id,
+                "log_read": False,
+                "log_create": False,
+                "log_write": True,
+                "log_unlink": False,
+                "log_type": "full",
+                "state": "subscribed",
+            }
         )
         try:
             self.test_group_set_users()


### PR DESCRIPTION
Though TransactionCase rolls back database changes, it does not call `unlink` on `auditlog.rule` records, meaning that `unsubscribe` is never called to unpatch model methods. This causes subsequent tests in other modules to unexpectedly execute patched methods.

This commit adds the `AuditLogRuleCommon` test class in an attempt to identify and prevent patched methods from contaminating the test environment.