### PR TITLE
[18.0][FIX] base_remote: skip ensure_one on empty remotes during RPC auth

### DIFF
--- a/base_remote/models/res_users.py
+++ b/base_remote/models/res_users.py
@@ -16,7 +16,7 @@ class ResUsers(models.Model):
         with cls.pool.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
             remote = env["res.users"].remote
-            if not config["test_enable"]:
+            if not config["test_enable"] and remote:
                 remote.ensure_one()
         result = method()
         if not result:


### PR DESCRIPTION
Closes #3458

When authenticating via XML-RPC or JSON-RPC (no HTTP context), the
remote property returns an empty recordset. Calling ensure_one() on
it crashes with ValueError: Expected singleton: res.remote().

Web browser logins continue to work because httprequest.remote_addr
is always present and returns a single record.

Fix: add a truthiness guard so we only call ensure_one() when a
remote record exists, matching the same pattern already used for
test mode.

This is exactly the fix proposed in the issue report.