### PR TITLE
[18][FIX] dbfilter_from_header: db name matching has to be strict

### DIFF
--- a/dbfilter_from_header/override.py
+++ b/dbfilter_from_header/override.py
@@ -17,7 +17,7 @@ def db_filter(dbs, host=None):
     httprequest = http.request.httprequest
     db_filter_hdr = httprequest.environ.get("HTTP_X_ODOO_DBFILTER")
     if db_filter_hdr:
-        dbs = [db for db in dbs if re.match(db_filter_hdr, db)]
+        dbs = [db for db in dbs if re.fullmatch(db_filter_hdr, db)]
     return dbs
 
 


### PR DESCRIPTION
Use case : 
We have 2 databases dbname and dbname-test
In case we setup the dbfilter to dbname, we have 2 databases that match.
So we are donig a strict match now (re.fullmatch since python 3.4)