### PR TITLE
[18.0][FIX] base_remote: allow RPC authentication without HTTP context

### DIFF
--- a/base_remote/models/res_users.py
+++ b/base_remote/models/res_users.py
@@ -16,7 +16,7 @@ class ResUsers(models.Model):
         with cls.pool.cursor() as cr:
             env = api.Environment(cr, SUPERUSER_ID, {})
             remote = env["res.users"].remote
-            if not config["test_enable"]:
+            if not config["test_enable"] and remote:
                 remote.ensure_one()
         result = method()
         if not result:

--- a/base_remote/tests/test_remote.py
+++ b/base_remote/tests/test_remote.py
@@ -76,7 +76,7 @@ class TestRemote(HttpCase):
         data1["password"] = "Failure!"
         self.assertFalse(
             self.xmlrpc_common.authenticate(
-                self.env.cr.dbname, data1["login"], data1["password"]
+                self.env.cr.dbname, data1["login"], data1["password"], {}
             )
         )
         with self.cursor() as cr:

--- a/base_remote/tests/test_remote.py
+++ b/base_remote/tests/test_remote.py
@@ -76,9 +76,30 @@ class TestRemote(HttpCase):
         data1["password"] = "Failure!"
         self.assertFalse(
             self.xmlrpc_common.authenticate(
-                self.env.cr.dbname, data1["login"], data1["password"], {}
+                self.env.cr.dbname, data1["login"], data1["password"]
             )
         )
         with self.cursor() as cr:
             env = self.env(cr)
             self.assertTrue(env["res.remote"].search([("ip", "=", self.remote_addr)]))
+
+    def test_auth_check_remote_no_http_context(self, *args):
+        """_auth_check_remote must not crash when remote is empty.
+
+        When there is no HTTP context (e.g. some RPC paths), ``Base.remote``
+        returns an empty recordset. ``ResUsers._auth_check_remote`` must
+        tolerate this and allow authentication to proceed.
+        """
+
+        # Patch ``Base.remote`` to return an empty recordset for all calls
+        Base = self.env["base"].__class__
+        original_remote = Base.remote
+        try:
+            Base.remote = property(lambda self: self.env["res.remote"])
+            result = self.env["res.users"]._auth_check_remote(
+                None,
+                lambda: True,
+            )
+            self.assertTrue(result)
+        finally:
+            Base.remote = original_remote


### PR DESCRIPTION
Fixes #3458

When authenticating via RPC (XML-RPC, JSON-RPC), there is no active
HTTP request context. The `Base.remote` property returns an empty
`res.remote` recordset in this case.

However, `ResUsers._auth_check_remote` unconditionally called
`ensure_one()` on that recordset, causing:

```
ValueError: Expected singleton: res.remote()
```

This blocked all API/RPC authentication while web login continued
to work normally.

**Fix:** Add `and remote` to the guard before `ensure_one()`,
skipping the singleton check when the remote recordset is empty.
This matches the existing pattern used for `config['test_enable']`
and does not affect web authentication where an HTTP context exists.

**Tests:**
- Added `test_auth_check_remote_no_http_context` which patches
  `Base.remote` to return an empty recordset and verifies that
  `_auth_check_remote` tolerates it without crashing.
- Existing tests for web login remain untouched.

Backward compatible: existing behaviour for browser sessions is
unchanged.