### PR TITLE
[18.0][REF] auditlog et al: adapt to new Odoo test patch checker

### DIFF
--- a/attachment_queue/tests/test_attachment_queue.py
+++ b/attachment_queue/tests/test_attachment_queue.py
@@ -32,24 +32,19 @@ class TestAttachmentBaseQueue(BaseCommon):
             ).create(vals)
         return self.env["attachment.queue"].create(vals)
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
-        from .test_models import AttachmentQueue
-
-        cls.loader.update_registry((AttachmentQueue,))
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        cls.loader.restore_registry()
-        return super().tearDownClass()
-
     def setUp(self):
         super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
+        from .test_models import AttachmentQueue
+
+        self.loader.update_registry((AttachmentQueue,))
         self.aq_model = self.env["attachment.queue"]
+
+    def tearDown(self):
+        super().tearDown()
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_job_created(self):
         with trap_jobs() as trap:

--- a/auditlog/models/rule.py
+++ b/auditlog/models/rule.py
@@ -216,7 +216,7 @@ class AuditlogRule(models.Model):
 
     def _patch_method(self, model, method_name, check_attr):
         result = new_method = False
-        model_class = type(model)
+        model_class = model.env.registry[model._name]
         if method_name == "create":
             new_method = self._make_create()
         elif method_name == "read":
@@ -273,15 +273,13 @@ class AuditlogRule(models.Model):
         """Restore original ORM methods of models defined in rules."""
         updated = False
         for rule in self:
-            model_model = self.env[rule.model_id.model or rule.model_model]
+            model_class = self.env.registry[rule.model_id.model or rule.model_model]
             for method in ["create", "read", "write", "unlink", "export_data"]:
                 if getattr(rule, f"log_{method}") and hasattr(
-                    getattr(model_model, method), "origin"
+                    getattr(model_class, method), "origin"
                 ):
-                    setattr(
-                        type(model_model), method, getattr(model_model, method).origin
-                    )
-                    delattr(type(model_model), f"auditlog_ruled_{method}")
+                    delattr(model_class, method)
+                    delattr(model_class, f"auditlog_ruled_{method}")
                     updated = True
         if updated:
             self._update_registry()

--- a/auditlog/tests/common.py
+++ b/auditlog/tests/common.py
@@ -1,33 +1,27 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SETATTR_SOURCES
+
+from odoo.addons.base.tests.common import BaseCommon
+
+# Register rule.py as a known path in odoo.tests.common for patching methods
+SETATTR_SOURCES["_patch_method"] = tuple(
+    list(SETATTR_SOURCES.get("_patch_method", [])) + ["/auditlog/models/rule.py"],
+)
 
 
-class AuditLogRuleCommon(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.models = set()
-
+class AuditLogRuleCommon(BaseCommon):
     @classmethod
     def create_rule(cls, vals):
-        rule = cls.env["auditlog.rule"].with_context(tracking_disable=True).create(vals)
-        # Keep track of patched models
-        cls.models |= set(rule.model_id.mapped("model"))
-        return rule
+        # Deprecated, just call `create` in your test setup.
+        return cls.env["auditlog.rule"].create(vals)
 
-    @classmethod
-    def tearDownClass(cls):
-        for rule in cls.env["auditlog.rule"].search([]):
+    def tearDown(self):
+        # Unsubscribe all rules in tearDown to prevent Odoo's patch checker in
+        # tests/common.py from ringing the alarm.
+        for rule in self.env["auditlog.rule"].search([]):
             try:
                 rule.unsubscribe()
             except KeyError:  # pragma: no cover
-                continue  # Model not loaded yet
-
-        # Assert no patched methods remain
-        for model in cls.models:
-            for method in ["create", "read", "write", "unlink"]:
-                assert not hasattr(
-                    getattr(cls.env[model], method), "origin"
-                ), f"{model} {method} still patched"
-        super().tearDownClass()
+                continue  # Preexisting rule for model not loaded yet
+        return super().tearDown()

--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -3,6 +3,8 @@
 # © 2021 Stefan Rijnhart <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.tools import mute_logger
+
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.addons.base.models.res_users import name_boolean_group
 
@@ -388,13 +390,15 @@ class TestFieldRemoval(AuditLogRuleCommon):
             }
         )
 
-        cls.auditlog_rule.subscribe()
+    def setUp(self):
+        super().setUp()
+        self.auditlog_rule.subscribe()
         # Trigger log creation
-        rec = cls.env["x_test.model"].create({"x_test_field": "test value"})
+        rec = self.env["x_test.model"].create({"x_test_field": "test value"})
         rec.write({"x_test_field": "test value 2"})
 
-        cls.logs = cls.env["auditlog.log"].search(
-            [("res_id", "=", rec.id), ("model_id", "=", cls.test_model.id)]
+        self.logs = self.env["auditlog.log"].search(
+            [("res_id", "=", rec.id), ("model_id", "=", self.test_model.id)]
         )
 
     def assert_values(self):
@@ -418,13 +422,20 @@ class TestFieldRemoval(AuditLogRuleCommon):
         self.assert_values()
 
         # Remove the field
-        self.test_field.with_context(**{MODULE_UNINSTALL_FLAG: True}).unlink()
+        with mute_logger("odoo.api"):  # Mute 'Too many iterations for flushing fields'
+            self.test_field.with_context(**{MODULE_UNINSTALL_FLAG: True}).unlink()
         self.assert_values()
         # The field should not be linked
         self.assertFalse(self.logs.mapped("line_ids.field_id"))
 
         # Remove the model
-        self.test_model.with_context(**{MODULE_UNINSTALL_FLAG: True}).unlink()
+        with mute_logger(
+            # 'Too many iterations for flushing fields'
+            "odoo.api",
+            # 'The following fields were force-deleted .* x_name',
+            "odoo.addons.base.models.ir_model",
+        ):
+            self.test_model.with_context(**{MODULE_UNINSTALL_FLAG: True}).unlink()
         self.assert_values()
 
         # The model should not be linked
@@ -512,14 +523,16 @@ class AuditLogRuleTestForUserFields(AuditLogRuleCommon):
         # Updating users_to_exclude_ids
         cls.auditlog_rule.users_to_exclude_ids = [[4, cls.users_to_exclude_ids]]
 
-        # Subscribe auditlog.rule
-        cls.auditlog_rule.subscribe()
-
         cls.auditlog_log = cls.env["auditlog.log"]
 
-        # Creating new res.partner
-        cls.testpartner1 = (
-            cls.env["res.partner"]
+    def setUp(self):
+        super().setUp()
+        # Subscribe auditlog.rule
+        self.auditlog_rule.subscribe()
+
+        # Creating new partners to trigger log creation (or not)
+        self.testpartner1 = (
+            self.env["res.partner"]
             .with_context(tracking_disable=True)
             .create(
                 {
@@ -530,10 +543,10 @@ class AuditLogRuleTestForUserFields(AuditLogRuleCommon):
         )
 
         # Creating new res.partner from excluded user
-        cls.testpartner2 = (
-            cls.env["res.partner"]
+        self.testpartner2 = (
+            self.env["res.partner"]
             .with_context(tracking_disable=True)
-            .with_user(cls.user.id)
+            .with_user(self.user.id)
             .create(
                 {
                     "name": "testpartner2",
@@ -669,8 +682,11 @@ class AuditLogRuleTestForUserModel(AuditLogRuleCommon):
         cls.group = cls.env.ref("auditlog.group_auditlog_manager")
 
         cls.auditlog_log = cls.env["auditlog.log"]
+
+    def setUp(self):
+        super().setUp()
         # Subscribe auditlog.rule
-        cls.auditlog_rule.subscribe()
+        self.auditlog_rule.subscribe()
 
     def test_01_AuditlogFull_field_group_write_log(self):
         """Change group and check successfully created log"""
@@ -739,9 +755,6 @@ class AuditlogFast_excluded_fields(AuditLogRuleCommon):
         # Updating phone in fields_to_exclude_ids
         cls.auditlog_rule.fields_to_exclude_ids = [[4, cls.fields_to_exclude_ids]]
 
-        # Subscribe auditlog.rule
-        cls.auditlog_rule.subscribe()
-
         cls.auditlog_log = cls.env["auditlog.log"]
 
         # Creating new res.partner
@@ -755,6 +768,11 @@ class AuditlogFast_excluded_fields(AuditLogRuleCommon):
                 }
             )
         )
+
+    def setUp(self):
+        super().setUp()
+        # Subscribe auditlog.rule
+        self.auditlog_rule.subscribe()
 
     def test_01_AuditlogFast_field_exclude_write_log(self):
         # Checking fields_to_exclude_ids

--- a/auditlog/tests/test_http.py
+++ b/auditlog/tests/test_http.py
@@ -1,9 +1,11 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.tests.common import HttpCase, tagged
 
+from .common import AuditLogRuleCommon
+
 
 @tagged("post_install", "-at_install")
-class TestAuditlogHttp(HttpCase):
+class TestAuditlogHttp(HttpCase, AuditLogRuleCommon):
     def test_compute_display_name(self):
         self.authenticate("admin", "admin")
         rule = self.env["auditlog.rule"].create(

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -9,26 +9,26 @@ from odoo.tests import TransactionCase
 
 
 class TestBaseException(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        # FakeModelLoader must be used in setUp, not setUpClass
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .purchase_test import ExceptionRule, LineTest, PurchaseTest, WizardTest
 
-        cls.loader.update_registry((ExceptionRule, LineTest, PurchaseTest, WizardTest))
-        cls.partner = cls.env["res.partner"].create({"name": "Foo"})
-        cls.po = cls.env["base.exception.test.purchase"].create(
+        self.loader.update_registry((ExceptionRule, LineTest, PurchaseTest, WizardTest))
+        self.partner = self.env["res.partner"].create({"name": "Foo"})
+        self.po = self.env["base.exception.test.purchase"].create(
             {
                 "name": "Test base exception to basic purchase",
-                "partner_id": cls.partner.id,
+                "partner_id": self.partner.id,
                 "line_ids": [
                     (0, 0, {"name": "line test", "amount": 120.0, "qty": 1.5})
                 ],
             }
         )
-        cls.exception_rule = cls.env["exception.rule"].create(
+        self.exception_rule = self.env["exception.rule"].create(
             {
                 "name": "No ZIP code on destination",
                 "sequence": 10,
@@ -37,20 +37,19 @@ class TestBaseException(TransactionCase):
                 "exception_type": "by_py_code",
             }
         )
-        exception_rule_confirm_obj = cls.env["exception.rule.confirm.test.purchase"]
-        cls.exception_rule_confirm = exception_rule_confirm_obj.with_context(
-            active_model="base.exception.test.purchase", active_ids=cls.po.ids
+        exception_rule_confirm_obj = self.env["exception.rule.confirm.test.purchase"]
+        self.exception_rule_confirm = exception_rule_confirm_obj.with_context(
+            active_model="base.exception.test.purchase", active_ids=self.po.ids
         ).create(
             {
-                "related_model_id": cls.po.id,
+                "related_model_id": self.po.id,
                 "ignore": False,
             }
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_valid(self):
         self.partner.write({"zip": "00000"})

--- a/base_name_search_improved/tests/test_name_search.py
+++ b/base_name_search_improved/tests/test_name_search.py
@@ -1,7 +1,13 @@
 # © 2016 Daniel Reis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase, tagged
+from odoo.tests.common import SETATTR_SOURCES, TransactionCase, tagged
+
+# Register our patching method in Odoo's test checker
+SETATTR_SOURCES["_register_hook"] = tuple(
+    list(SETATTR_SOURCES.get("_register_hook", []))
+    + ["/base_name_search_improved/models/ir_model.py"],
+)
 
 
 @tagged("post_install", "-at_install")
@@ -15,14 +21,6 @@ class NameSearchCase(TransactionCase):
         cls.address_field = cls.env.ref("base.field_res_partner__contact_address")
         cls.zip_field = cls.env.ref("base.field_res_partner__zip")
 
-        cls.model_partner = cls.env.ref("base.model_res_partner")
-        cls.model_partner.name_search_ids = cls.phone_field
-        cls.model_partner.add_smart_search = True
-        cls.model_partner.use_smart_name_search = True
-
-        # this use does not make muche sense but with base module we dont have
-        # much models to use for tests
-        cls.model_partner.name_search_domain = "[('parent_id', '=', False)]"
         cls.Partner = cls.env["res.partner"]
         cls.partner1 = cls.Partner.create(
             {"name": "Luigi Verconti", "vat": "1111", "phone": "+351 555 777 333"}
@@ -38,6 +36,29 @@ class NameSearchCase(TransactionCase):
                 "barcode": "1111",
             }
         )
+
+    def setUp(self):
+        super().setUp()
+        self.patched_models = [
+            model._name
+            for model in self.env.registry.values()
+            if "name_search" in vars(model)
+        ]
+        self.model_partner = self.env.ref("base.model_res_partner")
+        self.model_partner.name_search_ids = self.phone_field
+        self.model_partner.add_smart_search = True
+        self.model_partner.use_smart_name_search = True
+
+        # this use does not make muche sense but with base module we dont have
+        # much models to use for tests
+        self.model_partner.name_search_domain = "[('parent_id', '=', False)]"
+
+    def tearDown(self):
+        for model in self.env.registry.values():
+            if "name_search" in vars(model) and model._name not in self.patched_models:
+                delattr(model, "name_search")
+
+        super().tearDown()
 
     def test_RelevanceOrderedResults(self):
         """Return results ordered by relevance"""

--- a/base_partition/tests/test_partition.py
+++ b/base_partition/tests/test_partition.py
@@ -7,6 +7,7 @@ import math
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 
 class TestPartition(TransactionCase):
@@ -119,9 +120,11 @@ class TestPartition(TransactionCase):
         with self.assertRaises(UserError):
             list(records.batch())
 
-        records.__class__._default_batch_size = batch_size
+        with mute_logger("odoo.tests.common"):
+            records.__class__._default_batch_size = batch_size
         batches_from_default = list(records.batch())
         self.assertEqual(batches_from_default, batches)
+        delattr(records.__class__, "_default_batch_size")
 
     def test_read_per_record(self):
         categories = self.c1 | self.c2 | self.c3

--- a/base_sequence_option/tests/common.py
+++ b/base_sequence_option/tests/common.py
@@ -7,27 +7,26 @@ from odoo.tests import common
 
 
 class CommonBaseSequenceOption(common.TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .base_sequence_tester import BaseSequenceTester, IrSequenceOption
 
-        cls.loader.update_registry((BaseSequenceTester, IrSequenceOption))
+        self.loader.update_registry((BaseSequenceTester, IrSequenceOption))
 
-        cls.test_model = cls.env[BaseSequenceTester._name]
+        self.test_model = self.env[BaseSequenceTester._name]
 
-        cls.tester_model = cls.env["ir.model"].search(
+        self.tester_model = self.env["ir.model"].search(
             [("model", "=", "base.sequence.tester")]
         )
 
         # Access record:
-        cls.env["ir.model.access"].create(
+        self.env["ir.model.access"].create(
             {
                 "name": "access.tester",
-                "model_id": cls.tester_model.id,
+                "model_id": self.tester_model.id,
                 "perm_read": 1,
                 "perm_write": 1,
                 "perm_create": 1,
@@ -36,8 +35,8 @@ class CommonBaseSequenceOption(common.TransactionCase):
         )
 
         # Create sequence for type A and type B
-        cls.ir_sequence_obj = cls.env["ir.sequence"]
-        cls.ir_sequence_obj.create(
+        self.ir_sequence_obj = self.env["ir.sequence"]
+        self.ir_sequence_obj.create(
             {
                 "name": "Default Sequence",
                 "code": "base.sequence.tester",
@@ -45,14 +44,14 @@ class CommonBaseSequenceOption(common.TransactionCase):
                 "prefix": "DEF/",
             }
         )
-        seq_a = cls.ir_sequence_obj.create(
+        seq_a = self.ir_sequence_obj.create(
             {
                 "name": "Type A",
                 "padding": 5,
                 "prefix": "TYPE-A/",
             }
         )
-        seq_b = cls.ir_sequence_obj.create(
+        seq_b = self.ir_sequence_obj.create(
             {
                 "name": "Type B",
                 "padding": 5,
@@ -61,33 +60,32 @@ class CommonBaseSequenceOption(common.TransactionCase):
         )
 
         # Create sequence options for model base.sequence.tester:
-        cls.base_sequence_obj = cls.env["ir.sequence.option"]
-        cls.base_seq = cls.base_sequence_obj.create(
+        self.base_sequence_obj = self.env["ir.sequence.option"]
+        self.base_seq = self.base_sequence_obj.create(
             {
                 "name": "Test Model",
                 "model": "base.sequence.tester",
                 "use_sequence_option": True,
             }
         )
-        cls.sequence_obj = cls.env["ir.sequence.option.line"]
-        cls.sequence_obj.create(
+        self.sequence_obj = self.env["ir.sequence.option.line"]
+        self.sequence_obj.create(
             {
-                "base_id": cls.base_seq.id,
+                "base_id": self.base_seq.id,
                 "name": "Option 1",
                 "filter_domain": [("test_type", "=", "a")],
                 "sequence_id": seq_a.id,
             }
         )
-        cls.sequence_obj.create(
+        self.sequence_obj.create(
             {
-                "base_id": cls.base_seq.id,
+                "base_id": self.base_seq.id,
                 "name": "Option 1",
                 "filter_domain": [("test_type", "=", "b")],
                 "sequence_id": seq_b.id,
             }
         )
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        return super().tearDownClass()
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()

--- a/base_time_window/tests/test_time_window_mixin.py
+++ b/base_time_window/tests/test_time_window_mixin.py
@@ -16,15 +16,16 @@ class TestTimeWindowMixin(TransactionCase):
         cls.weekday1 = cls.env["time.weekday"].search([("name", "=", "1")])
         cls.weekday2 = cls.env["time.weekday"].search([("name", "=", "2")])
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .test_models import TestTimeWindowModel
 
-        cls.loader.update_registry((TestTimeWindowModel,))
+        self.loader.update_registry((TestTimeWindowModel,))
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
+    def tearDown(self):
+        self.loader.restore_registry()
         super().tearDownClass()
 
     def test_time_window_no_overlap(self):

--- a/jsonifier/tests/test_get_parser.py
+++ b/jsonifier/tests/test_get_parser.py
@@ -7,6 +7,7 @@
 from odoo import tools
 from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 from ..models.utils import convert_simple_to_full_parser
 
@@ -291,7 +292,8 @@ class TestParser(TransactionCase):
         self.assertIn("Expected singleton", str(err.exception))
 
     def test_json_export_callable_parser(self):
-        self.partner.__class__.jsonify_custom = jsonify_custom
+        with mute_logger("odoo.tests.common"):  # Mute patch detector
+            self.partner.__class__.jsonify_custom = jsonify_custom
         parser = [
             # callable subparser
             ("name", lambda rec, fname: rec[fname] + " rocks!"),
@@ -368,7 +370,8 @@ class TestParser(TransactionCase):
         self.assertEqual(json, expected_json)
 
     def test_simple_export_with_function(self):
-        self.category.__class__.jsonify_custom = jsonify_custom
+        with mute_logger("odoo.tests.common"):  # Mute patch detector
+            self.category.__class__.jsonify_custom = jsonify_custom
         export = self.env["ir.exports"].create(
             {
                 "export_fields": [
@@ -379,6 +382,7 @@ class TestParser(TransactionCase):
 
         json = self.category.jsonify(export.get_json_parser())[0]
         self.assertEqual(json, {"name": "yeah!"})
+        del self.category.__class__.jsonify_custom
 
     def test_export_relational_display_names(self):
         """If we export a relational, we get its display_name in the json."""

--- a/module_auto_update/tests/test_module.py
+++ b/module_auto_update/tests/test_module.py
@@ -115,30 +115,25 @@ class TestModuleAfterInstall(TransactionCase):
         self.assertTrue(self.base_module in changed_modules)
 
         def upgrade_module_mock(self_model):
-            upgrade_module_mock.call_count += 1
             # since we are upgrading base, all installed module
             # must have been marked to upgrade at this stage
             self.assertEqual(self.base_module.state, "to upgrade")
             self.assertEqual(self.own_module.state, "to upgrade")
             installed_modules.write({"state": "installed"})
 
-        upgrade_module_mock.call_count = 0
-
         # upgrade_changed_checksum commits, so mock that
-        with mock.patch.object(self.env.cr, "commit"):
-            # we simulate an install by setting module states
-            origin = Bmu.upgrade_module
-            Bmu.upgrade_module = upgrade_module_mock
-            try:
+        with mock.patch.object(
+            Bmu, "upgrade_module", autospec=True, side_effect=upgrade_module_mock
+        ) as mocked:
+            with mock.patch.object(self.env.cr, "commit"):
+                # we simulate an install by setting module states
                 Imm.upgrade_changed_checksum()
-                self.assertEqual(upgrade_module_mock.call_count, 1)
+                self.assertEqual(mocked.call_count, 1)
                 self.assertEqual(self.base_module.state, "installed")
                 self.assertEqual(self.own_module.state, "installed")
                 saved_checksums = Imm._get_saved_checksums()
                 self.assertTrue(saved_checksums["base"])
                 self.assertTrue(saved_checksums[MODULE_NAME])
-            finally:
-                Bmu.upgrade_module = origin
 
     def test_incomplete_upgrade(self):
         Imm = self.env["ir.module.module"]
@@ -152,7 +147,6 @@ class TestModuleAfterInstall(TransactionCase):
         Imm._save_checksums(saved_checksums)
 
         def upgrade_module_mock(self_model):
-            upgrade_module_mock.call_count += 1
             # since we are upgrading base, all installed module
             # must have been marked to upgrade at this stage
             self.assertEqual(self.base_module.state, "to upgrade")
@@ -161,19 +155,15 @@ class TestModuleAfterInstall(TransactionCase):
             # simulate partial upgrade
             self.own_module.write({"state": "to upgrade"})
 
-        upgrade_module_mock.call_count = 0
-
         # upgrade_changed_checksum commits, so mock that
-        with mock.patch.object(self.env.cr, "commit"):
-            # we simulate an install by setting module states
-            origin = Bmu.upgrade_module
-            Bmu.upgrade_module = upgrade_module_mock
-            try:
+        with mock.patch.object(
+            Bmu, "upgrade_module", autospec=True, side_effect=upgrade_module_mock
+        ) as mocked:
+            with mock.patch.object(self.env.cr, "commit"):
+                # we simulate an install by setting module states
                 with self.assertRaises(IncompleteUpgradeError):
                     Imm.upgrade_changed_checksum()
-                self.assertEqual(upgrade_module_mock.call_count, 1)
-            finally:
-                Bmu.upgrade_module = origin
+                self.assertEqual(mocked.call_count, 1)
 
     def test_incomplete_upgrade_no_checkusm(self):
         Imm = self.env["ir.module.module"]
@@ -188,26 +178,21 @@ class TestModuleAfterInstall(TransactionCase):
         self.base_module.write({"state": "to upgrade"})
 
         def upgrade_module_mock(self_model):
-            upgrade_module_mock.call_count += 1
             # since we are upgrading base, all installed module
             # must have been marked to upgrade at this stage
             self.assertEqual(self.base_module.state, "to upgrade")
             self.assertEqual(self.own_module.state, "installed")
             installed_modules.write({"state": "installed"})
 
-        upgrade_module_mock.call_count = 0
-
         # upgrade_changed_checksum commits, so mock that
-        with mock.patch.object(self.env.cr, "commit"):
-            # we simulate an install by setting module states
-            origin = Bmu.upgrade_module
-            Bmu.upgrade_module = upgrade_module_mock
-            # got just other modules to_upgrade and no checksum ones
-            try:
+        with mock.patch.object(
+            Bmu, "upgrade_module", autospec=True, side_effect=upgrade_module_mock
+        ) as mocked:
+            with mock.patch.object(self.env.cr, "commit"):
+                # we simulate an install by setting module states
+                # got just other modules to_upgrade and no checksum ones
                 Imm.upgrade_changed_checksum()
-                self.assertEqual(upgrade_module_mock.call_count, 1)
-            finally:
-                Bmu.upgrade_module = origin
+                self.assertEqual(mocked.call_count, 1)
 
     def test_nothing_to_upgrade(self):
         Imm = self.env["ir.module.module"]
@@ -216,17 +201,13 @@ class TestModuleAfterInstall(TransactionCase):
         Imm._save_installed_checksums()
 
         def upgrade_module_mock(self_model):
-            upgrade_module_mock.call_count += 1
-
-        upgrade_module_mock.call_count = 0
+            pass
 
         # upgrade_changed_checksum commits, so mock that
-        with mock.patch.object(self.env.cr, "commit"):
-            # we simulate an install by setting module states
-            origin = Bmu.upgrade_module
-            Bmu.upgrade_module = upgrade_module_mock
-            try:
+        with mock.patch.object(
+            Bmu, "upgrade_module", autospec=True, side_effect=upgrade_module_mock
+        ) as mocked:
+            with mock.patch.object(self.env.cr, "commit"):
+                # we simulate an install by setting module states
                 Imm.upgrade_changed_checksum()
-                self.assertEqual(upgrade_module_mock.call_count, 0)
-            finally:
-                Bmu.upgrade_module = origin
+                self.assertEqual(mocked.call_count, 0)

--- a/rpc_helper/tests/test_xmlrpc.py
+++ b/rpc_helper/tests/test_xmlrpc.py
@@ -18,7 +18,8 @@ class TestXMLRPC(common.HttpCase):
         cls.admin_uid = cls.env.ref("base.user_admin").id
 
     def _set_disable(self, val):
-        type(self.env["res.partner"])._disable_rpc = val
+        with mute_logger("odoo.test.common"):  # Mute test patch logging
+            type(self.env["res.partner"])._disable_rpc = val
 
     def _set_disable_on_model(self, val):
         self.env["ir.model"]._get("res.partner").rpc_config_edit = json.dumps(

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 from odoo.tests import common, tagged
+from odoo.tools import mute_logger
 
 from .. import compare, upgrade_log
 from ..odoo_patch.odoo_patch import OdooPatch
@@ -62,7 +63,8 @@ class TestUpgradeAnalysis(common.TransactionCase):
                 ]
             )
         )
-        with OdooPatch():
+        # Mute Odoo's noisy model patch snitcher
+        with mute_logger("odoo.tests.common"), OdooPatch():
             self.env["ir.model.constraint"]._reflect_model(self.IrModuleModule)
         self.assertTrue(
             self.env["upgrade.record"].search(


### PR DESCRIPTION
Requires

- [x] https://github.com/OCA/odoo-test-helper/pull/39
- [x] https://github.com/Tecnativa/odoo-test-helper/pull/1

See https://github.com/odoo/odoo/pull/247151

Fixes in `auditlog`:

* Register with the patch checker to prevent exhaustive logging

```
odoo odoo.tests.common: /__w/server-tools/server-tools/auditlog/models/rule.py:232:_patch_method setting res.groups.unlink to <function AuditlogRule._make_unlink.<locals>.unlink_full at 0x7fa51ea90f70>
```

* Align model patching with how it's done in base_automation to fully remove patched methods. Fixes #3439
* Dismantle own patch checker.
* Ensure no patching takes place in setUpClass.

Fixes in other modules:

* Make sure patches or registry updates happen in setUp, not setUpClass and are properly cleaned.