### PR TITLE
[19.0][IMP] base_view_inheritance_extension: wraptext

### DIFF
--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -135,7 +135,7 @@ Authors
 Contributors
 ------------
 
--  Holger Brunn <hbrunn@therp.nl>
+-  Holger Brunn <mail@hunki-enterprises.com>
 -  Ronald Portier <rportier@therp.nl>
 -  `Tecnativa <https://www.tecnativa.com>`__:
 
@@ -161,6 +161,14 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-hbrunn| image:: https://github.com/hbrunn.png?size=40px
+    :target: https://github.com/hbrunn
+    :alt: hbrunn
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-hbrunn| 
 
 This module is part of the `OCA/server-tools <https://github.com/OCA/server-tools/tree/19.0/base_view_inheritance_extension>`_ project on GitHub.
 

--- a/base_view_inheritance_extension/README.rst
+++ b/base_view_inheritance_extension/README.rst
@@ -76,10 +76,43 @@ conditional changes**
        $domain_to_add
    </attribute>
 
+**Wrap loose text in an element for further processing**
+
+.. code:: xml
+
+      <wraptext expr="//some/node" position="text" element="span" />
+      <wraptext expr="//some/node/other_node" position="tail" element="div" />
+
+which transforms
+
+.. code:: xml
+
+       <some>
+           <node>
+               plain text 1
+               <other_node />
+               plain text2
+           </node>
+       </some>
+
+to
+
+.. code:: xml
+
+       <some>
+           <node>
+               <span>plain text 1</span>
+               <other_node />
+               <div>plain text2</div>
+           </node>
+       </some>
+
+making those texts accessible for further operations
+
 Known issues / Roadmap
 ======================
 
-- Support an ``eval`` attribute for our new node types.
+-  Support an ``eval`` attribute for our new node types.
 
 Bug Tracker
 ===========
@@ -102,19 +135,19 @@ Authors
 Contributors
 ------------
 
-- Holger Brunn <hbrunn@therp.nl>
-- Ronald Portier <rportier@therp.nl>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Holger Brunn <hbrunn@therp.nl>
+-  Ronald Portier <rportier@therp.nl>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Sergio Teruel
-  - Carlos Dauden
+   -  Sergio Teruel
+   -  Carlos Dauden
 
-- `Trobz <https://www.trobz.com>`__:
+-  `Trobz <https://www.trobz.com>`__:
 
-  - Nhan Tran <nhant@trobz.com>
+   -  Nhan Tran <nhant@trobz.com>
 
-- Iván Todorovich <ivan.todorovich@camptocamp.com>
-- Frederic Grall <fgr@apik.cloud>
+-  Iván Todorovich <ivan.todorovich@camptocamp.com>
+-  Frederic Grall <fgr@apik.cloud>
 
 Maintainers
 -----------

--- a/base_view_inheritance_extension/__manifest__.py
+++ b/base_view_inheritance_extension/__manifest__.py
@@ -12,4 +12,5 @@
     "website": "https://github.com/OCA/server-tools",
     "depends": ["base"],
     "demo": ["demo/ir_ui_view.xml"],
+    "maintainers": ["hbrunn"],
 }

--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -9,6 +9,7 @@ import re
 from lxml import etree
 
 from odoo import api, models
+from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
 
@@ -82,6 +83,85 @@ class IrUiView(models.Model):
         if hasattr(self, f"inheritance_handler_{node.tag}"):
             handler = getattr(self, f"inheritance_handler_{node.tag}")
         return handler
+
+    @api.model
+    def inheritance_handler_wraptext(self, source, specs):
+        """Implement wraptext inheritance spec
+
+        .. code-block:: xml
+
+            <wraptext expr="//some/node" position="text" element="span" />
+
+        Which transforms xml like
+
+        .. code-block:: xml
+
+            <some>
+                <node>
+                    plain text
+                    <other_node />
+                </node>
+            </some>
+
+        to
+
+        .. code-block:: xml
+
+            <some>
+                <node>
+                    <span>plain text</span>
+                    <other_node />
+                </node>
+            </some>
+
+        """
+        if len(specs):
+            raise ValidationError(self.env._("wraptext elements cannot have children"))
+
+        expression = specs.attrib.get("expr")
+        found = source.xpath(specs.attrib["expr"])
+        if not found:
+            raise ValidationError(
+                self.env._("wraptext: nothing found for expression %r", expression)
+            )
+
+        found = found[0]
+        text_position = specs.attrib.get("position", "text")
+        if text_position not in ("text", "tail"):
+            raise ValidationError(
+                self.env._("wraptext: the only valid positions are 'text' or 'tail'")
+            )
+
+        wrapped = etree.Element(specs.attrib.get("element", "t"))
+        wrapped.text = getattr(found, text_position)
+        setattr(found, text_position, None)
+
+        if self.env.context.get("edit_translations") and not wrapped.text:
+            # translation might have wrapped the text already in a <span> element
+            # we wrap this element so that subsequent view manipulations find
+            # the wrapped element at the same position in the tree it would be at
+            # without translation
+            next_sibling = found.getnext()
+
+            if (
+                text_position == "text"
+                and len(found)
+                and found[0].attrib.get("data-oe-translation-state")
+            ):
+                wrapped.append(found[0])
+            elif (
+                text_position == "tail"
+                and next_sibling is not None
+                and next_sibling.attrib.get("data-oe-translation-state")
+            ):
+                wrapped.append(next_sibling)
+
+        if text_position == "text":
+            found.insert(0, wrapped)
+        elif text_position == "tail":
+            found.addnext(wrapped)
+
+        return source
 
     @api.model
     def _get_inheritance_handler_attributes(self, node):

--- a/base_view_inheritance_extension/readme/CONTRIBUTORS.md
+++ b/base_view_inheritance_extension/readme/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-- Holger Brunn \<<hbrunn@therp.nl>\>
+- Holger Brunn \<<mail@hunki-enterprises.com>\>
 - Ronald Portier \<<rportier@therp.nl>\>
 - [Tecnativa](https://www.tecnativa.com):
   - Sergio Teruel

--- a/base_view_inheritance_extension/readme/USAGE.md
+++ b/base_view_inheritance_extension/readme/USAGE.md
@@ -30,3 +30,36 @@ conditional changes**
     $domain_to_add
 </attribute>
 ```
+
+**Wrap loose text in an element for further processing**
+
+``` xml
+   <wraptext expr="//some/node" position="text" element="span" />
+   <wraptext expr="//some/node/other_node" position="tail" element="div" />
+```
+
+which transforms
+
+``` xml
+    <some>
+        <node>
+            plain text 1
+            <other_node />
+            plain text2
+        </node>
+    </some>
+```
+
+to
+
+``` xml
+    <some>
+        <node>
+            <span>plain text 1</span>
+            <other_node />
+            <div>plain text2</div>
+        </node>
+    </some>
+```
+
+making those texts accessible for further operations

--- a/base_view_inheritance_extension/static/description/index.html
+++ b/base_view_inheritance_extension/static/description/index.html
@@ -471,7 +471,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
 <ul class="simple">
-<li>Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</li>
+<li>Holger Brunn &lt;<a class="reference external" href="mailto:mail&#64;hunki-enterprises.com">mail&#64;hunki-enterprises.com</a>&gt;</li>
 <li>Ronald Portier &lt;<a class="reference external" href="mailto:rportier&#64;therp.nl">rportier&#64;therp.nl</a>&gt;</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Sergio Teruel</li>
@@ -495,6 +495,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/hbrunn"><img alt="hbrunn" src="https://github.com/hbrunn.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/server-tools/tree/19.0/base_view_inheritance_extension">OCA/server-tools</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/base_view_inheritance_extension/static/description/index.html
+++ b/base_view_inheritance_extension/static/description/index.html
@@ -419,6 +419,32 @@ conditional changes</strong></p>
     </span>$domain_to_add<span class="w">
 </span><span class="nt">&lt;/attribute&gt;</span>
 </pre>
+<p><strong>Wrap loose text in an element for further processing</strong></p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;wraptext</span><span class="w"> </span><span class="na">expr=</span><span class="s">&quot;//some/node&quot;</span><span class="w"> </span><span class="na">position=</span><span class="s">&quot;text&quot;</span><span class="w"> </span><span class="na">element=</span><span class="s">&quot;span&quot;</span><span class="w"> </span><span class="nt">/&gt;</span><span class="w">
+</span><span class="nt">&lt;wraptext</span><span class="w"> </span><span class="na">expr=</span><span class="s">&quot;//some/node/other_node&quot;</span><span class="w"> </span><span class="na">position=</span><span class="s">&quot;tail&quot;</span><span class="w"> </span><span class="na">element=</span><span class="s">&quot;div&quot;</span><span class="w"> </span><span class="nt">/&gt;</span>
+</pre>
+<p>which transforms</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;some&gt;</span><span class="w">
+    </span><span class="nt">&lt;node&gt;</span><span class="w">
+        </span>plain<span class="w"> </span>text<span class="w"> </span>1<span class="w">
+        </span><span class="nt">&lt;other_node</span><span class="w"> </span><span class="nt">/&gt;</span><span class="w">
+        </span>plain<span class="w"> </span>text2<span class="w">
+    </span><span class="nt">&lt;/node&gt;</span><span class="w">
+</span><span class="nt">&lt;/some&gt;</span>
+</pre>
+<p>to</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;some&gt;</span><span class="w">
+    </span><span class="nt">&lt;node&gt;</span><span class="w">
+        </span><span class="nt">&lt;span&gt;</span>plain<span class="w"> </span>text<span class="w"> </span>1<span class="nt">&lt;/span&gt;</span><span class="w">
+        </span><span class="nt">&lt;other_node</span><span class="w"> </span><span class="nt">/&gt;</span><span class="w">
+        </span><span class="nt">&lt;div&gt;</span>plain<span class="w"> </span>text2<span class="nt">&lt;/div&gt;</span><span class="w">
+    </span><span class="nt">&lt;/node&gt;</span><span class="w">
+</span><span class="nt">&lt;/some&gt;</span>
+</pre>
+<p>making those texts accessible for further operations</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h2>

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -5,6 +5,7 @@
 
 from lxml import etree
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -222,3 +223,47 @@ class TestBaseViewInheritanceExtension(TransactionCase):
         )
         with self.assertRaisesRegex(TypeError, "Attribute `domain` is not a dict"):
             self.env["ir.ui.view"].apply_inheritance_specs(source, specs)
+
+    def test_wraptext(self):
+        """Test textwrap transformations"""
+        base_view = self.env["ir.ui.view"].create(
+            {
+                "type": "qweb",
+                "arch": "<some>"
+                "<node>plain text 1<other_node />plain text2</node></some>",
+            }
+        )
+        inherited_view = self.env["ir.ui.view"].create(
+            {
+                "type": "qweb",
+                "inherit_id": base_view.id,
+                "arch": "<data>"
+                '<wraptext expr="//some/node" position="text" element="span" />'
+                '<wraptext expr="//some/node/other_node" position="tail" '
+                'element="div" />'
+                "</data>",
+            }
+        )
+        self.assertEqual(
+            base_view.with_context(load_all_views=True).get_combined_arch(),
+            "<some><node><span>plain text 1</span><other_node/>"
+            "<div>plain text2</div></node></some>",
+        )
+        translatable_arch = base_view.with_context(
+            load_all_views=True, edit_translations=True
+        )._get_combined_arch()
+        self.assertTrue(
+            translatable_arch.xpath("//some/node/span/span[@data-oe-translation-state]")
+        )
+        self.assertTrue(
+            translatable_arch.xpath("//some/node/div/span[@data-oe-translation-state]")
+        )
+
+        with self.assertRaisesRegex(ValidationError, "children"):
+            inherited_view.write({"arch": "<wraptext><node /></wraptext>"})
+        with self.assertRaisesRegex(ValidationError, "found"):
+            inherited_view.write({"arch": '<wraptext expr="//not/existing" />'})
+        with self.assertRaisesRegex(ValidationError, "positions"):
+            inherited_view.write(
+                {"arch": '<wraptext expr="//some/node" position="other" />'}
+            )


### PR DESCRIPTION
this finally lets us deal with text in upstream views that's not accessible to standard inheritance. When you have xml like

```xml
       <some>
           <node>
               plain text 1
               <other_node />
               plain text2
           </node>
       </some>
```

you're pretty much out of luck when you want to change either of the texts, you have to replace the whole node.

This PR allows to say

```xml
      <wraptext expr="//some/node" position="text" element="span" />
      <wraptext expr="//some/node/other_node" position="tail" element="div" />
```

in inherited views, which transforms the above to

```xml
       <some>
           <node>
               <span>plain text 1</span>
               <other_node />
               <div>plain text2</div>
           </node>
       </some>
```

that you can further modify with the inheritance machinery