### PR TITLE
[16.0][IMP] session_db: support binary fields

### DIFF
--- a/session_db/pg_session_store.py
+++ b/session_db/pg_session_store.py
@@ -2,6 +2,8 @@
 # @author Nicolas Seinlet
 # Copyright (c) ACSONE SA 2022
 # @author Stéphane Bidoul
+import base64
+import binascii
 import json
 import logging
 import os
@@ -66,6 +68,7 @@ class PGSessionStore(sessions.SessionStore):
         self._cr = None
         self._open_connection()
         self._setup_db()
+        self.prefix_binary = "base64::"
 
     def __del__(self):
         self._close_connection()
@@ -108,7 +111,8 @@ class PGSessionStore(sessions.SessionStore):
     @with_lock
     @with_cursor
     def save(self, session):
-        payload = json.dumps(dict(session))
+        json_session = self.session_to_str(dict(session))
+        payload = json.dumps(json_session)
         self._cr.execute(
             """
                 INSERT INTO http_sessions(sid, write_date, payload)
@@ -131,6 +135,7 @@ class PGSessionStore(sessions.SessionStore):
         self._cr.execute("SELECT payload FROM http_sessions WHERE sid=%s", (sid,))
         try:
             data = json.loads(self._cr.fetchone()[0])
+            data = self.str_to_session(data)
         except Exception:
             return self.new()
 
@@ -148,6 +153,45 @@ class PGSessionStore(sessions.SessionStore):
             "WHERE now() at time zone 'UTC' - write_date > %s",
             (f"{max_lifetime} seconds",),
         )
+
+    def _traverse_and_convert(self, data_node, conversion_func):
+        """
+        Recursively applies a conversion function to all elements in dicts and lists.
+        """
+        if isinstance(data_node, dict):
+            return {
+                self._traverse_and_convert(
+                    key, conversion_func
+                ): self._traverse_and_convert(value, conversion_func)
+                for key, value in data_node.items()
+            }
+        if isinstance(data_node, list):
+            return [
+                self._traverse_and_convert(item, conversion_func) for item in data_node
+            ]
+
+        return conversion_func(data_node)
+
+    def session_to_str(self, data):
+        def convert(value):
+            if isinstance(value, bytes):
+                return self.prefix_binary + base64.b64encode(value).decode("utf-8")
+            return value
+
+        return self._traverse_and_convert(data, convert)
+
+    def str_to_session(self, data):
+        def convert(value):
+            if isinstance(value, str) and value.startswith(self.prefix_binary):
+                try:
+                    return base64.b64decode(
+                        value[len(self.prefix_binary) :], validate=True
+                    )
+                except (ValueError, TypeError, binascii.Error):
+                    return value
+            return value
+
+        return self._traverse_and_convert(data, convert)
 
 
 _original_session_store = http.root.__class__.session_store

--- a/session_db/tests/test_pg_session_store.py
+++ b/session_db/tests/test_pg_session_store.py
@@ -1,3 +1,4 @@
+import base64
 from unittest import mock
 
 import psycopg2
@@ -92,3 +93,46 @@ class TestPGSessionStore(TransactionCase):
         assert "postgres://test:PASSWORD@localhost:5432/test" == _make_postgres_uri(
             **connection_info
         )
+
+    def test_binary_serialization_roundtrip(self):
+        """Ensures binary data is safely serialized to a base64 string
+        and accurately deserialized back to bytes."""
+        original_data = {
+            "normal_text": "test",
+            "binary_data": b"Test binary",
+        }
+        serialized = self.session_store.session_to_str(original_data)
+        expected_b64 = base64.b64encode(b"Test binary").decode("utf-8")
+        self.assertEqual(
+            serialized["binary_data"],
+            f"base64::{expected_b64}",
+            "Binary data should be serialized with the configured prefix.",
+        )
+        self.assertEqual(serialized["normal_text"], "test")
+
+        deserialized = self.session_store.str_to_session(serialized)
+        self.assertEqual(deserialized["binary_data"], b"Test binary")
+        self.assertIsInstance(deserialized["binary_data"], bytes)
+
+    def test_recursive_traversal(self):
+        """Verifies that base64 serialization works inside nested structures."""
+        data = {
+            "list_of_data": [b"binary_in_list", "100", {"deep_key": b"deep_binary"}]
+        }
+        serialized = self.session_store.session_to_str(data)
+        self.assertTrue(serialized["list_of_data"][0].startswith("base64::"))
+        self.assertTrue(
+            serialized["list_of_data"][2]["deep_key"].startswith("base64::")
+        )
+
+        result = self.session_store.str_to_session(serialized)
+        self.assertEqual(result["list_of_data"][0], b"binary_in_list")
+        self.assertEqual(result["list_of_data"][1], "100")
+        self.assertEqual(result["list_of_data"][2]["deep_key"], b"deep_binary")
+
+    def test_invalid_base64_fallback(self):
+        """Failsafe: Invalid base64 strings with the exact prefix must return
+        the original string without crashing the session load."""
+        invalid_data = {"bad_binary": "base64::TESTS_INVALID_@#$"}
+        result = self.session_store.str_to_session(invalid_data)
+        self.assertEqual(result["bad_binary"], "base64::TESTS_INVALID_@#$")


### PR DESCRIPTION
## Summary

This PR fixes a error traceback occurring in the `session_db` module when `bytes` objects are present in the Odoo session (`request.session`). 

When custom modules place binary data in the session (e.g., for temporary image previews before saving a record), the `pg_session_store.py` script crashes during the `json.dumps(dict(session))` call because the standard `json` cannot serialize `bytes` objects natively.

## Traceback Resolved

```python
Traceback (most recent call last):
  File "/home/odoo/instance/odoo/odoo/http.py", line 2072, in __call__
    response = request._serve_db()
  File "/home/odoo/instance/odoo/odoo/http.py", line 1664, in _serve_db
    exc.error_response = self.registry['ir.http']._handle_error(exc)
  File "/home/odoo/instance/odoo/addons/http_routing/models/ir_http.py", line 660, in _handle_error
    cls._post_dispatch(response)
  File "/home/odoo/instance/odoo/addons/utm/models/ir_http.py", line 26, in _post_dispatch
    super()._post_dispatch(response)
  File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_http.py", line 161, in _post_dispatch
    request.dispatcher.post_dispatch(response)
  File "/home/odoo/instance/odoo/odoo/http.py", line 1757, in post_dispatch
    self.request._save_session()
  File "/home/odoo/instance/odoo/odoo/http.py", line 1579, in _save_session
    root.session_store.save(sess)
  File "/home/odoo/instance/extra_addons/server-tools/session_db/pg_session_store.py", line 34, in wrapper
    return func(*args, **kwargs)
  File "/home/odoo/instance/extra_addons/server-tools/session_db/pg_session_store.py", line 49, in wrapper
    return func(self, *args, **kwargs)
  File "/home/odoo/instance/extra_addons/server-tools/session_db/pg_session_store.py", line 111, in save
    payload = json.dumps(dict(session))
  File "/usr/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```

## Technical Implementation

- Pre-serialization Hook (session_to_str): Intercepts the session dictionary before JSON serialization. It recursively scans for bytes objects and safely encodes them as base64 strings prefixed with `base64::`.
- Post-deserialization Hook (str_to_session): Intercepts the JSON payload upon retrieval, decoding any string containing this specific prefix back into a standard bytes object.

## Evidence

- Before the fix

Video: https://drive.google.com/file/d/1M3T3rBrKN4jcU2t-zuxDcViyrPwlnn20/view?usp=sharing

- After the fix

Video: https://drive.google.com/file/d/1V6eztsmkGEGkQaJoD725aVlrvE06XLuO/view