### PR TITLE
[16.0][FIX] base_technical_user: use company from env, not from user + multi company context

### DIFF
--- a/base_technical_user/models/models.py
+++ b/base_technical_user/models/models.py
@@ -12,9 +12,21 @@ class Base(models.AbstractModel):
 
     def sudo_tech(self, raise_if_missing=False):
         self_sudoer = self
-        tech_user = self.env.user.company_id.user_tech_id
+        tech_user = self.env.company.user_tech_id
         if tech_user:
             self_sudoer = self.with_user(tech_user.id)
+            # We restrict the allowed companies to the one of the tech user
+            allowed_company_ids = self.env.context.get("allowed_company_ids")
+            # TODO: Is any(...) part necessary as we can consider company should always be
+            # the one of the tech_user ?
+            if allowed_company_ids and any(
+                company
+                for company in allowed_company_ids
+                if company != tech_user.company_id.id
+            ):
+                self_sudoer = self_sudoer.with_context(
+                    allowed_company_ids=self.env.company.ids
+                )
         elif raise_if_missing:
             raise UserError(
                 _("The technical user is missing in the company {}").format(

--- a/base_technical_user/models/models.py
+++ b/base_technical_user/models/models.py
@@ -30,7 +30,7 @@ class Base(models.AbstractModel):
         elif raise_if_missing:
             raise UserError(
                 _("The technical user is missing in the company {}").format(
-                    self.env.user.company_id.name
+                    self.env.company.name
                 )
             )
         return self_sudoer

--- a/base_technical_user/tests/test_sudo_tech.py
+++ b/base_technical_user/tests/test_sudo_tech.py
@@ -12,12 +12,23 @@ class SudoTechCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(SudoTechCase, cls).setUpClass()
+        cls.company_2 = cls.env["res.company"].create(
+            {
+                "name": "Company 2 tech",
+            }
+        )
         cls.user_tech = (
             cls.env["res.users"]
             .with_context(tracking_disable=True, no_reset_password=True)
             .create({"login": "tech", "name": "tech"})
         )
         cls.company = cls.env.ref("base.main_company")
+        cls.user_tech_2 = (
+            cls.env["res.users"]
+            .with_context(tracking_disable=True, no_reset_password=True)
+            .with_company(cls.company_2)
+            .create({"login": "tech2", "name": "tech2", "company_id": cls.company_2.id})
+        )
         cls.env(user=cls.env.ref("base.user_demo").id)
 
     def test_sudo_tech(self):
@@ -32,3 +43,19 @@ class SudoTechCase(TransactionCase):
     def test_sudo_tech_missing_raise(self):
         with self.assertRaises(UserError):
             self.env["res.partner"].sudo_tech(raise_if_missing=True)
+
+    def test_sudo_tech_company_2(self):
+        self.company_2.user_tech_id = self.user_tech_2
+        self_tech = self.env["res.partner"].with_company(self.company_2).sudo_tech()
+        self.assertEqual(self_tech._uid, self.user_tech_2.id)
+
+    def test_sudo_tech_company_2_record(self):
+        # We switch company twice to fill in allowed_company_ids
+        user = self.env.user.with_company(self.company_2).with_company(self.company)
+        self.assertEqual(
+            self.company,
+            user.env.company,
+        )
+        self.company_2.user_tech_id = self.user_tech_2
+        self_tech = user.with_company(self.company_2).sudo_tech()
+        self.assertEqual(self_tech._uid, self.user_tech_2.id)

--- a/base_technical_user/tests/test_sudo_tech.py
+++ b/base_technical_user/tests/test_sudo_tech.py
@@ -11,21 +11,28 @@ from odoo.tests import TransactionCase
 class SudoTechCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
-        super(SudoTechCase, cls).setUpClass()
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.company_2 = cls.env["res.company"].create(
             {
                 "name": "Company 2 tech",
             }
         )
+        cls.company_3 = cls.env["res.company"].create(
+            {
+                "name": "Company 3 NO tech",
+                "user_tech_id": False,
+            }
+        )
         cls.user_tech = (
             cls.env["res.users"]
-            .with_context(tracking_disable=True, no_reset_password=True)
+            .with_context(no_reset_password=True)
             .create({"login": "tech", "name": "tech"})
         )
         cls.company = cls.env.ref("base.main_company")
         cls.user_tech_2 = (
             cls.env["res.users"]
-            .with_context(tracking_disable=True, no_reset_password=True)
+            .with_context(no_reset_password=True)
             .with_company(cls.company_2)
             .create({"login": "tech2", "name": "tech2", "company_id": cls.company_2.id})
         )
@@ -59,3 +66,16 @@ class SudoTechCase(TransactionCase):
         self.company_2.user_tech_id = self.user_tech_2
         self_tech = user.with_company(self.company_2).sudo_tech()
         self.assertEqual(self_tech._uid, self.user_tech_2.id)
+
+    def test_sudo_tech_company_3(self):
+        """
+        Ensure the error message is related to the
+        active company when there is no technical user.
+        """
+        user = self.env.user.with_company(self.company_3)
+        self.assertEqual(self.company_3, user.env.company)
+        self.assertNotEqual(user.env.company, user.company_id)
+        with self.assertRaises(UserError) as em:
+            user.sudo_tech(raise_if_missing=True)
+        self.assertIn(self.company_3.name, em.exception.args[0])
+        self.assertNotIn(user.company_id.name, em.exception.args[0])


### PR DESCRIPTION
1) the company should be taken through self.env.company as user.company_id
is now the default company for the user (and not the current one).

2) the actual code does not allow to do recordset.with_company(B).sudo_tech()....
as allowed_company_ids in context can be filled in with current company
(and not the one of the tech user - which is unique)

This was Done by Denis Roussel in 14.0 but somehow forgotten during 16.0 migration (back there in 18.0...)