### PR TITLE
[19.0][IMP] upgrade_analysis: generate changes for renamed noupdate records

### DIFF
--- a/upgrade_analysis/compare.py
+++ b/upgrade_analysis/compare.py
@@ -540,7 +540,7 @@ def compare_xml_sets(old_records, new_records):
         if entry["noupdate_switched"]:
             content += " (noupdate switched)"
         reprs[module_map(entry["module"])].append(content)
-    return reprs
+    return reprs, moved_records, renamed_records, modified_records
 
 
 def compare_model_sets(old_records, new_records):

--- a/upgrade_analysis/models/upgrade_analysis.py
+++ b/upgrade_analysis/models/upgrade_analysis.py
@@ -164,7 +164,9 @@ class UpgradeAnalysis(models.Model):
             {field: record[field] for field in flds}
             for record in RemoteRecord.read(remote_xml_record_ids, flds)
         ]
-        res_xml = compare.compare_xml_sets(remote_xml_records, local_xml_records)
+        res_xml, moved_xml_records, renamed_xml_records, modified_xml_records = (
+            compare.compare_xml_sets(remote_xml_records, local_xml_records)
+        )
 
         # Retrieve model representations and compare
         flds = [
@@ -270,7 +272,9 @@ class UpgradeAnalysis(models.Model):
             )
         noupdate_modules = []
         try:
-            noupdate_modules = self.generate_noupdate_changes()
+            noupdate_modules = self.generate_noupdate_changes(
+                moved_xml_records, renamed_xml_records, modified_xml_records
+            )
         except Exception as e:
             _logger.exception(f"Error generating noupdate changes: {e}")
             general_log += "ERROR: error when generating noupdate changes: {e}\n"
@@ -486,7 +490,9 @@ class UpgradeAnalysis(models.Model):
 
         return records_update, records_noupdate
 
-    def generate_noupdate_changes(self):
+    def generate_noupdate_changes(
+        self, moved_xml_records, renamed_xml_records, modified_xml_records
+    ):
         """Communicate with the remote server to fetch all xml data records
         per module, and generate a diff in XML format that can be imported
         from the module's migration script using openupgrade.load_data()
@@ -498,6 +504,14 @@ class UpgradeAnalysis(models.Model):
         local_modules = local_record_obj.list_modules()
         all_remote_modules = remote_record_obj.list_modules()
         changed_modules = []
+        # {new_module: {name: previous_module}}
+        renamed_xmlids = {}
+        for renamed_xml_record in renamed_xml_records:
+            if renamed_xml_record.get("old") or not renamed_xml_record.get("new"):
+                continue
+            renamed_xmlids.setdefault(renamed_xml_record["module"], {}).update(
+                {renamed_xml_record["suffix"]: renamed_xml_record["renamed"]}
+            )
         for local_module in local_modules:
             remote_files = []
             remote_modules = []
@@ -515,6 +529,35 @@ class UpgradeAnalysis(models.Model):
                     )
                     remote_update.update(add_remote_update)
                     remote_noupdate.update(add_remote_noupdate)
+                if any(
+                    renamed_from_module == remote_module
+                    for renamed_from_module in renamed_xmlids.get(
+                        local_module, {}
+                    ).values()
+                ):
+                    # if xmlids have been renamed (moved) to the current module, query
+                    # their definition from the module that contained it previously
+                    remote_modules.append(remote_module)
+                    renamed_from_module_files = remote_record_obj.get_xml_records(
+                        remote_module
+                    )
+                    renamed_from_module_update, renamed_from_module_noupdate = (
+                        self._parse_files(renamed_from_module_files, remote_module)
+                    )
+                    remote_update.update(
+                        {
+                            name: xml
+                            for name, xml in renamed_from_module_update.items()
+                            if renamed_xmlids[local_module].get(name) == remote_module
+                        }
+                    )
+                    remote_noupdate.update(
+                        {
+                            name: xml
+                            for name, xml in renamed_from_module_noupdate.items()
+                            if renamed_xmlids[local_module].get(name) == remote_module
+                        }
+                    )
             if not remote_modules:
                 continue
             local_files = local_record_obj.get_xml_records(local_module)

--- a/upgrade_analysis/tests/test_module.py
+++ b/upgrade_analysis/tests/test_module.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from unittest.mock import patch
 
 from lxml import etree
 
@@ -152,3 +153,142 @@ class TestUpgradeAnalysis(common.TransactionCase):
         )
         self.assertIn('<field name="module_ids" eval="None"/>', diff)
         self.assertIn('<field name="display_name"/>', diff)
+
+    def test_analyze(self):
+        """
+        Test a full analysis run.
+        For the time being, only xmlid related functionality is tested
+        """
+        analysis = self.env["upgrade.analysis"].create(
+            {
+                "config_id": self.env["upgrade.comparison.config"]
+                .create(
+                    {
+                        "database": self.env.cr.dbname,
+                    }
+                )
+                .id,
+            }
+        )
+        upgrade_analysis_version = (
+            self.env["ir.module.module"]
+            .search([("name", "=", "upgrade_analysis")])
+            .latest_version
+        )
+
+        self.env["upgrade.record"].create(
+            {
+                "name": "upgrade_analysis.test_noupdate_xmlid",
+                "mode": "create",
+                "type": "xmlid",
+                "module": "upgrade_analysis",
+                "model": "upgrade.comparison.config",
+                "noupdate": True,
+            }
+        )
+
+        class RemoteUpgradeRecord:
+            _records = {
+                1: {
+                    "name": "other_module.test_noupdate_xmlid",
+                    "mode": "create",
+                    "type": "xmlid",
+                    "module": "other_module",
+                    "prefix": "other_module",
+                    "model": "upgrade.comparison.config",
+                    "noupdate": True,
+                    "suffix": "test_noupdate_xmlid",
+                },
+            }
+
+            def search(self, domain):
+                if domain == [("type", "=", "xmlid")]:
+                    return [
+                        _id
+                        for _id, vals in self._records.items()
+                        if vals["type"] == "xmlid"
+                    ]
+                return []
+
+            def read(self, ids, fields):  # pylint: disable=method-required-super
+                return [
+                    {field: record.get(field) for field in fields}
+                    for _id, record in self._records.items()
+                    if _id in ids
+                ]
+
+            def field_dump(self):
+                return []
+
+            def list_modules(self):
+                return set(record["module"] for record in self._records.values())
+
+            def get_xml_records(self, module):
+                if module == "other_module":
+                    return [
+                        """
+                        <odoo noupdate="1">
+                            <record
+                                id="test_noupdate_xmlid"
+                                model="upgrade.comparison.config"
+                            >
+                                <field
+                                    name="name"
+                                >Noupdate xmlid from other_module</field>
+                                <field name="server">some_server</field>
+                            </record>
+                        </odoo>
+                        """
+                    ]
+
+        def local_get_xml_records(module):
+            if module == "upgrade_analysis":
+                return [
+                    """
+                    <odoo noupdate="1">
+                        <record
+                            id="test_noupdate_xmlid"
+                            model="upgrade.comparison.config"
+                        >
+                            <field
+                                name="name"
+                            >Noupdate xmlid from upgrade_analysis</field>
+                            <field name="server">some_server</field>
+                        </record>
+                    </odoo>
+                    """
+                ]
+
+        written_files = {}
+
+        def write_file(module_name, version, content, filename="upgrade_analysis.txt"):
+            written_files[f"{module_name}-{version}-{filename}"] = content
+
+        with (
+            patch.object(analysis.config_id.__class__, "get_connection"),
+            patch.object(
+                analysis.__class__, "_get_remote_model"
+            ) as patched_get_remote_model,
+            patch.object(analysis.__class__, "_write_file") as patched_write_file,
+            patch.object(
+                self.env["upgrade.record"].__class__, "get_xml_records"
+            ) as patched_get_xml_records,
+        ):
+            patched_get_remote_model.side_effect = lambda *args: RemoteUpgradeRecord()
+            patched_get_xml_records.side_effect = local_get_xml_records
+            patched_write_file.side_effect = write_file
+            analysis.analyze()
+
+        expected_noupdate_content = """<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+  <record id="test_noupdate_xmlid" model="upgrade.comparison.config">
+    <field name="name">Noupdate xmlid from upgrade_analysis</field>
+  </record>
+</odoo>
+"""
+        self.assertEqual(
+            written_files[
+                f"upgrade_analysis-{upgrade_analysis_version}-noupdate_changes.xml"
+            ],
+            expected_noupdate_content,
+        )


### PR DESCRIPTION
when a noupdate record is moved into another module, content changes were not reflected in `noupdate_changes.xml`.  A case where that's really problematic is https://github.com/OCA/OpenUpgrade/issues/5812

This fix will emit the following extra records on the next run of the analysis cronjob after merge:

openupgrade_scripts/scripts/uom/19.0.1.0/noupdate_changes.xml ([v18](https://github.com/odoo/odoo/blob/18.0/addons/product/data/product_data.xml#L35), [v19](https://github.com/odoo/odoo/blob/19.0/addons/uom/data/uom_data.xml#L5))

```xml
  <record id="decimal_product_uom" model="decimal.precision" forcecreate="True">
    <field name="name">Product Unit</field>
  </record>
```

openupgrade_scripts/scripts/hr_holidays/19.0.1.6/noupdate_changes.xml ([v18](https://github.com/odoo/odoo/blob/18.0/addons/hr_holidays_attendance/data/hr_holidays_attendance_data.xml#L4), [v19](https://github.com/odoo/odoo/blob/19.0/addons/hr_holidays/data/hr_leave_type_data.xml#L81))

```xml
  <record id="holiday_status_extra_hours" model="hr.leave.type">
    <field name="icon_id" ref="hr_holidays.icon_4"/>
    <field name="overtime_deductible" eval="False"/>
    <field name="requires_allocation">False</field>
    <field name="country_id" eval="False"/>
    <field name="hide_on_dashboard">True</field>
  </record>
```

openupgrade_scripts/scripts/base/19.0.1.3/noupdate_changes.xml ([v18](https://github.com/odoo/odoo/blob/18.0/addons/l10n_fr/data/res_country_data.xml#L2), [v19](https://github.com/odoo/odoo/blob/19.0/odoo/addons/base/data/res_country_data.xml#L1701))

```xml
  <record id="dom-tom" model="res.country.group">
    <field name="country_ids" eval="[Command.set([                 ref('yt'),ref('gp'),ref('mq'),ref('gf'),ref('re'),                 ref('pf'),ref('pm'),ref('mf'),ref('bl'),ref('nc'),             ])]"/>
    <field name="code">DOM-TOM</field>
  </record>
```

openupgrade_scripts/scripts/account/19.0.1.4/noupdate_changes.xml ([v18](https://github.com/odoo/odoo/blob/18.0/addons/account_peppol_selfbilling/data/mail_template.xml#L63), [v19](https://github.com/odoo/odoo/blob/19.0/addons/account/data/mail_template_data.xml#L206))

```xml
  <record id="email_template_edi_self_billing_credit_note" model="mail.template">
    <field name="body_html" type="html">
    ...
    </field>
  </record>
```

all of which are updates we actually want I think