### PR TITLE
[17.0] auditlog : Add log_export_data field to ensure consitency

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -100,6 +100,15 @@ class AuditlogRule(models.Model):
             "record of the model of this rule"
         ),
     )
+    log_export_data = fields.Boolean(
+        "Log Exports",
+        default=True,
+        help=(
+            "Select this if you want to keep track of exports "
+            "of the model of this rule"
+        ),
+        states={"subscribed": [("readonly", True)]},
+    )
     log_type = fields.Selection(
         [("full", "Full log"), ("fast", "Fast log")],
         string="Type",


### PR DESCRIPTION
[A few days ago](https://github.com/svanerp/server-tools/commit/e2fb9f3b8141a1c46ad4be47c0c2569e599800ac), on branch `16.0`, a field appeared in the `auditlog.rule` class: `log_eport_data`.
Unfortunately, it is not present on branch `17.0` and I do not see any pending PRs.
On branch `18.0`, the field is present again.
My guess is that the field first appeared in `18.0` and then a backport was made to `16.0`.
**The purpose of this PR is to ensure the consistency of the module by adding the missing field in 17.0.**