### PR TITLE
[18.0][FIX] auditlog: Ensure display_name computation works with new record.

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -25,7 +25,10 @@ class AuditlogHTTPRequest(models.Model):
     @api.depends("create_date", "name")
     def _compute_display_name(self):
         for httprequest in self:
-            create_date = fields.Datetime.from_string(httprequest.create_date)
+            create_date = (
+                fields.Datetime.from_string(httprequest.create_date)
+                or fields.Datetime.now()
+            )
             tz_create_date = fields.Datetime.context_timestamp(httprequest, create_date)
             httprequest.display_name = "{} ({})".format(
                 httprequest.name or "?", fields.Datetime.to_string(tz_create_date)

--- a/auditlog/models/http_session.py
+++ b/auditlog/models/http_session.py
@@ -20,7 +20,10 @@ class AuditlogtHTTPSession(models.Model):
     @api.depends("create_date", "user_id")
     def _compute_display_name(self):
         for httpsession in self:
-            create_date = fields.Datetime.from_string(httpsession.create_date)
+            create_date = (
+                fields.Datetime.from_string(httpsession.create_date)
+                or fields.Datetime.now()
+            )
             tz_create_date = fields.Datetime.context_timestamp(httpsession, create_date)
             httpsession.display_name = "{} ({})".format(
                 httpsession.user_id and httpsession.user_id.name or "?",

--- a/auditlog/tests/__init__.py
+++ b/auditlog/tests/__init__.py
@@ -2,3 +2,4 @@
 from . import common
 from . import test_auditlog
 from . import test_autovacuum
+from . import test_http

--- a/auditlog/tests/test_http.py
+++ b/auditlog/tests/test_http.py
@@ -1,0 +1,44 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAuditlogHttp(HttpCase):
+    def test_compute_display_name(self):
+        self.authenticate("admin", "admin")
+        rule = self.env["auditlog.rule"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "log_type": "full",
+                "state": "subscribed",
+            }
+        )
+        self.addCleanup(rule.unsubscribe)
+        partner = self.env.ref("base.partner_demo")
+        self.make_jsonrpc_request(
+            "/web/dataset/call_kw",
+            params={
+                "model": "res.partner",
+                "method": "write",
+                "args": [partner.id, {"name": "test"}],
+                "kwargs": {},
+            },
+            headers={
+                "Cookie": f"session_id={self.session.sid};",
+            },
+        )
+        logs = self.env["auditlog.log"].search(
+            [("model_id", "=", rule.model_id.id), ("res_id", "=", partner.id)]
+        )
+        self.assertEqual(len(logs), 1)
+        http_request_id = logs[0]["http_request_id"]
+        self.assertRegex(
+            http_request_id.display_name,
+            r"/web/dataset/call_kw \(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\)",
+        )
+        http_session_id = logs[0]["http_session_id"]
+        self.assertRegex(
+            http_session_id.display_name,
+            r"Mitchell Admin \(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\)",
+        )


### PR DESCRIPTION
This was identified by running `base` module tests on an odoo:18 container with `auditlog` installed, yielding:

```
ERROR odoo odoo.addons.base.tests.test_display_name: FAIL: Subtest TestEveryModel.test_display_name_new_record [`_compute_display_name` doesn't work with new record (first onchange call).] (model='auditlog.http.session')
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/addons/base/tests/test_display_name.py", line 34, in test_display_name_new_record
    model.onchange({}, [], fields_spec)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/models/models.py", line 1019, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/addons/web/models/models.py", line 1106, in __init__
    self.fetch(name)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/models/models.py", line 1121, in fetch
    self[field_name] = self.record[field_name]
                       ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 7076, in __getitem__
    return self._fields[key].__get__(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1236, in __get__
    self.recompute(record)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1463, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1436, in apply_except_missing
    func(records)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1485, in compute_value
    records._compute_field_value(self)
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5295, in _compute_field_value
    fields.determine(field.compute, self)
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 110, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/usr/local/src/metricwise/oca/server-tools/auditlog/models/http_session.py", line 24, in _compute_display_name
    tz_create_date = fields.Datetime.context_timestamp(httpsession, create_date)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 2400, in context_timestamp
    assert isinstance(timestamp, datetime), 'Datetime instance expected'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Datetime instance expected
```

Note: The newly created tests/test_http.py failed to provoke the issue, so it is necessary to run `base` tests to confirm the fix.