### PR TITLE
[14.0][FIX] model_read_only: address same label warning

### DIFF
--- a/model_read_only/models/models.py
+++ b/model_read_only/models/models.py
@@ -9,7 +9,7 @@ class ModelReadonlyRestriction(models.Model):
     _description = "Model Readonly Restriction"
 
     model_id = fields.Many2one("ir.model")
-    model_name = fields.Char(related="model_id.model")
+    model_name = fields.Char(related="model_id.model", string="Model Name")
     restriction_domain = fields.Char(
         "Domain", help="If empty - restriction is applied always."
     )


### PR DESCRIPTION
Fixes the following warning

```
2026-03-31 12:12:35,210 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (model_name, model_id) of model.readonly.restriction() have the same label: Model. 
```