### PR TITLE
[19.0][IMP] tracking_manager: rename parameter in create method for clarity

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -160,8 +160,8 @@ class Base(models.AbstractModel):
         return super().write(vals)
 
     @api.model_create_multi
-    def create(self, list_vals):
-        records = super().create(list_vals)
+    def create(self, vals_list):
+        records = super().create(vals_list)
         if self.is_tracked_by_o2m():
             records._tm_track_create_unlink("create")
         return records


### PR DESCRIPTION
Calling the json2 API results in this error:
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/addons/rpc/controllers/json2.py", line 82, in web_json_2_rpc
    signature.bind(records, **kwargs)
  File "/usr/lib/python3.12/inspect.py", line 3242, in bind
    return self._bind(args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3157, in _bind
    raise TypeError(msg) from None
TypeError: missing a required argument: 'list_vals'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 2302, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/service/model.py", line 188, in retrying
    result = func()
             ^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 2357, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 2637, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 355, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/odoo/http.py", line 811, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/addons/rpc/controllers/json2.py", line 84, in web_json_2_rpc
    raise UnprocessableEntity(exc.args[0]) from exc
werkzeug.exceptions.UnprocessableEntity: 422 Unprocessable Entity: missing a required argument: 'list_vals'
 ```