### PR TITLE
17.0 [FIX] auditlog: Unable to create a user session

### DIFF
--- a/auditlog/models/http_session.py
+++ b/auditlog/models/http_session.py
@@ -20,7 +20,10 @@ class AuditlogtHTTPSession(models.Model):
     @api.depends("create_date", "user_id")
     def _compute_display_name(self):
         for httpsession in self:
-            create_date = fields.Datetime.from_string(httpsession.create_date)
+            create_date = (
+                fields.Datetime.from_string(httpsession.create_date)
+                or fields.Datetime.now()
+            )
             tz_create_date = fields.Datetime.context_timestamp(httpsession, create_date)
             httpsession.display_name = "{} ({})".format(
                 httpsession.user_id and httpsession.user_id.name or "?",

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -3,6 +3,10 @@
 # © 2021 Stefan Rijnhart <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import timedelta
+
+from odoo import fields
+
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.addons.base.models.res_users import name_boolean_group
 
@@ -270,6 +274,12 @@ class AuditlogCommon:
             ),
             1,
         )
+
+    def test_http_session(self):
+        display_name = self.env["auditlog.http.session"].new().display_name
+        now_plus_one_hour = fields.Datetime.now() + timedelta(hours=1)
+        expected_time_str = now_plus_one_hour.strftime("%Y-%m-%d %H:%M:%S")
+        self.assertEqual(display_name, "? (" + expected_time_str + ")")
 
 
 class TestAuditlogFull(AuditLogRuleCommon, AuditlogCommon):

--- a/auditlog/views/http_session_view.xml
+++ b/auditlog/views/http_session_view.xml
@@ -22,7 +22,7 @@
         <field name="name">auditlog.http.session.tree</field>
         <field name="model">auditlog.http.session</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree create="false">
                 <field name="user_id" />
                 <field name="create_date" />
                 <field name="name" />


### PR DESCRIPTION
- When attempting to create a new user session, an error message popped up, so I added that it should take the current date if no date is provided.

- The error message copied from a runboat 

Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 1971, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/odoo/service/model.py", line 152, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 1999, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 2203, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 786, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 25, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 21, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/addons/web/models/models.py", line 1083, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
  File "/opt/odoo/addons/web/models/models.py", line 1170, in __init__
    self.fetch(name)
  File "/opt/odoo/addons/web/models/models.py", line 1185, in fetch
    self[field_name] = self.record[field_name]
  File "/opt/odoo/odoo/models.py", line 6695, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/opt/odoo/odoo/fields.py", line 1152, in __get__
    self.recompute(record)
  File "/opt/odoo/odoo/fields.py", line 1379, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/odoo/fields.py", line 1352, in apply_except_missing
    func(records)
  File "/opt/odoo/odoo/fields.py", line 1401, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/odoo/models.py", line 4923, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/odoo/fields.py", line 102, in determine
    return needle(*args)
  File "/mnt/data/odoo-addons-dir/auditlog/models/http_session.py", line 24, in _compute_display_name
    tz_create_date = fields.Datetime.context_timestamp(httpsession, create_date)
  File "/opt/odoo/odoo/fields.py", line 2269, in context_timestamp
    assert isinstance(timestamp, datetime), 'Datetime instance expected'
AssertionError: Datetime instance expected

The above server error caused the following client error:
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (http://oca-server-tools-17-0-013a975d296a.runboat.odoo-community.org/web/assets/083efc9/web.assets_web.min.js:938:101)
        at App.handleError (http://oca-server-tools-17-0-013a975d296a.runboat.odoo-community.org/web/assets/083efc9/web.assets_web.min.js:1596:29)
        at ComponentNode.initiateRender (http://oca-server-tools-17-0-013a975d296a.runboat.odoo-community.org/web/assets/083efc9/web.assets_web.min.js:1030:19)

Caused by: RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (http://oca-server-tools-17-0-013a975d296a.runboat.odoo-community.org/web/assets/083efc9/web.assets_web.min.js:2955:163)
        at XMLHttpRequest.<anonymous> (http://oca-server-tools-17-0-013a975d296a.runboat.odoo-community.org/web/assets/083efc9/web.assets_web.min.js:2959:13)