### PR TITLE
[19.0][FIX] upgrade_analysis: don't generate invalid noupdate xml for discarded field values

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -5,6 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 # flake8: noqa: C901
 
+import ast
 import logging
 import os
 from copy import deepcopy
@@ -351,7 +352,8 @@ class UpgradeAnalysis(models.Model):
                     if record_remote_dict[key].tag == "field":
                         field_name = remote_record.xpath(key)[0].attrib.get("name")
                         if (
-                            field_name
+                            local_record.attrib["model"] not in self.env
+                            or field_name
                             not in self.env[local_record.attrib["model"]]._fields.keys()
                         ):
                             continue
@@ -360,6 +362,15 @@ class UpgradeAnalysis(models.Model):
                     for attr in ["eval", "ref"]:
                         if attr in attribs:
                             del attribs[attr]
+                    if record_remote_dict[key].tag == "field" and set(attribs) == {
+                        "name"
+                    }:
+                        # if previous version has set a field but current version
+                        # doesn't, set whatever the NULL value of the field is
+                        # (usually None)
+                        model = self.env[local_record.attrib["model"]]
+                        field = model._fields[attribs["name"]]
+                        attribs["eval"] = ast.unparse(ast.Constant(field.falsy_value))
                     element.append(etree.Element(record_remote_dict[key].tag, attribs))
                 else:
                     oldrepr = self._get_node_value(record_remote_dict[key])

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+from lxml import etree
+
 from odoo.tests import common, tagged
 
 from .. import compare, upgrade_log
@@ -117,3 +119,34 @@ class TestUpgradeAnalysis(common.TransactionCase):
             assertInFieldComparison(comparison, "state", "added: [new]")
         with self.assertRaises(AssertionError):
             assertInFieldComparison(comparison, "state", "removed")
+
+    def test_xml_comparison(self):
+        """
+        Test corner cases in noupdate_changes
+        """
+        # x2many field that was set in noupdate data in previous version,
+        # but not mentioned in noupdate data of current version
+        diff = self.env["upgrade.analysis"]._get_xml_diff(
+            {},
+            {
+                "some_xmlid": etree.fromstring(
+                    """
+                    <record id="some_xmlid" model="upgrade.install.wizard">
+                        <field
+                            name="module_ids"
+                            eval="[Command.set([ref('base.module_web')])]"
+                        />
+                    </record>
+                    """
+                ),
+            },
+            {},
+            {
+                "some_xmlid": etree.fromstring(
+                    """
+                    <record id="some_xmlid" model="upgrade.install.wizard" />
+                    """
+                ),
+            },
+        )
+        self.assertIn('<field name="module_ids" eval="None"/>', diff)


### PR DESCRIPTION
in v18, there's currencies set on payment's `payment_method_bank_transfer` record: https://github.com/OCA/OCB/blob/18.0/addons/payment/data/payment_method_data.xml#L593

in v19, no currencies are set: https://github.com/OCA/OCB/blob/19.0/addons/payment/data/payment_method_data.xml#L565

which generates

```xml
<field name="supported_currency_ids"/>
```

in `noupdate_changes.xml`. But this amounts to writing `''` on a many2many field, which fails as that's an invalid value for this field type.

So here I propose to write whatever the field's NULL value is instead, ensuring we generically empty that field in such a case.