### PR TITLE
[16][IMP] attachment_synchronize: catch connection reset error for retry

### DIFF
--- a/attachment_synchronize/models/attachment_queue.py
+++ b/attachment_synchronize/models/attachment_queue.py
@@ -47,6 +47,11 @@ class AttachmentQueue(models.Model):
                     str(err),
                     seconds=self._timeout_retry_seconds(),
                 ) from err
+            except ConnectionResetError as err:
+                raise RetryableJobError(
+                    str(err),
+                    seconds=self._timeout_retry_seconds(),
+                ) from err
         return res
 
     def _timeout_retry_seconds(self):


### PR DESCRIPTION
Same as what is already done for ConnectionResetError