### PR TITLE
[FIX] base_remote: Allow RPC authentication without HTTP context

### DIFF
--- a/base_remote/models/res_users.py
+++ b/base_remote/models/res_users.py
@@ -16,7 +16,7 @@ class ResUsers(models.Model):
         with cls.pool.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
             remote = env["res.users"].remote
-            if not config["test_enable"]:
+            if not config["test_enable"] and remote:
                 remote.ensure_one()
         result = method()
         if not result:


### PR DESCRIPTION
## Description

Fixes #3458

This PR fixes a bug where XML-RPC and JSON-RPC authentication fails with `ValueError: Expected singleton: res.remote()`.

## Root Cause

When authenticating via RPC (non-HTTP requests), there is no HTTP request context available. The `remote` property in `models/base.py` gracefully handles this by returning an empty recordset. However, `_auth_check_remote` in `models/res_users.py` unconditionally calls `ensure_one()` on this recordset, causing authentication to fail.

## Changes

- Modified line 19 in `base_remote/models/res_users.py`
- Added check to skip `ensure_one()` when `remote` is empty (no HTTP context)
- Maintains device tracking for web browser connections (primary use case)
- Follows same pattern already used for test mode

## Testing

Tested with OdooRPC Python library:
- ✅ RPC/API authentication now works
- ✅ Web browser authentication still works
- ✅ Device tracking for HTTP connections maintained

## Impact

- ✅ Fixes RPC/API authentication (OdooRPC, mobile apps, external integrations)
- ✅ Maintains existing web browser device tracking functionality
- ✅ No security or functionality regression