### PR TITLE
[18.0][FIX] auditlog: Remove deprecated name_get methods from models.

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -31,9 +31,6 @@ class AuditlogHTTPRequest(models.Model):
                 httprequest.name or "?", fields.Datetime.to_string(tz_create_date)
             )
 
-    def name_get(self):
-        return [(request.id, request.display_name) for request in self]
-
     @api.model
     def current_http_request(self):
         """Create a log corresponding to the current HTTP request, and returns

--- a/auditlog/models/http_session.py
+++ b/auditlog/models/http_session.py
@@ -27,9 +27,6 @@ class AuditlogtHTTPSession(models.Model):
                 fields.Datetime.to_string(tz_create_date),
             )
 
-    def name_get(self):
-        return [(session.id, session.display_name) for session in self]
-
     @api.model
     def current_http_session(self):
         """Create a log corresponding to the current HTTP user session, and


### PR DESCRIPTION
The `name_get` method was deprecated in Odoo 17 and removed in Odoo 18.

This was identified by running `base` module tests on an odoo:18 container with `auditlog` installed, yielding:
```
ERROR odoo odoo.addons.base.tests.test_deprecation: FAIL: Subtest TestModelDeprecations.test_name_get (model='auditlog.http.session')
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/addons/base/tests/test_deprecation.py", line 37, in test_name_get
    self.fail(f"Deprecated name_get method found on {model_name} in {module.__name__}, you should override `_compute_display_name` instead")
AssertionError: Deprecated name_get method found on auditlog.http.session in odoo.addons.auditlog.models.http_session, you should override `_compute_display_name` instead
```