### PR TITLE
[18.0][IMP] upgrade_analysis: blacklist more test modules

### DIFF
--- a/upgrade_analysis/blacklist.py
+++ b/upgrade_analysis/blacklist.py
@@ -10,6 +10,6 @@ BLACKLIST_MODULES = [
 # delay the process and spit out annoying log messages continuously.
 
 # We also don't want to analyze tests modules
-BLACKLIST_MODULES_STARTS_WITH = ["hw_", "test_"]
+BLACKLIST_MODULES_STARTS_WITH = ["hw_", "test_", "l10n_test_"]
 
-BLACKLIST_MODULES_ENDS_WITH = ["_test"]
+BLACKLIST_MODULES_ENDS_WITH = ["_test", "_tests"]


### PR DESCRIPTION
- <img width="314" height="64" alt="Selection_5584" src="https://github.com/user-attachments/assets/569d4dc4-f745-4e6a-8ffe-a61e2a90c9ae" />
- <img width="286" height="65" alt="Selection_5586" src="https://github.com/user-attachments/assets/237a82ee-2bba-4c2e-8213-0168f21dc7e9" />
