### PR TITLE
[18.0][IMP] excel_import_export: Support Updating Existing Data via Database ID Import

### DIFF
--- a/excel_import_export/models/xlsx_import.py
+++ b/excel_import_export/models/xlsx_import.py
@@ -65,6 +65,9 @@ class XLSXImport(models.AbstractModel):
         try:
             record = self.env[model].new()
             for f in field.split("/"):
+                # Supporting import by database ID
+                if f == ".id":
+                    f = "id"
                 field_type = record._fields[f].type
                 if field_type in ("one2many", "many2many"):
                     record = record[f]

--- a/excel_import_export/readme/CONTRIBUTORS.md
+++ b/excel_import_export/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
   (<http://ecosoft.co.th>)
 - Saran Lim. \<<saranl@ecosoft.co.th>\> (<http://ecosoft.co.th>)
 - Do Anh Duy \<<duyda@trobz.com>\>
+- 张飞虎 \<<feihu.zhang@orado.cn>\>

--- a/excel_import_export/readme/USAGE.md
+++ b/excel_import_export/readme/USAGE.md
@@ -69,6 +69,33 @@ excel_import_export_demo/report_sale_order)
 5.  Create instruction dictionary for report in xlsx.template model --
     templates.xml
 
+**Use Case 4:** Import and Update Existing Records by Database ID
+
+This feature enables batch updating of existing data by including the record ID
+in the export template and using it during import to match and update corresponding
+records.
+
+**Scenario:** Suitable for procurement quotation processes where product quotes
+need to be batch updated. For example, a purchase order contains hundreds of
+products. You can export the details to suppliers for quoting, then import the
+supplier's returned quotes to quickly update the prices in the quotation for
+easy comparison.
+
+**Workflow:**
+
+1.  Define Export Template: When exporting purchase details, include id field (ID) 
+    in the template.
+
+2.  Configure Import Template: In the import template's ID field, enter ".id"
+    to leverage Odoo's built-in mechanism for matching and updating corresponding
+    records.
+
+3.  Execute Import: Select the file with supplier quotes for import.
+
+4.  Complete Update: After successful import, the prices in the related purchase
+    quotation lines will automatically update to the latest quotes provided by
+    the supplier.
+
 **Note:**
 
 Another option for reporting is to use report action


### PR DESCRIPTION
## Use Case
This feature is designed for procurement quotation scenarios involving a large number of products (e.g., over 100 items). Purchasing details can be exported to suppliers for price filling, and then re-imported to update the quotation for comparison.

## Steps

- **Define an export template** that includes the ID field for each record.
- **Set up an import template** with `.id` in the ID column to leverage Odoo’s built‑in record‑matching mechanism.
- Import the supplier’s updated quotation file.
- Prices in the corresponding purchase quotation lines will be updated automatically.