### PR TITLE
[FIX][18.0] fetchmail_attach_from_folder tests: mock expunge()

### DIFF
--- a/fetchmail_attach_from_folder/models/fetchmail_server.py
+++ b/fetchmail_attach_from_folder/models/fetchmail_server.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -30,7 +31,11 @@ class FetchmailServer(models.Model):
             if this.state != "done":
                 this.folders_available = _("Confirm connection first.")
                 continue
-            connection = this.connect()
+            try:
+                connection = this.connect()
+            except UserError:
+                this.folders_available = _("Confirm connection first.")
+                continue
             list_result = connection.list()
             if list_result[0] != "OK":
                 this.folders_available = _("Unable to retrieve folders.")

--- a/fetchmail_attach_from_folder/models/fetchmail_server_folder.py
+++ b/fetchmail_attach_from_folder/models/fetchmail_server_folder.py
@@ -180,22 +180,26 @@ class FetchmailServerFolder(models.Model):
     def retrieve_imap_folder(self, connection):
         """Retrieve all mails for one IMAP folder."""
         self.ensure_one()
-        msgids = self.get_msgids(connection, self.get_criteria())
-        for msgid in msgids[0].split():
+        message_uids = self.get_message_uids(connection, self.get_criteria())
+        for message_uid in message_uids[0].split():
             # We will accept exceptions for single messages
             try:
                 self.env.cr.execute("savepoint apply_matching")
-                self.apply_matching(connection, msgid)
+                self.apply_matching(connection, message_uid)
                 self.env.cr.execute("release savepoint apply_matching")
             except Exception:
                 self.env.cr.execute("rollback to savepoint apply_matching")
                 _logger.exception(
-                    "Failed to fetch mail %(msgid)s from server %(server)s",
-                    {"msgid": msgid, "server": self.server_id.name},
+                    "Failed to fetch mail %(message_uid)s from server %(server)s",
+                    {"message_uid": message_uid, "server": self.server_id.name},
                 )
 
-    def get_msgids(self, connection, criteria):
+    def get_message_uids(self, connection, criteria):
         """Return imap ids of messages to process"""
+        # Note that these message_uids are linked to the folder on
+        # the imap server. They have nothing at all todo with the
+        # message_id field that is part of the message itself, and the
+        # two should not be confused.
         self.ensure_one()
         server = self.server_id
         _logger.info(
@@ -207,7 +211,8 @@ class FetchmailServerFolder(models.Model):
                 _("Could not open folder %(folder)s on server %(server)s")
                 % {"folder": self.path, "server": server.name}
             )
-        result, msgids = connection.search(None, criteria)
+        charset = None  # Generally we do not need to set a charset.
+        result, message_uids = connection.uid("search", charset, criteria)
         if result != "OK":
             raise UserError(
                 _("Could not search folder %(folder)s on server %(server)s")
@@ -217,14 +222,14 @@ class FetchmailServerFolder(models.Model):
             "finished checking for emails in folder %(folder)s on server %(server)s",
             {"folder": self.path, "server": server.name},
         )
-        return msgids
+        return message_uids
 
-    def apply_matching(self, connection, msgid):
+    def apply_matching(self, connection, message_uid):
         """Return id of object matched (which will be the thread_id)."""
         self.ensure_one()
         thread_id = None
         thread_model = self.env["mail.thread"]
-        message_org = self.fetch_msg(connection, msgid)
+        message_org = self.fetch_msg(connection, message_uid)
         if self.match_algorithm == "odoo_standard":
             thread_id = thread_model.message_process(
                 self.model_id.model,
@@ -242,9 +247,9 @@ class FetchmailServerFolder(models.Model):
         matched = True if thread_id else False
         if matched:
             self.run_server_action(thread_id)
-        self.update_msg(connection, msgid, matched=matched)
-        if self.archive_path:
-            self._archive_msg(connection, msgid)
+        self.update_msg(connection, message_uid, matched=matched)
+        if self.archive_path and not self.delete_matching:
+            self._archive_msg(connection, message_uid)
         return thread_id  # Can be None if no match found.
 
     def run_server_action(self, matched_object_ids):
@@ -263,34 +268,38 @@ class FetchmailServerFolder(models.Model):
                 }
             ).run()
 
-    def fetch_msg(self, connection, msgid):
+    def fetch_msg(self, connection, message_uid):
         """Select a single message from a folder."""
         self.ensure_one()
-        result, msgdata = connection.fetch(msgid, "(RFC822)")
+        result, msgdata = connection.uid("fetch", message_uid, "(RFC822)")
         if result != "OK":
             raise UserError(
-                _("Could not fetch %(msgid)s in folder %(folder)s on server %(server)s")
-                % {"msgid": msgid, "folder": self.path, "server": self.server_id.name}
+                _(
+                    "Could not fetch %(message_uid)s in folder %(folder)s"
+                    " on server %(server)s",
+                    message_uid=message_uid,
+                    folder=self.path,
+                    server=self.server_id.name,
+                )
             )
         message_org = msgdata[0][1]  # rfc822 message source
         return message_org
 
-    def update_msg(self, connection, msgid, matched=True, flagged=False):
+    def update_msg(self, connection, message_uid, matched=True, flagged=False):
         """Update msg in imap folder depending on match and settings."""
         if matched:
             if self.delete_matching:
-                connection.store(msgid, "+FLAGS", "\\DELETED")
+                connection.uid("store", message_uid, "+FLAGS", "\\DELETED")
             elif flagged and self.flag_nonmatching:
-                connection.store(msgid, "-FLAGS", "\\FLAGGED")
+                connection.uid("store", message_uid, "-FLAGS", "\\FLAGGED")
         else:
             if self.flag_nonmatching:
-                connection.store(msgid, "+FLAGS", "\\FLAGGED")
+                connection.uid("store", message_uid, "+FLAGS", "\\FLAGGED")
 
-    def _archive_msg(self, connection, msgid):
+    def _archive_msg(self, connection, message_uid):
         """Archive message. Folder should already have been created."""
-        self.ensure_one()
-        connection.copy(msgid, self.archive_path)
-        connection.store(msgid, "+FLAGS", "\\Deleted")
+        connection.uid("copy", message_uid, self.archive_path)
+        connection.uid("store", message_uid, "+FLAGS", "\\Deleted")
         connection.expunge()
 
     @api.model
@@ -331,10 +340,11 @@ class FetchmailServerFolder(models.Model):
         matches = matcher.search_matches(self, message_dict)
         if not matches:
             _logger.info(
-                "No match found for message %(subject)s with msgid %(msgid)s",
+                "No match found for message %(subject)s"
+                " with message_uid %(message_uid)s",
                 {
                     "subject": message_dict.get("subject", "no subject"),
-                    "msgid": message_dict.get("message_id", "no msgid"),
+                    "message_uid": message_dict.get("message_id", "no message_uid"),
                 },
             )
             return None

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -251,6 +251,7 @@ class TestAttachMailManually(TransactionCase):
         mock_conn = MagicMock()
         mock_conn.select.return_value = ("OK",)
         mock_conn.search.return_value = ("OK", [b"1"])
+        mock_conn.uid.return_value = ("OK", [b"1"])
         mock_conn.fetch.return_value = (
             "OK",
             [(b"1 (RFC822 {123}", b"Mocked raw email content")],
@@ -261,7 +262,7 @@ class TestAttachMailManually(TransactionCase):
         )
         return mock_conn
 
-    def _mock_fetch_msg(self, connection, msgid):
+    def _mock_fetch_msg(self, connection, message_uid):
         """Return a tuple like the real fetch_msg: (dict, bytes)"""
         mail_message = {
             "subject": "Test",
@@ -282,7 +283,9 @@ class TestAttachMailManually(TransactionCase):
             patch.object(
                 self.folder.__class__, "fetch_msg", side_effect=self._mock_fetch_msg
             ),
-            patch.object(self.folder.__class__, "get_msgids", return_value=[b"1"]),
+            patch.object(
+                self.folder.__class__, "get_message_uids", return_value=[b"1"]
+            ),
             patch.object(self.folder.__class__, "get_criteria", return_value="ALL"),
         ):
             wizard = self.Wizard.with_context(folder_id=self.folder.id).create({})
@@ -297,7 +300,7 @@ class TestAttachMailManually(TransactionCase):
         with patch.object(
             self.folder.__class__,
             "fetch_msg",
-            side_effect=lambda conn, msgid: (
+            side_effect=lambda conn, message_uid: (
                 {
                     "subject": "With Object",
                     "date": "2025-07-23",
@@ -315,7 +318,7 @@ class TestAttachMailManually(TransactionCase):
                             0,
                             0,
                             {
-                                "msgid": "1",
+                                "message_uid": "1",
                                 "subject": "No Object",
                                 "object_id": False,
                             },
@@ -324,7 +327,7 @@ class TestAttachMailManually(TransactionCase):
                             0,
                             0,
                             {
-                                "msgid": "2",
+                                "message_uid": "2",
                                 "subject": "With Object",
                                 "object_id": f"res.partner,{self.partner.id}",
                             },
@@ -342,7 +345,7 @@ class TestAttachMailManually(TransactionCase):
     def test_prepare_mail_returns_expected_dict(self):
         """Test _prepare_mail returns correct structure."""
         folder = self.folder
-        msgid = "123"
+        message_uid = "123"
         mail_message = {
             "subject": "Test",
             "date": "2025-07-23",
@@ -350,9 +353,9 @@ class TestAttachMailManually(TransactionCase):
             "body": "<p>Body</p>",
         }
 
-        result = self.Wizard._prepare_mail(folder, msgid, mail_message)
+        result = self.Wizard._prepare_mail(folder, message_uid, mail_message)
         expected = {
-            "msgid": "123",
+            "message_uid": "123",
             "subject": "Test",
             "date": "2025-07-23",
             "body": "<p>Body</p>",
@@ -366,7 +369,9 @@ class TestAttachMailManually(TransactionCase):
         with (
             patch.object(FetchmailServer, "connect", return_value=MagicMock()),
             patch.object(self.folder.__class__, "fetch_msg", return_value=({}, b"raw")),
-            patch.object(self.folder.__class__, "get_msgids", return_value=[b"1"]),
+            patch.object(
+                self.folder.__class__, "get_message_uids", return_value=[b"1"]
+            ),
             patch.object(self.folder.__class__, "get_criteria", return_value="ALL"),
         ):
             wizard = self.Wizard.with_context(folder_id=self.folder.id).create({})

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -1,5 +1,6 @@
 # Copyright - 2015-2018 Therp BV <https://acme.com>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# pylint: disable=method-required-super
 from unittest.mock import MagicMock, patch
 
 from odoo.tests.common import TransactionCase
@@ -39,16 +40,24 @@ class MockConnection:
     def select(self, path=None):
         return ("OK",)
 
-    def store(self, msgid, msg_item, value):
+    def create(self, path):
+        """Mock creating a folder."""
+        return ("OK",)
+
+    def store(self, message_uid, msg_item, value):
         """Mock store command."""
         return "OK"
 
-    def fetch(self, msgid, parts):
+    def copy(self, message_uid, folder_path):
+        """Mock copy command."""
+        return "OK"
+
+    def fetch(self, message_uid, parts):
         """Return RFC822 formatted message."""
         return ("OK", MSG_BODY)
 
     def search(self, charset, criteria):
-        """Return some msgid's."""
+        """Return some message uid's."""
         return ("OK", ["123 456"])
 
     def close(self):
@@ -153,12 +162,18 @@ class TestMatchAlgorithms(TransactionCase):
         folder = self.folder
         folder.match_algorithm = "email_exact"
         connection = MockConnection()
-        msgid = "<485a8041-d560-a981-5afc-d31c1f136748@acme.com>"
-        folder.apply_matching(connection, msgid)
+        message_uid = "<485a8041-d560-a981-5afc-d31c1f136748@acme.com>"
+        folder.apply_matching(connection, message_uid)
 
     def test_retrieve_imap_folder_domain(self):
         folder = self.folder
         folder.match_algorithm = "email_domain"
+        connection = MockConnection()
+        folder.retrieve_imap_folder(connection)
+
+    def test_archive_messages(self):
+        folder = self.folder
+        folder.archive_path = "archived_messages"
         connection = MockConnection()
         folder.retrieve_imap_folder(connection)
 

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -58,6 +58,11 @@ class MockConnection:
         """Mock an IMAP4.expunge action"""
         return ("OK", None)
 
+    def uid(self, command, *args):
+        """Return from the appropiate mocked method."""
+        method = getattr(self, command)
+        return method(*args)
+
 
 class TestMatchAlgorithms(TransactionCase):
     @classmethod

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -54,6 +54,10 @@ class MockConnection:
     def close(self):
         pass
 
+    def expunge(self):
+        """Mock an IMAP4.expunge action"""
+        return ("OK", None)
+
 
 class TestMatchAlgorithms(TransactionCase):
     @classmethod

--- a/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
+++ b/fetchmail_attach_from_folder/wizard/attach_mail_manually.py
@@ -20,9 +20,9 @@ class AttachMailManually(models.TransientModel):
     )
 
     @api.model
-    def _prepare_mail(self, folder, msgid, mail_message):
+    def _prepare_mail(self, folder, message_uid, mail_message):
         return {
-            "msgid": msgid,
+            "message_uid": message_uid,
             "subject": mail_message.get("subject", ""),
             "date": mail_message.get("date") or False,
             "body": mail_message.get("body", ""),
@@ -43,11 +43,11 @@ class AttachMailManually(models.TransientModel):
         connection = folder.server_id.connect()
         connection.select(folder.path)
         criteria = "FLAGGED" if folder.flag_nonmatching else folder.get_criteria()
-        msgids = folder.get_msgids(connection, criteria)
-        for msgid in msgids[0].split():
-            mail_message, message_org = folder.fetch_msg(connection, msgid)
+        message_uids = folder.get_message_uids(connection, criteria)
+        for message_uid in message_uids[0].split():
+            mail_message, message_org = folder.fetch_msg(connection, message_uid)
             defaults["mail_ids"].append(
-                (0, 0, self._prepare_mail(folder, msgid, mail_message))
+                (0, 0, self._prepare_mail(folder, message_uid, mail_message))
             )
         connection.close()
         return defaults
@@ -61,11 +61,11 @@ class AttachMailManually(models.TransientModel):
         for mail in self.mail_ids:
             if not mail.object_id:
                 continue
-            msgid = mail.msgid
-            mail_message, message_org = folder.fetch_msg(connection, msgid)
+            message_uid = mail.message_uid
+            mail_message, message_org = folder.fetch_msg(connection, message_uid)
             folder.attach_mail(mail.object_id, mail_message)
             folder.update_msg(
-                connection, msgid, matched=True, flagged=folder.flag_nonmatching
+                connection, message_uid, matched=True, flagged=folder.flag_nonmatching
             )
         connection.close()
         return {"type": "ir.actions.act_window_close"}
@@ -97,7 +97,7 @@ class AttachMailManuallyMail(models.TransientModel):
     _description = __doc__
 
     wizard_id = fields.Many2one("fetchmail.attach.mail.manually", readonly=True)
-    msgid = fields.Char("Message id", readonly=True)
+    message_uid = fields.Char("Message id", readonly=True)
     subject = fields.Char(readonly=True)
     date = fields.Datetime(readonly=True)
     email_from = fields.Char("From", readonly=True)


### PR DESCRIPTION
@NL66278 So on 16.0 test runs I saw:

```
2026-01-25 10:24:19,760 890 ERROR odoo odoo.addons.fetchmail_attach_from_folder.models.fetchmail_server_folder: Failed to fetch mail 123 from server Test Fetchmail Server 
Traceback (most recent call last):
  File "/__w/server-tools/server-tools/fetchmail_attach_from_folder/models/fetchmail_server_folder.py", line 188, in retrieve_imap_folder
    self.apply_matching(connection, message_uid)
  File "/__w/server-tools/server-tools/fetchmail_attach_from_folder/models/fetchmail_server_folder.py", line 252, in apply_matching
    self._archive_msg(connection, message_uid)
  File "/__w/server-tools/server-tools/fetchmail_attach_from_folder/models/fetchmail_server_folder.py", line 304, in _archive_msg
    connection.expunge()
AttributeError: 'MockConnection' object has no attribute 'expunge'
```

I fixed that, does it make sense on 18.0 too? It doesn't seem to block merges.