### PR TITLE
[18.0][FIX] fetchmail_attach_from_folder: case-insensitive email matching

### DIFF
--- a/fetchmail_attach_from_folder/match_algorithm/email_exact.py
+++ b/fetchmail_attach_from_folder/match_algorithm/email_exact.py
@@ -1,11 +1,11 @@
 # Copyright - 2013-2024 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo.tools.mail import email_split
+from odoo.tools.mail import email_normalize, email_split
 from odoo.tools.safe_eval import safe_eval
 
 
 class EmailExact:
-    """Search for exactly the mailadress as noted in the email"""
+    """Search for exactly the email address as noted in the email."""
 
     def _get_mailaddresses(self, folder, message_dict):
         mailaddresses = []
@@ -13,11 +13,24 @@ class EmailExact:
         for field in fields:
             if field in message_dict:
                 mailaddresses += email_split(message_dict[field])
-        return [addr.lower() for addr in mailaddresses]
+        # Normalize using email_normalize for consistent matching.
+        # This strips display names, lowercases the address, and handles
+        # edge cases (e.g. "<user@domain.com>" or "User <user@domain.com>").
+        return [email_normalize(addr) or addr.lower() for addr in mailaddresses]
 
     def _get_mailaddress_search_domain(
-        self, folder, message_dict, operator="=", values=None
+        self, folder, message_dict, operator="=ilike", values=None
     ):
+        """Build search domain for email matching.
+
+        We use ``=ilike`` (case-insensitive exact match) instead of ``=``
+        so that uppercase email variants (e.g. ``Name.SURNAME@Domain.com``)
+        also match partners whose email is stored in mixed case.
+
+        ``=ilike`` is safe here because there are no ``%`` wildcards in the
+        search values, so it behaves exactly like a case-insensitive ``=``
+        (PostgreSQL: ``LOWER(field) = LOWER(value)``).
+        """
         mailaddresses = values or self._get_mailaddresses(folder, message_dict)
         if not mailaddresses:
             return [(0, "=", 1)]

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -8,7 +8,7 @@ from odoo import fields
 from odoo.fields import Command
 from odoo.tests.common import TransactionCase
 
-from ..match_algorithm import email_domain
+from ..match_algorithm import email_domain, email_exact
 
 TEST_EMAIL = "reynaert@dutchsagas.nl"
 TEST_SUBJECT = "Test subject"
@@ -143,6 +143,34 @@ class TestMatchAlgorithms(TransactionCase):
                 "model_id": cls.partner_ir_model.id,
             }
         )
+
+    def test_email_exact_case_insensitive(self):
+        """A message to REYN@dom.ain should match partner with reyn@dom.ain."""
+        MAIL_MESSAGE["from"] = TEST_EMAIL.upper()
+        self.folder.match_algorithm = "email_exact"
+        matcher = email_exact.EmailExact()
+        matches = matcher.search_matches(self.folder, MAIL_MESSAGE)
+        self.assertEqual(matches, self.test_partner)
+
+    def test_email_exact_case_insensitive_partner_uppercase(self):
+        """A message to reyn@dom.ain should match partner with REYN@dom.ain."""
+        self.test_partner.email = TEST_EMAIL.upper()
+        MAIL_MESSAGE["from"] = TEST_EMAIL
+        self.folder.match_algorithm = "email_exact"
+        matcher = email_exact.EmailExact()
+        matches = matcher.search_matches(self.folder, MAIL_MESSAGE)
+        self.assertEqual(matches, self.test_partner)
+        # restore original partner email for subsequent tests
+        self.test_partner.email = TEST_EMAIL
+
+    def test_email_exact_display_name(self):
+        """A message in the form 'Name <email@domain>' should be parsed correctly."""
+        TEST_DISPLAY_NAME = "Reynaert de Vos <reynaert@dutchsagas.nl>"
+        MAIL_MESSAGE["from"] = TEST_DISPLAY_NAME
+        self.folder.match_algorithm = "email_exact"
+        matcher = email_exact.EmailExact()
+        matches = matcher.search_matches(self.folder, MAIL_MESSAGE)
+        self.assertEqual(matches, self.test_partner)
 
     def test_email_exact(self):
         """A message to ronald@acme.com should be linked to partner with that email."""


### PR DESCRIPTION
## Bug

Closes #3402

Emails containing uppercase letters were not linked to partner records because the  match algorithm lowercased the incoming email addresses but then searched with  (case-sensitive exact match). If the partner stored the email as mixed-case (e.g. Name.SURNAME@Domain.com), the match failed.

## Fix

Use Odoo's  operator instead of . This matches Odoo's own approach in core ( line 965) and performs a case-insensitive exact match via PostgreSQL .

## Changes
- : default operator changed from  to 
- : added  covering uppercase email matching

## Compatibility
- Fully backward compatible: existing exact matches still work; now uppercase variants also match.