### PR TITLE
[18.0][FIX] fetchmail_attach_from_folder: case-insensitive email matching

### DIFF
--- a/fetchmail_attach_from_folder/match_algorithm/email_domain.py
+++ b/fetchmail_attach_from_folder/match_algorithm/email_domain.py
@@ -21,7 +21,7 @@ class EmailDomain(EmailExact):
                 self._get_mailaddress_search_domain(
                     folder,
                     message_dict,
-                    operator="like",
+                    operator="ilike",
                     values=["%@" + domain for domain in set(domains)],
                 ),
                 order=folder.model_order,

--- a/fetchmail_attach_from_folder/match_algorithm/email_exact.py
+++ b/fetchmail_attach_from_folder/match_algorithm/email_exact.py
@@ -16,7 +16,7 @@ class EmailExact:
         return [addr.lower() for addr in mailaddresses]
 
     def _get_mailaddress_search_domain(
-        self, folder, message_dict, operator="=", values=None
+        self, folder, message_dict, operator="=ilike", values=None
     ):
         mailaddresses = values or self._get_mailaddresses(folder, message_dict)
         if not mailaddresses:

--- a/fetchmail_attach_from_folder/tests/test_match_algorithms.py
+++ b/fetchmail_attach_from_folder/tests/test_match_algorithms.py
@@ -150,6 +150,31 @@ class TestMatchAlgorithms(TransactionCase):
         self._test_search_matches(email_domain.EmailDomain)
         self._test_apply_matching(email_domain.EmailDomain)
 
+    def test_email_exact_case_insensitive(self):
+        """Email matching must be case-insensitive regardless of stored casing."""
+        from ..match_algorithm.email_exact import EmailExact
+
+        mixed_case_email = TEST_EMAIL.replace("reynaert", "Reynaert").replace(
+            "dutchsagas", "DutchSagas"
+        )
+        self.test_partner.write({"email": mixed_case_email})
+        MAIL_MESSAGE["from"] = TEST_EMAIL
+        matcher = EmailExact()
+        matches = matcher.search_matches(self.folder, MAIL_MESSAGE)
+        self.assertEqual(matches, self.test_partner)
+
+    def test_email_domain_case_insensitive(self):
+        """Domain matching must be case-insensitive regardless of stored casing."""
+        mixed_case_email = TEST_EMAIL.replace("dutchsagas", "DutchSagas")
+        self.test_partner.write({"email": mixed_case_email})
+        alternate_email = TEST_EMAIL.replace("reynaert@", "mariken@")
+        MAIL_MESSAGE["from"] = alternate_email
+        self.folder.match_algorithm = "email_domain"
+        self.folder.match_first = True
+        matcher = email_domain.EmailDomain()
+        matches = matcher.search_matches(self.folder, MAIL_MESSAGE)
+        self.assertEqual(matches, self.test_partner)
+
     def test_email_domain(self):
         """Test with email in same domain, but different mailbox."""
         ALTERNATE_EMAIL = TEST_EMAIL.replace("reynaert@", "mariken@")


### PR DESCRIPTION
## Problem

PostgreSQL `=` operator is case-sensitive. Partners stored with mixed-case emails (e.g. `Name.SURNAME@Domain.com`) were not matched when incoming email address had different casing (e.g. `name.surname@domain.com`). The existing `_get_mailaddresses()` already lowercases the extracted incoming address, but the search domain operator `=` did not account for mixed-case values stored in the database.

Closes #3402

## Solution

- `email_exact.py`: change default `operator="="` → `operator="=ilike"`
- `email_domain.py`: change `operator="like"` → `operator="ilike"`

## Tests

Added two new test cases:
- `test_email_exact_case_insensitive`: partner stored with mixed-case email, incoming address lowercase → must match
- `test_email_domain_case_insensitive`: domain match with mixed-case stored email → must match