### PR TITLE
[FIX] tracking_manager: Fixed wrong usage of create function

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -165,8 +165,8 @@ class Base(models.AbstractModel):
         return super().write(vals)
 
     @api.model_create_multi
-    def create(self, list_vals):
-        records = super().create(list_vals)
+    def create(self, vals_list):
+        records = super().create(vals_list)
         if self.is_tracked_by_o2m():
             records._tm_track_create_unlink("create")
         return records


### PR DESCRIPTION
Using the wrong parameter in create function leads to, that globally all create-functions called with parameter "vals_list" will break. 

TypeError: Base.create() got an unexpected keyword argument 'vals_list'