### PR TITLE
Remove pygount hardcoded version and improve compatibility

### DIFF
--- a/module_analysis/__manifest__.py
+++ b/module_analysis/__manifest__.py
@@ -26,7 +26,7 @@
         "data/ir_module_type_rule.xml",
     ],
     "external_dependencies": {
-        "python": ["pygount==1.4.0"],
+        "python": ["pygount"],
     },
     "installable": True,
 }

--- a/module_analysis/models/ir_module_module.py
+++ b/module_analysis/models/ir_module_module.py
@@ -53,11 +53,11 @@ class IrModuleModule(models.Model):
         field_name: Odoo field name to store the analysis
         """
         return {
-            ".py": {"code": "python_code_qty"},
-            ".xml": {"code": "xml_code_qty"},
-            ".js": {"code": "js_code_qty"},
-            ".css": {"code": "css_code_qty"},
-            ".scss": {"code": "scss_code_qty"},
+            ".py": {"code_count": "python_code_qty"},
+            ".xml": {"code_count": "xml_code_qty"},
+            ".js": {"code_count": "js_code_qty"},
+            ".css": {"code_count": "css_code_qty"},
+            ".scss": {"code_count": "scss_code_qty"},
         }
 
     @api.model

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ odoorpc
 openpyxl
 openupgradelib
 paramiko<4.0.0
-pygount==1.4.0
+pygount
 pysftp
 sentry_sdk<=1.9.0
 unidecode


### PR DESCRIPTION
pygount 1.4.0 is now very old and current code does not work on recent versions. It is however easy to improve compatibility accross pygount versions using the code_count property instead of the code one, which was removed in 2.0.0. That way, pygount 1.4.0 stays supported but also modern version up to at least
 3.1.0.