### PR TITLE
[19.0][IMP] base_view_inheritance_extension: better error messages for non-locatable nodes

### DIFF
--- a/base_view_inheritance_extension/models/ir_ui_view.py
+++ b/base_view_inheritance_extension/models/ir_ui_view.py
@@ -187,6 +187,7 @@ class IrUiView(models.Model):
             </field>
         """
         node = self.locate_node(source, specs)
+        self._assert_node(node, specs)
         for spec in specs:
             attr_name = spec.get("name")
             # Parse ast from both node and spec
@@ -212,6 +213,7 @@ class IrUiView(models.Model):
             </attribute>
         </$node>"""
         node = self.locate_node(source, specs)
+        self._assert_node(node, specs)
         for attribute_node in specs:
             attribute_name = attribute_node.get("name")
             old_value = node.get(attribute_name) or ""
@@ -230,6 +232,7 @@ class IrUiView(models.Model):
             </attribute>
         </$node>"""
         node = self.locate_node(source, specs)
+        self._assert_node(node, specs)
         for attribute_node in specs:
             attribute_name = attribute_node.get("name")
             condition = attribute_node.get("condition")
@@ -275,3 +278,25 @@ class IrUiView(models.Model):
         domain_str = pattern.sub(r"\1", domain_str)
         pattern = re.compile(r"'([^']+)_is_a_var_to_replace'")
         return pattern.sub(r"\1", domain_str)
+
+    @api.model
+    def _assert_node(self, node, specs):
+        """Raise a ValueError detailing the failing specification if node is None"""
+        if node is None:
+            self._raise_view_error(
+                ValueError(
+                    self.env._(
+                        "Element '%s' cannot be located in parent view",
+                        etree.tostring(
+                            etree.Element(
+                                specs.tag,
+                                {
+                                    a: v
+                                    for a, v in specs.attrib.items()
+                                    if a != "position"
+                                },
+                            )
+                        ).decode("utf8"),
+                    )
+                ),
+            )

--- a/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
+++ b/base_view_inheritance_extension/tests/test_base_view_inheritance_extension.py
@@ -267,3 +267,11 @@ class TestBaseViewInheritanceExtension(TransactionCase):
             inherited_view.write(
                 {"arch": '<wraptext expr="//some/node" position="other" />'}
             )
+
+    def test_locate_failure_error_message(self):
+        """Be sure there is a helpful error message when locating nodes fails"""
+        source = etree.fromstring("<form />")
+        specs = etree.fromstring('<nonexistent position="inside" />')
+        with self.assertRaisesRegex(ValueError, "nonexistent.*parent view") as caught:
+            self.env["ir.ui.view"].apply_inheritance_specs(source, specs)
+        self.assertTrue(caught.exception.context)


### PR DESCRIPTION
before this, having a wrong xpath or similar looked like this:

```
AttributeError: 'NoneType' object has no attribute 'get'
```

now it's

```
Element '<nonexistent />' cannot be located in parent view

View error context:
{'file': '...',
 'line': 1,
 'name': '...',
 'view': ir.ui.view(42,),
 'view.model': False,
 'view.parent': ir.ui.view(4242,),
 'xmlid': '...'}
```