### PR TITLE
[18.0][REF] auditlog: Remove deprecated `name_get` methods (odoo/odoo#122085)

### DIFF
--- a/auditlog/models/http_request.py
+++ b/auditlog/models/http_request.py
@@ -31,9 +31,6 @@ class AuditlogHTTPRequest(models.Model):
                 httprequest.name or "?", fields.Datetime.to_string(tz_create_date)
             )
 
-    def name_get(self):
-        return [(request.id, request.display_name) for request in self]
-
     @api.model
     def current_http_request(self):
         """Create a log corresponding to the current HTTP request, and returns

--- a/auditlog/models/http_session.py
+++ b/auditlog/models/http_session.py
@@ -27,9 +27,6 @@ class AuditlogtHTTPSession(models.Model):
                 fields.Datetime.to_string(tz_create_date),
             )
 
-    def name_get(self):
-        return [(session.id, session.display_name) for session in self]
-
     @api.model
     def current_http_session(self):
         """Create a log corresponding to the current HTTP user session, and


### PR DESCRIPTION
This PR fix a runboat error due to a deprecated API `name_get`

Could be paired with #3392 to fix all the runboats errors.
OdooSh env -> https://www.odoo.sh/project/newlogic-oca-server-tools/builds