### PR TITLE
[18.0][FIX] base_name_search_improved: Call the name_search() method with the appropriate limit

### DIFF
--- a/base_name_search_improved/models/ir_model.py
+++ b/base_name_search_improved/models/ir_model.py
@@ -82,9 +82,10 @@ class Base(models.AbstractModel):
     @api.model
     def _search_smart_search(self, operator, value):
         if value and operator in ALLOWED_OPS:
+            total_items = self.search_count([])
             matching_records = self.with_context(
                 force_smart_name_search=True
-            ).name_search(name=value, operator=operator)
+            ).name_search(name=value, operator=operator, limit=total_items)
             if matching_records:
                 record_ids = [record[0] for record in matching_records]
                 return [("id", "in", record_ids)]


### PR DESCRIPTION
Call the `name_search()` method with the appropriate limit

It is important to call the name_search() method with the appropriate limit so that the filter is truly effective

Example use case:
- Thousands of products
- We apply filter A + smart_search = B
- By default, name_search() applies limit=100, so we will only get a total of 100 records to build the domain in _search_smart_search()
- When applying the A filter, the smart_search domain will return some incorrect records (4, for example); however, if the total number of possible records were specified as the limit, the correct domain would be returned (20 possible records, for example)

@Tecnativa TT63353