### PR TITLE
[18.0][FIX] auditlog: Test _compute_display_name more defensively.

### DIFF
--- a/auditlog/tests/test_http.py
+++ b/auditlog/tests/test_http.py
@@ -31,7 +31,11 @@ class TestAuditlogHttp(HttpCase, AuditLogRuleCommon):
             },
         )
         logs = self.env["auditlog.log"].search(
-            [("model_id", "=", rule.model_id.id), ("res_id", "=", partner.id)]
+            [
+                ("model_id", "=", rule.model_id.id),
+                ("res_id", "=", partner.id),
+                ("line_ids.field_name", "=", "name"),
+            ]
         )
         self.assertEqual(len(logs), 1)
         http_request_id = logs[0]["http_request_id"]


### PR DESCRIPTION
With OCA/partner-contact `partner_firstname` installed, the additional writes to `res.partner` were causing `test_compute_display_name` to fail.