### PR TITLE
[19.0][FIX] database_cleanup: restrict cleanup tools to settings users

### DIFF
--- a/database_cleanup/README.rst
+++ b/database_cleanup/README.rst
@@ -53,8 +53,8 @@ Usage
 
 After installation of this module, go to the Settings menu -> Technical
 -> Database cleanup. This menu is only available to members of the
-*Access Rights* group. Go through the modules, models, columns and
-tables entries under this menu (in that order) and find out if there is
+*Settings* group. Go through the modules, models, columns and tables
+entries under this menu (in that order) and find out if there is
 orphaned data in your database. You can either delete entries by line,
 or sweep all entries in one big step (if you are *really* confident).
 
@@ -84,12 +84,12 @@ Authors
 Contributors
 ------------
 
-- Stefan Rijnhart <stefan@opener.amsterdam>
-- Holger Brunn <hbrunn@therp.nl>
-- Stéphane Mangin <stephane.mangin@camptocamp.com>
-- `360ERP <https://www.360erp.com>`__:
+-  Stefan Rijnhart <stefan@opener.amsterdam>
+-  Holger Brunn <hbrunn@therp.nl>
+-  Stéphane Mangin <stephane.mangin@camptocamp.com>
+-  `360ERP <https://www.360erp.com>`__:
 
-  - Andrea Stirpe
+   -  Andrea Stirpe
 
 Maintainers
 -----------

--- a/database_cleanup/models/purge_line.py
+++ b/database_cleanup/models/purge_line.py
@@ -28,6 +28,6 @@ class CleanupPurgeLine(models.AbstractModel):
     @api.model_create_multi
     def create(self, values):
         # make sure the user trying this is actually supposed to do it
-        if self.env.ref("base.group_erp_manager") not in self.env.user.group_ids:
+        if self.env.ref("base.group_system") not in self.env.user.group_ids:
             raise AccessDenied
         return super().create(values)

--- a/database_cleanup/models/purge_wizard.py
+++ b/database_cleanup/models/purge_wizard.py
@@ -59,7 +59,7 @@ class PurgeWizard(models.AbstractModel):
     @api.model_create_multi
     def create(self, values):
         # make sure the user trying this is actually supposed to do it
-        if self.env.ref("base.group_erp_manager") not in self.env.user.group_ids:
+        if self.env.ref("base.group_system") not in self.env.user.group_ids:
             raise AccessDenied
         return super().create(values)
 

--- a/database_cleanup/readme/USAGE.md
+++ b/database_cleanup/readme/USAGE.md
@@ -1,6 +1,6 @@
 After installation of this module, go to the Settings menu -\> Technical
 -\> Database cleanup. This menu is only available to members of the
-*Access Rights* group. Go through the modules, models, columns and
+*Settings* group. Go through the modules, models, columns and
 tables entries under this menu (in that order) and find out if there is
 orphaned data in your database. You can either delete entries by line,
 or sweep all entries in one big step (if you are *really* confident).

--- a/database_cleanup/static/description/index.html
+++ b/database_cleanup/static/description/index.html
@@ -401,8 +401,8 @@ doing.</p>
 <h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
 <p>After installation of this module, go to the Settings menu -&gt; Technical
 -&gt; Database cleanup. This menu is only available to members of the
-<em>Access Rights</em> group. Go through the modules, models, columns and
-tables entries under this menu (in that order) and find out if there is
+<em>Settings</em> group. Go through the modules, models, columns and tables
+entries under this menu (in that order) and find out if there is
 orphaned data in your database. You can either delete entries by line,
 or sweep all entries in one big step (if you are <em>really</em> confident).</p>
 <p><a class="reference external image-reference" href="https://runbot.odoo-community.org/runbot/149/11.0"><img alt="Try me on Runbot" src="https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas" /></a></p>

--- a/database_cleanup/tests/common.py
+++ b/database_cleanup/tests/common.py
@@ -18,7 +18,7 @@ def environment():
     registry = odoo.modules.registry.Registry(common.get_db_name())
     with registry.cursor() as cr:
         env = odoo.api.Environment(cr, ADMIN_USER_ID, {})
-        env.user.group_ids |= env.ref("base.group_erp_manager")
+        env.user.group_ids |= env.ref("base.group_system")
         yield env
 
 

--- a/database_cleanup/views/menu.xml
+++ b/database_cleanup/views/menu.xml
@@ -5,7 +5,7 @@
         <field name="sequence" eval="10" />
         <!-- attach to Settings -> Technical -->
         <field name="parent_id" ref="base.menu_custom" />
-        <field name="group_ids" eval="[(6,0, [ref('base.group_erp_manager')])]" />
+        <field name="group_ids" eval="[(6,0, [ref('base.group_system')])]" />
     </record>
 
     <record model="ir.ui.menu" id="menu_purge_modules">


### PR DESCRIPTION
Align database_cleanup access restrictions with its ACLs by limiting the
menu and runtime security checks to Settings users.

The module already grants access to its cleanup wizard models only to
base.group_system in ir.model.access.csv, while the menu, Python checks,
tests, and documentation still referenced Access Rights users. This could
let users see the Database cleanup menu but fail with Access Denied when
opening a wizard.

Update the menu, Python guards, tests, and documentation to consistently
use base.group_system.