### PR TITLE
[18.0][FIX] auditlog: Enabling read logging raises ReadOnlySqlTransaction error.

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -221,6 +221,7 @@ class AuditlogRule(models.Model):
             new_method = self._make_create()
         elif method_name == "read":
             new_method = self._make_read()
+            new_method._readonly = False
         elif method_name == "write":
             new_method = self._make_write()
         elif method_name == "unlink":

--- a/auditlog/tests/test_http.py
+++ b/auditlog/tests/test_http.py
@@ -1,4 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
+
 from odoo.tests.common import HttpCase, tagged
 
 from .common import AuditLogRuleCommon
@@ -48,3 +50,38 @@ class TestAuditlogHttp(HttpCase, AuditLogRuleCommon):
             http_session_id.display_name,
             r"Mitchell Admin \(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\)",
         )
+
+    def test_read_only_cursor(self):
+        self.authenticate("admin", "admin")
+        rule = self.env["auditlog.rule"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "log_read": True,
+                "log_type": "full",
+                "state": "subscribed",
+            }
+        )
+        self.addCleanup(rule.unsubscribe)
+        partner = self.env.ref("base.partner_demo")
+        with self.assertNoLogs("odoo", level=logging.ERROR):
+            self.make_jsonrpc_request(
+                "/web/dataset/call_kw",
+                params={
+                    "model": "res.partner",
+                    "method": "read",
+                    "args": [partner.ids],
+                    "kwargs": {},
+                },
+                headers={
+                    "Cookie": f"session_id={self.session.sid};",
+                },
+            )
+        logs = self.env["auditlog.log"].search(
+            [
+                ("model_id", "=", rule.model_id.id),
+                ("method", "=", "read"),
+                ("res_id", "=", partner.id),
+            ]
+        )
+        self.assertEqual(len(logs), 1)


### PR DESCRIPTION
Odoo 18 introduced read-only database cursors [^1]. Enabling `auditlog` read logging causes each read-only request to raise a ReadOnlyTransaction error, which is handled internally by Odoo by retrying the request with a writable cursor. This seems guaranteed to cause slowness or repeated side effects.

```
ERROR odoo odoo.sql_db: bad query: b'INSERT INTO "auditlog_http_session" ("create_date", "create_uid", "name", "user_id", "write_date", "write_uid") VALUES (\'2025-09-25 12:41:48.826030\', 2, \'Kr70qQDV58xbpTy0o0mGGciI2XyMFWD39iNZQrKDnRbN-5RPc47W0jh9RliwdMlOqz9aaZD-81htkrF9sWDB\', 2, \'2025-09-25 12:41:48.826030\', 2) RETURNING "id"'
ERROR: cannot execute INSERT in a read-only transaction
 
WARNING odoo odoo.http: cannot execute INSERT in a read-only transaction, retrying with a read/write cursor 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2146, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 156, in retrying
    result = func()
             ^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2113, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 2361, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 756, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/extra-addons/oca/server-tools/auditlog/models/rule.py", line 378, in read
    rule_model.sudo().create_logs(
  File "/mnt/extra-addons/oca/server-tools/auditlog/models/rule.py", line 563, in create_logs
    "http_request_id": http_request_model.current_http_request(),
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/extra-addons/oca/server-tools/auditlog/models/http_request.py", line 63, in current_http_request
    "http_session_id": http_session_model.current_http_session(),
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/extra-addons/oca/server-tools/auditlog/models/http_session.py", line 51, in current_http_session
    httpsession.auditlog_http_session_id = self.create(vals).id
                                           ^^^^^^^^^^^^^^^^^
  File "<decorator-gen-0>", line 2, in create
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 497, in _model_create_multi
    return create(self, [arg])
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5032, in create
    records = self._create(data_list)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5216, in _create
    cr.execute(SQL(
  File "/usr/lib/python3/dist-packages/odoo/sql_db.py", line 582, in execute
    return self._cursor.execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/odoo/sql_db.py", line 357, in execute
    res = self._obj.execute(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.ReadOnlySqlTransaction: cannot execute INSERT in a read-only transaction
```

[^1]: https://github.com/odoo/odoo/commit/584a172274caefb23e5d91b609fc893160535416