### PR TITLE
[19.0][FIX] database_cleanup: Avoid blocking uninstall during purge modules

### DIFF
--- a/database_cleanup/wizards/purge_line_modules.py
+++ b/database_cleanup/wizards/purge_line_modules.py
@@ -25,10 +25,7 @@ class CleanupPurgeLineModule(models.TransientModel):
             return True
         self.logger.info("Purging modules %s", ", ".join(module_names))
         installed = modules.filtered(lambda x: x.state in ("installed", "to upgrade"))
-        to_remove = modules - installed
-        to_remove += to_remove.downstream_dependencies()
-        to_remove.write({"state": "to remove"})
-        installed.button_immediate_uninstall()
+        installed.module_uninstall()
         with self.env.registry.cursor() as new_cr:
             self.env(cr=new_cr)["ir.module.module"].browse(modules.ids).unlink()
         return self.write({"purged": True})


### PR DESCRIPTION
### Problems

The `button_immediate_uninstall()` method raises a `UserError` when any module is in one of the following states: `to install`, `to upgrade`, or `to remove`.

In the purge module workflow, modules to remove are updated to `to remove` before `button_immediate_uninstall()` is called to uninstall the installed modules. This causes the uninstall process to fail because the presence of modules in the `to remove` state blocks `button_immediate_uninstall()`.

### Changes

Remove the logic that explicitly marks modules as `to remove`.

Use `module_uninstall()` instead of `button_immediate_uninstall()` to uninstall modules. Unlike `button_immediate_uninstall()`, `module_uninstall()` does not set the module state to `to remove`, allowing modules to be unlinked successfully.

Note: The `_unlink_except_installed()` method prevents unlinking modules whose state is one of the following: `installed`, `to upgrade`, `to remove`, or `to install`.