### PR TITLE
[17.0][FIX] auditlog: fix timezone issue in TestAuditlogFast.test_http_session

### DIFF
--- a/auditlog/tests/test_auditlog.py
+++ b/auditlog/tests/test_auditlog.py
@@ -3,7 +3,6 @@
 # © 2021 Stefan Rijnhart <stefan@opener.amsterdam>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from datetime import timedelta
 
 from odoo import fields
 
@@ -276,9 +275,10 @@ class AuditlogCommon:
         )
 
     def test_http_session(self):
-        display_name = self.env["auditlog.http.session"].new().display_name
-        now_plus_one_hour = fields.Datetime.now() + timedelta(hours=1)
-        expected_time_str = now_plus_one_hour.strftime("%Y-%m-%d %H:%M:%S")
+        display_name = (
+            self.env["auditlog.http.session"].new().with_context(tz="UTC").display_name
+        )
+        expected_time_str = fields.Datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.assertEqual(display_name, "? (" + expected_time_str + ")")
 
 


### PR DESCRIPTION
Fixes
```
2026-04-01T10:39:13.0459936Z 2026-04-01 10:39:13,045 361 ␛[1;31m␛[1;49mERROR␛[0m odoo odoo.addons.auditlog.tests.test_auditlog: FAIL: TestAuditlogFast.test_http_session
2026-04-01T10:39:13.0460677Z Traceback (most recent call last):
2026-04-01T10:39:13.0461274Z   File "/__w/server-tools/server-tools/auditlog/tests/test_auditlog.py", line 282, in test_http_session
2026-04-01T10:39:13.0461983Z     self.assertEqual(display_name, "? (" + expected_time_str + ")")
2026-04-01T10:39:13.0462510Z AssertionError: '? (2026-04-01 12:39:13)' != '? (2026-04-01 11:39:13)'
2026-04-01T10:39:13.0462956Z - ? (2026-04-01 12:39:13)
2026-04-01T10:39:13.0463237Z ?                ^
2026-04-01T10:39:13.0463473Z + ? (2026-04-01 11:39:13)
```

that occurred since DST this weekend.