### PR TITLE
[FIX] base_fontawesome_web_editor: fix icon to image conversion

### DIFF
--- a/base_fontawesome_web_editor/static/src/js/wysiwyg/fonts.esm.js
+++ b/base_fontawesome_web_editor/static/src/js/wysiwyg/fonts.esm.js
@@ -45,9 +45,26 @@ patch(fonts, {
                 data.selector += ", " + match[0];
                 data.names.push(match[1]);
             } else {
+                let css = cssText.replace(/(^.*\{\s*)|(\s*\}\s*$)/g, "");
+                // FontAwesome >= 6.7.2 declares the icon's glyph via the --fa
+                // custom property instead of a classic `content` declaration.
+                // Odoo core's fontToImg() still parses `content: "..."` to
+                // extract the glyph, so synthesize one from --fa when it's
+                // the only declaration available. If the codepoint can't be
+                // parsed (e.g. unsupported --fa format), skip silently rather
+                // than crash; that icon just won't be convertible to an image.
+                if (!/content:/.test(css)) {
+                    const faMatch = css.match(/--fa:\s*["']\\([0-9a-fA-F]+)["']/);
+                    if (faMatch) {
+                        const codePoint = parseInt(faMatch[1], 16);
+                        if (Number.isFinite(codePoint)) {
+                            css += ` content: "${String.fromCodePoint(codePoint)}";`;
+                        }
+                    }
+                }
                 data = {
                     selector: match[0],
-                    css: cssText.replace(/(^.*\{\s*)|(\s*\}\s*$)/g, ""),
+                    css: css,
                     names: [match[1]],
                 };
             }


### PR DESCRIPTION
Closes #3457

## Problem
Sending a chatter message (or any HtmlField) containing a FontAwesome
icon crashes with `TypeError: Cannot read properties of null (reading '1')`
when the icon's CSS rule uses FontAwesome >= 6.7.2's `--fa` custom
property instead of a classic `content` declaration.

## Fix
`_processRuleSelectors` now synthesizes a `content: "..."` declaration
from `--fa` when no classic `content` declaration is present, so Odoo
core's `fontToImg()` can extract the glyph as it did before FA 6.7.2.

## Known limitation
Icons introduced only in FontAwesome 6 (not present in Odoo's bundled
server-side font used for `/web_editor/font_to_img`) still can't be
rendered as a converted image. This is a separate, pre-existing
limitation unrelated to this crash fix.