### PR TITLE
[19.0][IMP] upgrade_analysis: blacklist more test modules

### DIFF
--- a/upgrade_analysis/blacklist.py
+++ b/upgrade_analysis/blacklist.py
@@ -10,6 +10,6 @@ BLACKLIST_MODULES = [
 # delay the process and spit out annoying log messages continuously.
 
 # We also don't want to analyze tests modules
-BLACKLIST_MODULES_STARTS_WITH = ["hw_", "test_"]
+BLACKLIST_MODULES_STARTS_WITH = ["hw_", "test_", "l10n_test_"]
 
-BLACKLIST_MODULES_ENDS_WITH = ["_test"]
+BLACKLIST_MODULES_ENDS_WITH = ["_test", "_tests"]


### PR DESCRIPTION
Forward port of https://github.com/OCA/server-tools/pull/3594.