### PR TITLE
[IMP] base_search_fuzzy - add support of translatable fields

### DIFF
--- a/base_search_fuzzy/models/trgm_index.py
+++ b/base_search_fuzzy/models/trgm_index.py
@@ -11,6 +11,11 @@ from odoo import _, api, exceptions, fields, models
 _logger = logging.getLogger(__name__)
 
 
+@api.model
+def _lang_get(self):
+    return self.env["res.lang"].get_installed()
+
+
 class TrgmIndex(models.Model):
     """Model for Trigram Index."""
 
@@ -43,6 +48,11 @@ class TrgmIndex(models.Model):
         help="Cite from PostgreSQL documentation: GIN indexes are "
         "the preferred text search index type."
         "See: https://www.postgresql.org/docs/current/textsearch-indexes.html",
+    )
+    lang = fields.Selection(
+        _lang_get,
+        string="Language",
+        help="You will need one index per installed language.",
     )
 
     def _trgm_extension_exists(self):
@@ -130,17 +140,31 @@ class TrgmIndex(models.Model):
 
         table_name = self.env[self.field_id.model_id.model]._table
         column_name = self.field_id.name
+        is_translate = self.field_id.translate
         index_type = self.index_type
-        index_name = f"{column_name}_{index_type}_idx"
-        index_exists, index_name = self.get_not_used_index(index_name, table_name)
+        lang = self.lang
 
+        if is_translate:
+            index_name = f"{column_name}_{lang}_{index_type}_idx"
+        else:
+            index_name = f"{column_name}_{index_type}_idx"
+
+        index_exists, index_name = self.get_not_used_index(index_name, table_name)
         if not index_exists:
+            if is_translate:
+                if lang == "en_US":
+                    column_name = f"({column_name}->>'en_US')"
+                else:
+                    # Search are always done with a fallback on en_US
+                    column_name = (
+                        f"COALESCE({column_name}->>'{lang}', {column_name}->>'en_US')"
+                    )
             self.env.cr.execute(
                 """
-            CREATE INDEX %(index)s
-            ON %(table)s
-            USING %(indextype)s (%(column)s %(indextype)s_trgm_ops);
-            """,
+                CREATE INDEX %(index)s
+                ON %(table)s
+                USING %(indextype)s (%(column)s %(indextype)s_trgm_ops);
+                """,
                 {
                     "table": AsIs(table_name),
                     "index": AsIs(index_name),

--- a/base_search_fuzzy/views/trgm_index.xml
+++ b/base_search_fuzzy/views/trgm_index.xml
@@ -13,6 +13,11 @@
                         />
                         <field name="index_name" />
                         <field name="index_type" />
+                        <field
+                            name="lang"
+                            invisible="not field_id.translate"
+                            required="field_id.translate"
+                        />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
depends on:

- https://github.com/odoo/odoo/pull/232993


This allow to create a trigram index on translatable fields.

Searches on translatable fields look like this:

```sql
SELECT * FROM table WHERE COALESCE({column_name}->>'{lang}', {column_name}->>'en_US' % 'text'
```

On a DB with 8M dummy products (duplicated with `odoo populate`),

With a query containing

```sql
WHERE COALESCE("product_template"."name"->>'fr_FR', "product_template"."name"->>'en_US') % 'search text')
```

Without index
Execution Time: 10606.619 ms

With index:
Execution Time: 484.383 ms


:warning: For en_US to work with operator `%` this requires a patch on the core https://github.com/odoo/odoo/pull/232993