### PR TITLE
[18.0][FIX] tracking_manager_domain: prevent error when tracking properties

### DIFF
--- a/tracking_manager_domain/__manifest__.py
+++ b/tracking_manager_domain/__manifest__.py
@@ -9,7 +9,7 @@
     "version": "18.0.1.0.0",
     "category": "Tools",
     "website": "https://github.com/OCA/server-tools",
-    "author": "Akretion, Odoo Community Association (OCA)",
+    "author": "glueckkanja AG, Odoo Community Association (OCA)",
     "maintainers": ["CRogos"],
     "license": "AGPL-3",
     "application": False,

--- a/tracking_manager_domain/models/models.py
+++ b/tracking_manager_domain/models/models.py
@@ -63,8 +63,12 @@ class Base(models.AbstractModel):
         changes, tracking_value_ids = super()._mail_track(
             tracked_fields, initial_values
         )
+
+        # TODO: add properties support on domain filters
         tracking_value_field_ids = [
-            tracking_value_id[2]["field_id"] for tracking_value_id in tracking_value_ids
+            tracking_value_id[2]["field_id"]
+            for tracking_value_id in tracking_value_ids
+            if "field_id" in tracking_value_id[2]
         ]
         if tracking_value_field_ids:
             all_tracking_domain_fields = self._tm_all_tracking_domain_fields()[

--- a/tracking_manager_domain/tests/test_models.py
+++ b/tracking_manager_domain/tests/test_models.py
@@ -1,6 +1,9 @@
 # Copyright 2025 glueckkanja AG (<https://www.glueckkanja.com>) - Christopher Rogos
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from unittest.mock import patch
+
+from odoo import Command
 from odoo.tests.common import TransactionCase
 
 
@@ -48,3 +51,36 @@ class TestMailTrack(TransactionCase):
         # Check if changes and tracking_value_ids are empty when domain does not match
         self.assertEqual(len(changes), 0)
         self.assertEqual(len(tracking_value_ids), 0)
+
+    # TODO: add properties support on domain filters
+    def test_mail_track_lead_properties_noerror(self):
+        # arrange
+        person = self.env.ref("base.res_partner_12")
+        tracked_fields = {
+            "lead_properties": {"string": "Properties", "type": "properties"}
+        }
+        initial_values = {"3f32dd2678757113": False}
+
+        patch_changes = {1234: "lead_properties"}
+        patch_tracking_value_ids = [
+            Command.create(
+                {
+                    "old_value_integer": 15,
+                    "new_value_integer": 10,
+                    "old_value_char": "Azure Interior",
+                    "new_value_char": "Deco Addict",
+                    "field_info": {
+                        "desc": "Properties: Ev",
+                        "name": "lead_properties",
+                        "type": "many2one",
+                    },
+                }
+            )
+        ]
+
+        with patch(
+            "odoo.addons.tracking_manager.models.models.Base._mail_track",
+            return_value=(patch_changes, patch_tracking_value_ids),
+        ):
+            # act
+            person._mail_track(tracked_fields, initial_values)


### PR DESCRIPTION
<img width="629" height="205" alt="image" src="https://github.com/user-attachments/assets/917fb95e-1e95-46e7-b1ca-c7b03b577d4f" />

Prevent error when tracking fields of type property. (e.g. lead_properties)

```
2025-11-24 12:36:53,697 2 ERROR db18_test_tracking_manager_domain odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/src/odoo/odoo/http.py", line 2576, in __call__
    response = request._serve_db()
               ^^^^^^^^^^^^^^^^^^^
  File "/src/odoo/odoo/http.py", line 2103, in _serve_db
    return self._transactioning(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/src/odoo/odoo/http.py", line 2166, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/odoo/odoo/service/model.py", line 158, in retrying
    env.cr.flush()  # submit the changes to the database
    ^^^^^^^^^^^^^^
  File "/src/odoo/odoo/sql_db.py", line 160, in flush
    self.precommit.run()
  File "/src/odoo/odoo/tools/misc.py", line 1162, in run
    func()
  File "/src/odoo/addons/mail/models/mail_thread.py", line 548, in _track_finalize
    tracking = records.with_context(context)._message_track(fnames, initial_values)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/odoo/addons/mail/models/mail_thread.py", line 630, in _message_track
    tracking[record.id] = record._mail_track(tracked_fields, initial_values_dict[record.id])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/user/modules/oca/server-tools/tracking_manager_domain/models/models.py", line 67, in _mail_track
    tracking_value_id[2]["field_id"] for tracking_value_id in tracking_value_ids
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'field_id'
```