### PR TITLE
[16.0][IMP] tracking_manager: remove odoo_test_helper dependency

### DIFF
--- a/tracking_manager/__manifest__.py
+++ b/tracking_manager/__manifest__.py
@@ -14,13 +14,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": [
-        "base",
-        "mail",
-    ],
-    "external_dependencies": {
-        "python": ["odoo_test_helper"],
-    },
+    "depends": ["mail"],
     "data": [
         "views/ir_model_fields.xml",
         "views/ir_model.xml",

--- a/tracking_manager/static/description/index.html
+++ b/tracking_manager/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -363,9 +362,7 @@ ul.auto-toc {
 <div class="document">
 
 
-<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme">
-<img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme"><img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" /></a>
 <div class="section" id="tracking-manager">
 <h1>Tracking Manager</h1>
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -434,9 +431,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
The python package is not needed nor used in this module, so removing to avoid this extra package. Take into account that in [previous](github.com/OCA/server-tools/blob/15.0/tracking_manager/__manifest__.py) and [posterior](https://github.com/OCA/server-tools/blob/17.0/tracking_manager/__manifest__.py) versions this dependency is not included. 
This was added in the migration pr https://github.com/OCA/server-tools/pull/2789/changes/b33e39f41cd5303937802e2e39bd49f08a50234f#diff-3f82dbb3b9c93a5079031adb7b3a83107977a8b988b25af0228ad565050e1e00R21. 

Removing also base as a dependency (included in mail).