### PR TITLE
[18.0][IMP] auto_backup: add option to skip host key verification

### DIFF
--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -84,6 +84,13 @@ class DbBackup(models.Model):
         help="Path to the private key file. Only the Odoo user should have "
         "read permissions for that file.",
     )
+    sftp_ignore_hostkey = fields.Boolean(
+        "Ignore Host Key Verification",
+        default=False,
+        help="If enabled, the SFTP connection will not verify the server's "
+        "host key. This is less secure but useful when the server's host key "
+        "is not available in the known_hosts file.",
+    )
 
     backup_format = fields.Selection(
         [
@@ -278,6 +285,15 @@ class DbBackup(models.Model):
             "username": self.sftp_user,
             "port": self.sftp_port,
         }
+        # Optionally disable host key verification
+        if self.sftp_ignore_hostkey:
+            cnopts = pysftp.CnOpts()
+            cnopts.hostkeys = None
+            params["cnopts"] = cnopts
+            _logger.warning(
+                "SFTP host key verification disabled for %s - this is less secure",
+                self.sftp_host,
+            )
         _logger.debug(
             "Trying to connect to sftp://%(username)s@%(host)s:%(port)d", extra=params
         )

--- a/auto_backup/tests/test_db_backup.py
+++ b/auto_backup/tests/test_db_backup.py
@@ -234,3 +234,29 @@ class TestDbBackup(common.TransactionCase):
         now = datetime.now()
         res = self.Model.filename(now, ext="dump")
         self.assertTrue(res.endswith(".dump"))
+
+    @patch(f"{model}.pysftp")
+    def test_sftp_connection_without_ignore_hostkey(self, mock_pysftp):
+        """It should NOT pass cnopts when sftp_ignore_hostkey is False"""
+        rec_id = self.new_record()
+        rec_id.write({"sftp_ignore_hostkey": False})
+        rec_id.sftp_connection()
+        # Verify cnopts is NOT passed when ignore_hostkey is False
+        call_kwargs = mock_pysftp.Connection.call_args.kwargs
+        self.assertNotIn("cnopts", call_kwargs)
+
+    @patch(f"{model}.pysftp")
+    def test_sftp_connection_with_ignore_hostkey(self, mock_pysftp):
+        """It should pass cnopts with hostkeys=None when sftp_ignore_hostkey is True"""
+        rec_id = self.new_record()
+        rec_id.write({"sftp_ignore_hostkey": True})
+        rec_id.sftp_connection()
+        # Verify cnopts IS passed when ignore_hostkey is True
+        call_kwargs = mock_pysftp.Connection.call_args.kwargs
+        self.assertIn("cnopts", call_kwargs)
+        self.assertIsNone(call_kwargs["cnopts"].hostkeys)
+
+    def test_sftp_ignore_hostkey_default_value(self):
+        """It should have sftp_ignore_hostkey defaulting to False"""
+        rec_id = self.new_record()
+        self.assertFalse(rec_id.sftp_ignore_hostkey)

--- a/auto_backup/view/db_backup_view.xml
+++ b/auto_backup/view/db_backup_view.xml
@@ -38,6 +38,7 @@
                                 name="sftp_private_key"
                                 placeholder="/home/odoo/.ssh/id_rsa"
                             />
+                            <field name="sftp_ignore_hostkey" />
                             <button
                                 name="action_sftp_test_connection"
                                 type="object"


### PR DESCRIPTION
## Summary

Add a configurable option `sftp_ignore_hostkey` to allow users to disable SSH host key verification for SFTP connections.

### Problem

When using SFTP backup method, connections fail with `SSHException: No hostkey for host X found` if the server's host key is not in the `known_hosts` file. This is a common issue reported in #782.

### Solution

- Add new boolean field `sftp_ignore_hostkey` (default: `False`)
- When enabled, the SFTP connection skips host key verification
- A warning is logged when verification is disabled
- Security is maintained by default (verification enabled)

## Changes

- `auto_backup/models/db_backup.py`: Add field and modify `sftp_connection()` method
- `auto_backup/view/db_backup_view.xml`: Add field to SFTP settings form
- `auto_backup/tests/test_db_backup.py`: Add 3 new tests for the feature

## Test Plan

- [x] Pre-commit hooks pass
- [x] New unit tests added
- [ ] Manual testing with SFTP server

Closes #782