### PR TITLE
[19.0][FIX] upgrade_analysis: don't generate eval="''" attributes

### DIFF
--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -370,7 +370,9 @@ class UpgradeAnalysis(models.Model):
                         # (usually None)
                         model = self.env[local_record.attrib["model"]]
                         field = model._fields[attribs["name"]]
-                        attribs["eval"] = ast.unparse(ast.Constant(field.falsy_value))
+                        eval_constant = ast.unparse(ast.Constant(field.falsy_value))
+                        if eval_constant != "''":
+                            attribs["eval"] = eval_constant
                     element.append(etree.Element(record_remote_dict[key].tag, attribs))
                 else:
                     oldrepr = self._get_node_value(record_remote_dict[key])

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -136,6 +136,7 @@ class TestUpgradeAnalysis(common.TransactionCase):
                             name="module_ids"
                             eval="[Command.set([ref('base.module_web')])]"
                         />
+                        <field name="display_name">some name</field>
                     </record>
                     """
                 ),
@@ -150,3 +151,4 @@ class TestUpgradeAnalysis(common.TransactionCase):
             },
         )
         self.assertIn('<field name="module_ids" eval="None"/>', diff)
+        self.assertIn('<field name="display_name"/>', diff)


### PR DESCRIPTION
see https://github.com/OCA/OpenUpgrade/pull/5553#pullrequestreview-3913234747