### PR TITLE
[14.0][FIX] module_analysis: The 'code' attribute does not exist in SourceAnalysis Class

### DIFF
--- a/module_analysis/models/ir_module_module.py
+++ b/module_analysis/models/ir_module_module.py
@@ -52,11 +52,11 @@ class IrModuleModule(models.Model):
         field_name: Odoo field name to store the analysis
         """
         return {
-            ".py": {"code": "python_code_qty"},
-            ".xml": {"code": "xml_code_qty"},
-            ".js": {"code": "js_code_qty"},
-            ".css": {"code": "css_code_qty"},
-            ".scss": {"code": "css_code_qty"},
+            ".py": {"code_count": "python_code_qty"},
+            ".xml": {"code_count": "xml_code_qty"},
+            ".js": {"code_count": "js_code_qty"},
+            ".css": {"code_count": "css_code_qty"},
+            ".scss": {"code_count": "css_code_qty"},
         }
 
     @api.model


### PR DESCRIPTION
Hi, since Pygount doesn’t currently have a pinned version, some newer releases no longer include the 'code' attribute.I propose pinning this add-on to version 1.8.0.