### PR TITLE
[16.0][FIX] auditlog: Fix Invalid Reading of Stale Database Values

### DIFF
--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -485,6 +485,8 @@ class AuditlogRule(models.Model):
             if self.env.user in users_to_exclude:
                 return result
 
+            self.flush_recordset([field_name for field_name in vals.keys()])
+
             with ThrowAwayCache(self.env):
                 new_values = {d["id"]: d for d in records_write.read(fields_list)}
 

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -321,6 +321,30 @@ class TestAuditlogFull(AuditLogRuleCommon, AuditlogCommon):
         self.groups_rule.unlink()
         super(TestAuditlogFull, self).tearDown()
 
+    def test_update_logs_have_lines_with_changes(self):
+        self.groups_rule.subscribe()
+        initial_value = "test-group-1"
+        new_value = "test-group-2"
+        group = self.env["res.groups"].create({"name": initial_value})
+        group.write(
+            {
+                "name": new_value,
+            }
+        )
+        log = self.env["auditlog.log"].search(
+            [
+                ("model_id", "=", self.groups_model_id),
+                ("method", "=", "write"),
+                ("res_id", "=", group.id),
+            ]
+        )
+        self.assertEqual(len(log), 1)
+        self.assertEqual(len(log.line_ids), 1)
+        log_line = log.line_ids[0]
+        self.assertEqual(log_line.field_name, "name")
+        self.assertEqual(log_line.old_value, initial_value)
+        self.assertEqual(log_line.new_value, new_value)
+
 
 class TestAuditlogFast(AuditLogRuleCommon, AuditlogCommon):
     def setUp(self):


### PR DESCRIPTION
Due to the introduction of the `ThrowAwayCache`, in full log mode when attempting to log a write, the reading of the '_new_' values effectively reads the '_old_' values because prior changes were not flushed to the database yet at that point. This resulted in missing log lines in the created log entry since the old vs. new value comparison did not indicate any changes.

It has been confirmed that without the introduced patch for the database flush, the added test fails as expected.
