### PR TITLE
[18.0][FIX] mail_cleanup: command CLOSE illegal in state AUTH, only allowed i…

### DIFF
--- a/mail_cleanup/models/fetchmail_server.py
+++ b/mail_cleanup/models/fetchmail_server.py
@@ -51,7 +51,6 @@ class FetchmailServer(models.Model):
         expiration_date = datetime.date.today()
         expiration_date -= relativedelta(days=server.cleanup_days)
         search_text = expiration_date.strftime("(UNSEEN BEFORE %d-%b-%Y)")
-        imap_server.select()
         result, data = imap_server.search(None, search_text)
         for num in data[0].split():
             try:
@@ -86,7 +85,6 @@ class FetchmailServer(models.Model):
         purge_date = datetime.date.today()
         purge_date -= relativedelta(days=server.purge_days)
         search_text = purge_date.strftime("(BEFORE %d-%b-%Y)")
-        imap_server.select()
         result, data = imap_server.search(None, search_text)
         for num in data[0].split():
             try:
@@ -122,6 +120,7 @@ class FetchmailServer(models.Model):
             if server.server_type == "imap":
                 try:
                     imap_server = server.connect()
+                    imap_server.select()
                     if server.cleanup_days > 0:
                         self._cleanup_fetchmail_server(server, imap_server)
                     if server.purge_days > 0:


### PR DESCRIPTION
…n states SELECTED

Fixing: https://github.com/OCA/server-tools/issues/3435

You need to have a `server.select()`. These selects are done into the methods `_cleanup_fetchmail_server` and `_purge_fetchmail_server` if you don't match any of the IF statements. You will never do the `server.select()` and thus endup with a stacktrace. 

https://github.com/OCA/server-tools/blob/18.0/mail_cleanup/models/fetchmail_server.py#L125
https://github.com/OCA/server-tools/blob/18.0/mail_cleanup/models/fetchmail_server.py#L128C30-L128C53