### PR TITLE
[19.0][IMP] database_cleanup: Purge menu has action that does not exist or has been deleted

### DIFF
--- a/database_cleanup/wizards/purge_menus.py
+++ b/database_cleanup/wizards/purge_menus.py
@@ -4,6 +4,7 @@
 # pylint: disable=consider-merging-classes-inherited
 from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Command
 
 
 class CleanupPurgeWizardMenu(models.TransientModel):
@@ -22,19 +23,15 @@ class CleanupPurgeWizardMenu(models.TransientModel):
             .with_context(active_test=False)
             .search([("action", "!=", False)])
         ):
+            command = Command.create({"name": menu.complete_name, "menu_id": menu.id})
+            if not menu.action.exists():
+                # Menus may have actions that do not exist or have been deleted
+                res.append(command)
+                continue
             if menu.action.type != "ir.actions.act_window":
                 continue
             if menu.action.res_model and menu.action.res_model not in self.env:
-                res.append(
-                    (
-                        0,
-                        0,
-                        {
-                            "name": menu.complete_name,
-                            "menu_id": menu.id,
-                        },
-                    )
-                )
+                res.append(command)
         if not res:
             raise UserError(self.env._("No dangling menu entries found"))
         return res


### PR DESCRIPTION
### Problems

Some menus have actions that do not exist or have been deleted. When clicking on the menu "Purge obsolete menu entries" purge lines will be created for obsolete menus and the error below will be raised because of invalid action

<img width="1166" height="230" alt="image" src="https://github.com/user-attachments/assets/1f3417e6-2f07-4841-b6a3-5de0c0dbcb38" />

### Changes

Check whether the action exists by calling exists() before reading its data. If the action does not exist, create a purge line for the corresponding menu.