### PR TITLE
[14.0][FIX] scheduler_error_mailer: access problem

### DIFF
--- a/scheduler_error_mailer/models/ir_cron.py
+++ b/scheduler_error_mailer/models/ir_cron.py
@@ -28,7 +28,7 @@ class IrCron(models.Model):
         super()._handle_callback_exception(
             cron_name, server_action_id, job_id, job_exception
         )
-        my_cron = self.browse(job_id)
+        my_cron = self.browse(job_id).sudo()
 
         if my_cron.email_template_id:
             # we put the job_exception in context to be able to print it inside


### PR DESCRIPTION
Running into:

```
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/fields.py", line 994, in __get__
    value = env.cache.get(record, self)
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/api.py", line 820, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'ir.cron(85,).email_template_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/tools/func.py", line 71, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.access', <function IrModelAccess.check at 0x7fe85fe06550>, 1022, False, 'ir.cron', 'read', True, (None,))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/fields.py", line 1020, in __get__
    recs._fetch_field(self)
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/models.py", line 3085, in _fetch_field
    self._read(fnames)
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/models.py", line 3099, in _read
    self.check_access_rights('read')
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/models.py", line 3355, in check_access_rights
    return self.env['ir.model.access'].check(self._name, operation, raise_exception)
  File "<decorator-gen-35>", line 2, in check
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/home/ubuntu/odoo/.venv/lib/python3.8/site-packages/odoo/addons/base/models/ir_model.py", line 1832, in check
    raise AccessError(msg)
odoo.exceptions.AccessError: You are not allowed to access 'Scheduled Actions' (ir.cron) records.
```