### PR TITLE
[18.0][FIX] auditlog: move partner/user dependent tests to post_install

### DIFF
--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -2,7 +2,7 @@
 # © 2018 Pieter Paulussen <pieter_paulussen@me.com>
 # © 2021 Stefan Rijnhart <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+from odoo.tests import tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
@@ -280,6 +280,7 @@ class AuditlogCommon:
         )
 
 
+@tagged("-at_install", "post_install")
 class TestAuditlogFull(AuditLogRuleCommon, AuditlogCommon):
     @classmethod
     def setUpClass(cls):
@@ -298,6 +299,7 @@ class TestAuditlogFull(AuditLogRuleCommon, AuditlogCommon):
         )
 
 
+@tagged("-at_install", "post_install")
 class TestAuditlogExportData(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
@@ -329,6 +331,7 @@ class TestAuditlogExportData(AuditLogRuleCommon):
         self.assertIsInstance(domain[0][2], list)
 
 
+@tagged("-at_install", "post_install")
 class TestAuditlogFast(AuditLogRuleCommon, AuditlogCommon):
     @classmethod
     def setUpClass(cls):
@@ -347,6 +350,7 @@ class TestAuditlogFast(AuditLogRuleCommon, AuditlogCommon):
         )
 
 
+@tagged("-at_install", "post_install")
 class TestFieldRemoval(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
@@ -444,6 +448,7 @@ class TestFieldRemoval(AuditLogRuleCommon):
         self.assertFalse(self.auditlog_rule.model_id)
 
 
+@tagged("-at_install", "post_install")
 class TestAuditlogFullCaptureRecord(AuditLogRuleCommon, AuditlogCommon):
     @classmethod
     def setUpClass(cls):
@@ -463,6 +468,7 @@ class TestAuditlogFullCaptureRecord(AuditLogRuleCommon, AuditlogCommon):
         )
 
 
+@tagged("-at_install", "post_install")
 class AuditLogRuleTestForUserFields(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
@@ -647,6 +653,7 @@ class AuditLogRuleTestForUserFields(AuditLogRuleCommon):
         self.assertTrue(delete_log_record)
 
 
+@tagged("-at_install", "post_install")
 class AuditLogRuleTestForUserModel(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):
@@ -723,6 +730,7 @@ class AuditLogRuleTestForUserModel(AuditLogRuleCommon):
         self.assertTrue(write_log_record)
 
 
+@tagged("-at_install", "post_install")
 class AuditlogFast_excluded_fields(AuditLogRuleCommon):
     @classmethod
     def setUpClass(cls):

--- a/auditlog/tests/test_autovacuum.py
+++ b/auditlog/tests/test_autovacuum.py
@@ -2,9 +2,12 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import time
 
+from odoo.tests import tagged
+
 from .common import AuditLogRuleCommon
 
 
+@tagged("-at_install", "post_install")
 class TestAuditlogAutovacuum(AuditLogRuleCommon):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This PR updates several auditlog test classes to run as post_install tests instead of at_install.

### Why this change is needed

A subset of auditlog tests creates `res.partner / res.users` records in `setUpClass()` and `setUp()`
In our investigation, these tests were executed during the module loading phase, when the res.partner registry was not yet in its final state.

In that phase:
- `res.partner._fields` did not contain `autopost_bills`
- `default_get(["autopost_bills"])` returned `{}`

As a result, creating a partner failed with:

> psycopg2.errors.NotNullViolation: null value in column "autopost_bills"
> of relation "res_partner" violates not-null constraint

The same tests executed successfully as post-tests, when the registry was fully loaded and:
- `res.partner._fields` did contain `autopost_bills`
- `default_get(["autopost_bills"])` returned `{"autopost_bills": "ask"}`

### Root cause

The problem was not related to auditlog method patching/reverting logic.
The issue was that these tests were running too early (at_install) while depending on a fully initialized res.partner model.

### Fix

The affected test classes are now explicitly marked as:
```python
@tagged("-at_install", "post_install")
```

This makes their execution phase consistent with their actual dependencies.

### Why this is correct

These tests are not validating installation-time behavior.
They validate audit logging behavior on regular ORM operations and require the final registry state for `res.partner` / `res.users`

Running them as `post_install` is therefore the correct lifecycle for these scenarios.