### PR TITLE
[19.0][FIX] database_cleanup: create attachment with store_fname in test

### DIFF
--- a/database_cleanup/tests/test_purge_fields.py
+++ b/database_cleanup/tests/test_purge_fields.py
@@ -22,9 +22,13 @@ class TestCleanupPurgeFields(Common):
             }
             cls.model = env["ir.model"].create(cls.model_values)
             env.cr.execute(
-                "insert into ir_attachment (name, res_model, res_id, type) values "
-                "('test attachment', %s, 42, 'binary')",
-                [cls.model_name],
+                """
+                insert into ir_attachment
+                (name, res_model, res_id, store_fname, type)
+                values
+                ('test attachment', %(model_name)s, 42, 'dummy', 'binary');
+                """,
+                {"model_name": cls.model_name},
             )
 
             # create a nonexistent field


### PR DESCRIPTION
Tests break on test attachment created without store_fname when `mail` is installed. In that case, attachments are actively deleted when a model is unlinked, and the missing store_fname causes problems further down.

https://github.com/odoo/odoo/blob/d2274a3fdb/addons/mail/models/ir_model.py#L50-L68

Fixes
```

2026-01-02 20:25:20,571 385 ERROR odoo odoo.tests.suite: ERROR: tearDownClass (odoo.addons.database_cleanup.tests.test_purge_fields.TestCleanupPurgeFields)
Traceback (most recent call last):
  File "/__w/server-tools/server-tools/database_cleanup/tests/test_purge_fields.py", line 65, in tearDownClass
    model.unlink()
  File "/opt/odoo/addons/mail/models/ir_model.py", line 68, in unlink
    self.env['ir.attachment']._file_delete(fname)
  File "/opt/odoo/odoo/addons/base/models/ir_attachment.py", line 162, in _file_delete
    self._mark_for_gc(fname)
  File "/opt/odoo/odoo/addons/base/models/ir_attachment.py", line 167, in _mark_for_gc
    fname = re.sub('[.:]', '', fname).strip('/\\')
  File "/usr/lib/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

(E.g. in https://github.com/OCA/server-tools/actions/runs/20666022004/job/59338358298?pr=3484)