### PR TITLE
[18.0][FIX] base_exception: enforce blocking check in wizard

### DIFF
--- a/base_exception/__manifest__.py
+++ b/base_exception/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Exception Rule",
-    "version": "18.0.1.1.1",
+    "version": "18.0.1.1.2",
     "development_status": "Mature",
     "category": "Generic Modules",
     "summary": """

--- a/base_exception/tests/test_base_exception.py
+++ b/base_exception/tests/test_base_exception.py
@@ -141,6 +141,13 @@ class TestBaseException(TransactionCase):
         with self.assertRaises(UserError):
             self.po.action_ignore_exceptions()
         self.assertFalse(self.po.ignore_exception)
+        # The confirmation wizard must enforce the same blocking check, even
+        # when a downstream wizard sets ``ignore_exception`` directly.
+        self.exception_rule_confirm.exception_ids = self.po.exception_ids
+        self.exception_rule_confirm.ignore = True
+        with self.assertRaises(UserError):
+            self.exception_rule_confirm.action_confirm()
+        self.assertFalse(self.po.ignore_exception)
         with self.assertRaises(ValidationError):
             self.po.button_confirm()
         self.po.with_context(raise_exception=False).button_confirm()

--- a/base_exception/wizard/base_exception_confirm.py
+++ b/base_exception/wizard/base_exception_confirm.py
@@ -4,7 +4,7 @@
 # Copyright 2020 Hibou Corp.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class ExceptionRuleConfirm(models.AbstractModel):
@@ -34,4 +34,13 @@ class ExceptionRuleConfirm(models.AbstractModel):
 
     def action_confirm(self):
         self.ensure_one()
+        if self.ignore:
+            if any(self.exception_ids.mapped("is_blocking")):
+                raise UserError(
+                    _(
+                        "The exceptions can not be ignored, because "
+                        "some of them are blocking."
+                    )
+                )
+            self.related_model_id.action_ignore_exceptions()
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Closes #3667

## Problem

The confirmation wizard could allow blocking exceptions to be ignored when a downstream exception module set `ignore_exception = True` directly.

That write can remove the linked exceptions before `action_ignore_exceptions()` validates whether any exception is blocking.

## Solution

Validate the wizard's original exception list before allowing exceptions to be ignored. The wizard then calls `action_ignore_exceptions()` to follow the standard ignore workflow.

## Testing

- Added regression coverage for a downstream wizard that writes `ignore_exception` directly.
- The complete `base_exception` test suite passes.
- Pre-commit, Ruff, Ruff Format, and Pylint checks pass.
- Manually tested using `purchase_exception`.
- Confirmed that a blocking purchase exception raises an error and cannot be ignore

I confirm I have read the DCO (https://github.com/OCA/oca-addons-repo-template/blob/master/CONTRIBUTING.md) and signed it off.

@thomaspaulb help me review this