### PR TITLE
[19.0][FIX] auditlog: Maximum recursion error when creating new accounts

### DIFF
--- a/auditlog/README.rst
+++ b/auditlog/README.rst
@@ -112,18 +112,34 @@ Contributors
 ------------
 
 - Sebastien Alix <sebastien.alix@camptocamp.com>
+
 - Holger Brunn <hbrunn@therp.nl>
+
 - Holden Rehg <holdenrehg@gmail.com>
+
 - Eric Lembregts <eric@lembregts.eu>
+
 - Pieter Paulussen <pieter.paulussen@me.com>
+
 - Alan Ramos <alan.ramos@jarsa.com.mx>
+
 - Stefan Rijnhart <stefan@opener.amsterdam>
+
 - Bhavesh Odedra <bodedra@opensourceintegrators.com>
+
 - Hardik Suthar <hsuthar@opensourceintegrators.com>
+
 - Kitti U. <kittiu@ecosoft.co.th>
+
 - Bogdan Valentin Gabor <valentin.gabor@bt-group.com>
+
 - Dennis Sluijk d.sluijk@onestein.nl
+
 - Adam Heinz <adam.heinz@metricwise.com>
+
+- `OERP Canada <https://www.oerp.ca/>`__:
+
+  - Hembert Iregui <<hi@oerp.ca>
 
 Other credits
 -------------

--- a/auditlog/models/auditlog_rule.py
+++ b/auditlog/models/auditlog_rule.py
@@ -365,7 +365,7 @@ class AuditlogRule(models.Model):
 
         @api.model_create_multi
         def create_full(self, vals_list, **kwargs):
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             new_records = create_full.origin(self, vals_list, **kwargs)
             # Take a snapshot of record values from the cache instead of using
@@ -400,7 +400,7 @@ class AuditlogRule(models.Model):
 
         @api.model_create_multi
         def create_fast(self, vals_list, **kwargs):
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             vals_list = rule_model._update_vals_list(vals_list)
             vals_list2 = copy.deepcopy(vals_list)
@@ -443,9 +443,9 @@ class AuditlogRule(models.Model):
             # avoid logs on `read` produced by auditlog during internal
             # processing: read data of relevant records, 'ir.model',
             # 'ir.model.fields'... (no interest in logging such operations)
-            if self.env.context.get("auditlog_disabled"):
+            if self.env.context.get("auditlog_disabled_read"):
                 return result
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             if self.env.user in users_to_exclude:
                 return result
@@ -469,7 +469,12 @@ class AuditlogRule(models.Model):
         users_to_exclude = self.mapped("users_to_exclude_ids")
 
         def write_full(self, vals, **kwargs):
-            self = self.with_context(auditlog_disabled=True)
+            guard = self.env.context.get("auditlog_guard", set())
+            guard_keys = {(self._name, tuple(self.ids))}
+            if bool(guard.intersection(guard_keys)):
+                return write_full.origin(self, vals, **kwargs)
+            guard.update(guard_keys)
+            self = self.with_context(auditlog_guard=guard, auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             fields_list = rule_model.get_auditlog_fields(self)
             records_write = (
@@ -503,7 +508,7 @@ class AuditlogRule(models.Model):
             return result
 
         def write_fast(self, vals, **kwargs):
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             # Log the user input only, no matter if the `vals` is updated
             # afterwards as it could not represent the real state
@@ -535,7 +540,7 @@ class AuditlogRule(models.Model):
         users_to_exclude = self.mapped("users_to_exclude_ids")
 
         def unlink_full(self, **kwargs):
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             fields_list = rule_model.get_auditlog_fields(self)
             old_values = {
@@ -558,7 +563,7 @@ class AuditlogRule(models.Model):
             return unlink_full.origin(self, **kwargs)
 
         def unlink_fast(self, **kwargs):
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             if self.env.user in users_to_exclude:
                 return unlink_fast.origin(self, **kwargs)
@@ -583,7 +588,7 @@ class AuditlogRule(models.Model):
 
         def export_data(self, fields_to_export):
             res = export_data.origin(self, fields_to_export)
-            self = self.with_context(auditlog_disabled=True)
+            self = self.with_context(auditlog_disabled_read=True)
             rule_model = self.env["auditlog.rule"]
             if self.env.user in users_to_exclude:
                 return res

--- a/auditlog/readme/CONTRIBUTORS.md
+++ b/auditlog/readme/CONTRIBUTORS.md
@@ -11,3 +11,6 @@
 - Bogdan Valentin Gabor \<<valentin.gabor@bt-group.com>\>
 - Dennis Sluijk <d.sluijk@onestein.nl>
 - Adam Heinz \<<adam.heinz@metricwise.com>\>
+- [OERP Canada](https://www.oerp.ca/):
+
+  - Hembert Iregui \<<hi@oerp.ca\>

--- a/auditlog/static/description/index.html
+++ b/auditlog/static/description/index.html
@@ -462,6 +462,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Bogdan Valentin Gabor &lt;<a class="reference external" href="mailto:valentin.gabor&#64;bt-group.com">valentin.gabor&#64;bt-group.com</a>&gt;</li>
 <li>Dennis Sluijk <a class="reference external" href="mailto:d.sluijk&#64;onestein.nl">d.sluijk&#64;onestein.nl</a></li>
 <li>Adam Heinz &lt;<a class="reference external" href="mailto:adam.heinz&#64;metricwise.com">adam.heinz&#64;metricwise.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.oerp.ca/">OERP Canada</a>:<ul>
+<li>Hembert Iregui &lt;&lt;<a class="reference external" href="mailto:hi&#64;oerp.ca">hi&#64;oerp.ca</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/test_auditlog/tests/__init__.py
+++ b/test_auditlog/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_account_bank_statement_line
 from . import test_account_move_reverse
 from . import test_product_tax_multicompany
+from . import test_account_reentrancy

--- a/test_auditlog/tests/test_account_reentrancy.py
+++ b/test_auditlog/tests/test_account_reentrancy.py
@@ -1,0 +1,56 @@
+from odoo.tests.common import tagged
+
+from odoo.addons.auditlog.tests.common import AuditLogRuleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountAuditlog(AuditLogRuleCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.account_model_id = cls.env.ref("account.model_account_account").id
+        cls.rule = cls.create_rule(
+            {
+                "name": "Account Audit Rule",
+                "model_id": cls.account_model_id,
+                "log_create": True,
+                "log_write": True,
+                "log_read": True,
+                "log_unlink": True,
+                "log_type": "full",
+            }
+        )
+        cls.rule.set_to_confirmed()
+
+    def test_write_code_reentrancy(self):
+        """This test verifies the infinite recursion scenario
+        that occurs when a field defines both _compute_code and _inverse_code.
+        It ensures that the introduced guard correctly prevents re-entering
+        the same field's compute/inverse cycle, avoiding recursive execution
+        while preserving the expected field behavior.
+        """
+        account = self.env["account.account"].create(
+            {
+                "name": "Test Account",
+                "code": "1000",
+            }
+        )
+        logs = self.env["auditlog.log"].search(
+            [
+                ("model_id", "=", self.account_model_id),
+                ("method", "=", "write"),
+                ("res_id", "=", account.id),
+            ]
+        )
+        self.assertTrue(
+            logs.line_ids.filtered(lambda log_line: log_line.field_name == "code_store")
+        )
+        account.write({"code": "2000"})
+        logs = self.env["auditlog.log"].search(
+            [
+                ("model_id", "=", self.account_model_id),
+                ("method", "=", "write"),
+                ("res_id", "=", account.id),
+            ]
+        )
+        self.assertEqual(len(logs), 2)


### PR DESCRIPTION
### Module
Auditlog

### Describe the bug
Maximum recursion error when creating new accounts

### To Reproduce
Create a new rule for the account.account module
Check "Log Creates", "Log Writes" and "Full Log" in the new rule

Steps to reproduce the behavior:

Go to Accounting -> Configuration -> Chart of Account
Create a new account with code
Foreve loading and "RecursionError: maximum recursion depth exceeded"

**Expected behavior**
It should be able to save

**Additional context**
In Odoo, there are 2 methods in the AccountAccount class called _compute_code and _inverse_code.
Auditlog module keeps triggering these 2 methods and causing an infinite loop.