### PR TITLE
[16.0][FIX] auditlog: Fix Missing Log Lines When Setting Empty Field Values

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -91,6 +91,19 @@ class ThrowAwayCache:
         self._transaction.tocompute = self._original_tocompute
 
 
+class _Sentinel:
+    """A falsy sentinel object as a placeholder for absent values."""
+
+    def __str__(self):
+        return ""
+
+    def __bool__(self):
+        return False
+
+
+_SENTINEL = _Sentinel()
+
+
 class AuditlogRule(models.Model):
     _name = "auditlog.rule"
     _description = "Auditlog - Rule"
@@ -506,7 +519,7 @@ class AuditlogRule(models.Model):
             # afterwards as it could not represent the real state
             # of the data in the database
             vals2 = dict(vals)
-            old_vals2 = dict.fromkeys(list(vals2.keys()), None)
+            old_vals2 = dict.fromkeys(list(vals2.keys()), _SENTINEL)
             old_values = {id_: old_vals2 for id_ in self.ids}
             new_values = {id_: vals2 for id_ in self.ids}
             result = write_fast.origin(self, vals, **kwargs)

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -506,7 +506,7 @@ class AuditlogRule(models.Model):
             # afterwards as it could not represent the real state
             # of the data in the database
             vals2 = dict(vals)
-            old_vals2 = dict.fromkeys(list(vals2.keys()), False)
+            old_vals2 = dict.fromkeys(list(vals2.keys()), None)
             old_values = {id_: old_vals2 for id_ in self.ids}
             new_values = {id_: vals2 for id_ in self.ids}
             result = write_fast.origin(self, vals, **kwargs)

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -371,8 +371,7 @@ class TestAuditlogFastWriteEmptyValue(AuditLogRuleCommon):
         )
         cls.auditlog_rule.subscribe()
 
-    def test_when_removing_field_value_a_log_line_is_created(self):
-        self.test_record.write({"phone": False})
+    def assert_has_one_log_line_with_empty_values(self):
         logs = self.env["auditlog.log"].search(
             [
                 ("res_id", "=", self.test_record.id),
@@ -389,6 +388,14 @@ class TestAuditlogFastWriteEmptyValue(AuditLogRuleCommon):
         self.assertFalse(log_lines[0].old_value_text)
         self.assertFalse(log_lines[0].new_value)
         self.assertFalse(log_lines[0].new_value_text)
+
+    def test_when_removing_field_value_a_log_line_is_created(self):
+        self.test_record.write({"phone": False})
+        self.assert_has_one_log_line_with_empty_values()
+
+    def test_when_using_none_field_value_a_log_line_is_created(self):
+        self.test_record.write({"phone": None})
+        self.assert_has_one_log_line_with_empty_values()
 
 
 class TestFieldRemoval(AuditLogRuleCommon):

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -343,6 +343,54 @@ class TestAuditlogFast(AuditLogRuleCommon, AuditlogCommon):
         super(TestAuditlogFast, self).tearDown()
 
 
+class TestAuditlogFastWriteEmptyValue(AuditLogRuleCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_model = cls.env["ir.model"].search([("model", "=", "res.partner")])
+        cls.auditlog_rule = cls.create_rule(
+            {
+                "name": "test.model_res_partner",
+                "model_id": cls.test_model.id,
+                "log_type": "fast",
+                "log_read": False,
+                "log_create": False,
+                "log_write": True,
+                "log_unlink": False,
+            }
+        )
+        cls.test_record = (
+            cls.env["res.partner"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "name": "testpartner3",
+                    "phone": "123",
+                }
+            )
+        )
+        cls.auditlog_rule.subscribe()
+
+    def test_when_removing_field_value_a_log_line_is_created(self):
+        self.test_record.write({"phone": False})
+        logs = self.env["auditlog.log"].search(
+            [
+                ("res_id", "=", self.test_record.id),
+                ("model_id", "=", self.test_model.id),
+            ]
+        )
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0].model_name, "Contact")
+        self.assertEqual(logs[0].model_model, "res.partner")
+        log_lines = logs.mapped("line_ids")
+        self.assertEqual(len(log_lines), 1)
+        self.assertEqual(log_lines[0].field_name, "phone")
+        self.assertFalse(log_lines[0].old_value)
+        self.assertFalse(log_lines[0].old_value_text)
+        self.assertFalse(log_lines[0].new_value)
+        self.assertFalse(log_lines[0].new_value_text)
+
+
 class TestFieldRemoval(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes the comparison with old values when setting fields to empty values.

The old values for the comparison when using **fast log** mode were initialized with `False`. This causes the problem that when a field is set to an emty value by the user, auditlog does not create a log line because internal checks compare `False` to `False` and do not consider logging the change. Full log mode is not affected by this as there everything is logged by default. However, even in fast log mode, some companies have regulatory requirements which force them to log user actions that set empty values to fields, so that should be logged properly.
