### PR TITLE
[16.0][IMP] module_auto_update: auto_upgrade command

### DIFF
--- a/module_auto_update/README.rst
+++ b/module_auto_update/README.rst
@@ -77,6 +77,14 @@ in an Odoo shell session:
 
   env['ir.module.module'].upgrade_changed_checksum()
 
+For integration in toolchains the upgrade mechanism can also be invoked using the Odoo cli command ``auto_update``. The `--addons-path=` is required as first argument:
+
+.. code-block:: bash
+
+  odoo-bin --addons-path=... auto_update -d odoo
+  # or
+  odoo-bin --addons-path=... auto_update -c path/to/odoo.cfg
+
 Bug Tracker
 ===========
 

--- a/module_auto_update/__init__.py
+++ b/module_auto_update/__init__.py
@@ -1,4 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from . import models
+from . import cli, models
 from .hooks import uninstall_hook

--- a/module_auto_update/cli/__init__.py
+++ b/module_auto_update/cli/__init__.py
@@ -1,0 +1,4 @@
+# © 2025 initOS GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import auto_update

--- a/module_auto_update/cli/auto_update.py
+++ b/module_auto_update/cli/auto_update.py
@@ -1,0 +1,36 @@
+# © 2025 initOS GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import odoo
+from odoo import api
+from odoo.cli.shell import Shell
+from odoo.tools import config
+
+
+class ModuleAutoUpgrade(Shell):
+    """Run auto upgrade"""
+
+    name = "auto_update"
+
+    def run(self, args):
+        self.init(args)
+        registry = odoo.registry(config["db_name"])
+        with registry.cursor() as cr:
+            uid = odoo.SUPERUSER_ID
+            # Disabling prefetching of fields here because new fields for
+            # res.partner and res.users already exist in the python structures
+            # but aren't available in the database yet and would cause exception here
+            # This is different from invoking a python shell
+            ctx = (
+                odoo.api.Environment(cr, uid, {})["res.users"]
+                .with_context(prefetch_fields=False)
+                .context_get()
+            )
+
+            env = api.Environment(cr, uid, ctx)
+            env["ir.module.module"].upgrade_changed_checksum(
+                overwrite_existing_translations=config[
+                    "overwrite_existing_translations"
+                ],
+            )
+        return 0

--- a/module_auto_update/readme/USAGE.rst
+++ b/module_auto_update/readme/USAGE.rst
@@ -20,3 +20,11 @@ in an Odoo shell session:
 .. code-block:: python
 
   env['ir.module.module'].upgrade_changed_checksum()
+
+For integration in toolchains the upgrade mechanism can also be invoked using the Odoo cli command ``auto_update``. The `--addons-path=` is required as first argument:
+
+.. code-block:: bash
+
+  odoo-bin --addons-path=... auto_update -d odoo
+  # or
+  odoo-bin --addons-path=... auto_update -c path/to/odoo.cfg

--- a/module_auto_update/static/description/index.html
+++ b/module_auto_update/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -419,6 +420,12 @@ in an Odoo shell session:</p>
 <pre class="code python literal-block">
 <span class="n">env</span><span class="p">[</span><span class="s1">'ir.module.module'</span><span class="p">]</span><span class="o">.</span><span class="n">upgrade_changed_checksum</span><span class="p">()</span>
 </pre>
+<p>For integration in toolchains the upgrade mechanism can also be invoked using the Odoo cli command <tt class="docutils literal">auto_update</tt>. The <cite>–addons-path=</cite> is required as first argument:</p>
+<pre class="code bash literal-block">
+odoo-bin<span class="w"> </span>--addons-path<span class="o">=</span>...<span class="w"> </span>auto_update<span class="w"> </span>-d<span class="w"> </span>odoo<span class="w">
+</span><span class="c1"># or
+</span>odoo-bin<span class="w"> </span>--addons-path<span class="o">=</span>...<span class="w"> </span>auto_update<span class="w"> </span>-c<span class="w"> </span>path/to/odoo.cfg
+</pre>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
@@ -453,7 +460,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
As discussed in #2604. This will prevent problems when new fields of res.partner or res.users are added in existing problem when initializing the Odoo shell.

```bash
./odoo-bin --addons-path=ocb/addons,ocb/odoo/addons,custom-addons auto_update -d odoo
```