### PR TITLE
[18.0][FIX] auditlog: ensure methods from test template are actually run

### DIFF
--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -10,6 +10,12 @@ from .common import AuditLogRuleCommon
 
 
 class AuditlogCommon:
+    """Base case with basic log creation tests"""
+
+    # Ensure that test cases that inherit from this class run the methods
+    # that it provides.
+    allow_inherited_tests_method = True
+
     def test_LogCreation(self):
         """First test, caching some data."""
         self.groups_rule.subscribe()


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/6dc96811c24ec, test methods from inherited test classes are not run by default.