### PR TITLE
[17.0][FIX] auto_backup: allow scheduled backup when list_db is disabled

### DIFF
--- a/auto_backup/README.rst
+++ b/auto_backup/README.rst
@@ -114,7 +114,6 @@ Known issues / Roadmap
   Odoo instance. How to do this (for version 9.0) was outlined in `this
   blog
   post <https://web.archive.org/web/20240805225230/https://blog.laslabs.com/2016/10/running-python-scripts-within-odoos-environment/>`__.
-- Backups won't work if list_db=False is configured in the instance.
 
 Bug Tracker
 ===========

--- a/auto_backup/__manifest__.py
+++ b/auto_backup/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Database Auto-Backup",
     "summary": "Backups database",
-    "version": "17.0.1.1.1",
+    "version": "17.0.1.1.2",
     "author": "Yenthe Van Ginneken, "
     "Agile Business Group, "
     "Grupo ESOC Ingenieria de Servicios, "

--- a/auto_backup/models/db_backup.py
+++ b/auto_backup/models/db_backup.py
@@ -163,9 +163,12 @@ class DbBackup(models.Model):
                             shutil.copyfileobj(cached, destiny)
                     # Generate new backup
                     else:
-                        db.dump_db(
-                            self.env.cr.dbname, destiny, backup_format=rec.backup_format
-                        )
+                        with self._db_management_enabled():
+                            db.dump_db(
+                                self.env.cr.dbname,
+                                destiny,
+                                backup_format=rec.backup_format,
+                            )
                         backup = backup or destiny.name
                 successful |= rec
 
@@ -175,9 +178,10 @@ class DbBackup(models.Model):
             for rec in sftp:
                 filename = self.filename(datetime.now(), ext=rec.backup_format)
                 with rec.backup_log():
-                    cached = db.dump_db(
-                        self.env.cr.dbname, None, backup_format=rec.backup_format
-                    )
+                    with self._db_management_enabled():
+                        cached = db.dump_db(
+                            self.env.cr.dbname, None, backup_format=rec.backup_format
+                        )
 
                     with cached:
                         with rec.sftp_connection() as remote:
@@ -203,6 +207,25 @@ class DbBackup(models.Model):
     def action_backup_all(self):
         """Run all scheduled backups."""
         return self.search([]).action_backup()
+
+    @contextmanager
+    def _db_management_enabled(self):
+        """Temporarily allow database management functions during a backup.
+
+        ``odoo.service.db.dump_db`` is protected by
+        ``check_db_management_enabled``, which raises ``AccessDenied`` when
+        ``list_db = False`` is set in the Odoo configuration. That option only
+        aims at hiding database management from the web interface; a scheduled
+        backup is a trusted server-side operation, so we re-enable the flag for
+        the duration of the dump and always restore its original value
+        afterwards.
+        """
+        list_db = tools.config["list_db"]
+        tools.config["list_db"] = True
+        try:
+            yield
+        finally:
+            tools.config["list_db"] = list_db
 
     @contextmanager
     def backup_log(self):

--- a/auto_backup/readme/ROADMAP.md
+++ b/auto_backup/readme/ROADMAP.md
@@ -3,4 +3,3 @@
   changing settings, you need to run the backup from outside of the main
   Odoo instance. How to do this (for version 9.0) was outlined in [this blog
   post](https://web.archive.org/web/20240805225230/https://blog.laslabs.com/2016/10/running-python-scripts-within-odoos-environment/).
-- Backups won't work if list_db=False is configured in the instance.

--- a/auto_backup/static/description/index.html
+++ b/auto_backup/static/description/index.html
@@ -470,7 +470,6 @@ changing settings, you need to run the backup from outside of the main
 Odoo instance. How to do this (for version 9.0) was outlined in <a class="reference external" href="https://web.archive.org/web/20240805225230/https://blog.laslabs.com/2016/10/running-python-scripts-within-odoos-environment/">this
 blog
 post</a>.</li>
-<li>Backups won’t work if list_db=False is configured in the instance.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/auto_backup/tests/test_db_backup.py
+++ b/auto_backup/tests/test_db_backup.py
@@ -121,6 +121,15 @@ class TestDbBackup(BaseCommon):
         generated_backup = [f for f in os.listdir(rec_id.folder) if f >= filename]
         self.assertEqual(1, len(generated_backup))
 
+    def test_action_backup_local_list_db_disabled(self):
+        """It should backup locally even when list_db is disabled"""
+        rec_id = self.new_record("local")
+        filename = rec_id.filename(datetime.now())
+        with patch.dict(tools.config.options, {"list_db": False}):
+            rec_id.action_backup()
+        generated_backup = [f for f in os.listdir(rec_id.folder) if f >= filename]
+        self.assertEqual(1, len(generated_backup))
+
     def test_action_backup_local_cleanup(self):
         """Backup local database and cleanup old databases"""
         rec_id = self.new_record("local")


### PR DESCRIPTION
## Problem

When `list_db = False` is set in the Odoo configuration, scheduled `auto_backup`
jobs fail with:

> Database management functions blocked, admin disabled database listing

`odoo.service.db.dump_db` is decorated with `@check_db_management_enabled`, which
raises `AccessDenied` when `list_db` is False. The scheduled backup then fails
silently and leaves a **zero-byte** dump file — a silent data-loss risk.

## Fix

Wrap the `dump_db` calls in `action_backup()` with a small context manager that
temporarily re-enables `list_db` for the duration of the dump and **always**
restores its original value (`try/finally`, even on error). Adds a regression
test (`test_action_backup_local_list_db_disabled`).

Port of #3639.
