### PR TITLE
[18.0][IMP] tracking_manager: support records without display_name

### DIFF
--- a/tracking_manager/models/mail_tracking_value.py
+++ b/tracking_manager/models/mail_tracking_value.py
@@ -66,3 +66,37 @@ class MailTracking(models.Model):
                     ),
                 }
             raise
+        except TypeError:
+            # remove when https://github.com/odoo/odoo/pull/214121 is merged
+            field = self.env["ir.model.fields"]._get(record._name, col_name)
+            model_name = self.env._(self.env["ir.model"]._get(field.model).display_name)
+            values = {"field_id": field.id}
+            if col_info["type"] in {"one2many", "many2many"}:
+                values.update(
+                    {
+                        "old_value_char": ", ".join(
+                            value.display_name
+                            or self.env._(
+                                "Unnamed %(record_model_name)s (%(record_id)s)",
+                                record_model_name=model_name,
+                                record_id=value.id,
+                            )
+                            for value in initial_value
+                        )
+                        if initial_value
+                        else "",
+                        "new_value_char": ", ".join(
+                            value.display_name
+                            or self.env._(
+                                "Unnamed %(record_model_name)s (%(record_id)s)",
+                                record_model_name=model_name,
+                                record_id=value.id,
+                            )
+                            for value in new_value
+                        )
+                        if new_value
+                        else "",
+                    }
+                )
+                return values
+            raise


### PR DESCRIPTION
Solves:

```
RPC_ERROR

Odoo Server Error

Occured on c4a8-staging-24322665.dev.odoo.com on model contract.contract on 2025-10-14 12:54:34 GMT

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 2144, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/service/model.py", line 158, in retrying
    env.cr.flush()  # submit the changes to the database
    ^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 160, in flush
    self.precommit.run()
  File "/home/odoo/src/odoo/odoo/tools/misc.py", line 1162, in run
    func()
  File "/home/odoo/src/odoo/addons/mail/models/mail_thread.py", line 541, in _track_finalize
    tracking = records.with_context(context)._message_track(fnames, initial_values)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/mail/models/mail_thread.py", line 623, in _message_track
    tracking[record.id] = record._mail_track(tracked_fields, initial_values_dict[record.id])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/server-tools/tracking_manager_domain/models/models.py", line 63, in _mail_track
    changes, tracking_value_ids = super()._mail_track(
                                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/server-tools/tracking_manager/models/models.py", line 182, in _mail_track
    updated, tracking_value_ids = super()._mail_track(
                                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/mail/models/models.py", line 168, in _mail_track
    [0, 0, self.env['mail.tracking.value']._create_tracking_values(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/user/modules/oca/server-tools/tracking_manager/models/mail_tracking_value.py", line 35, in _create_tracking_values
    return super()._create_tracking_values(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/mail/models/mail_tracking_value.py", line 123, in _create_tracking_values
    'old_value_char': ', '.join(initial_value.mapped('display_name')) if initial_value else '',
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, bool found

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPCError@https://c4a8-staging-24322665.dev.odoo.com/web/assets/4b98f92/web.assets_web.min.js:3159:338
    makeErrorFromResponse@https://c4a8-staging-24322665.dev.odoo.com/web/assets/4b98f92/web.assets_web.min.js:3162:163
    rpc._rpc/promise</<@https://c4a8-staging-24322665.dev.odoo.com/web/assets/4b98f92/web.assets_web.min.js:3167:34
    
```