### PR TITLE
[FIX] module_auto_update: skip creating/checking checksums for modules with 'imported = True'. Fixes update with 'studio_customization' installed.

### DIFF
--- a/module_auto_update/models/module.py
+++ b/module_auto_update/models/module.py
@@ -81,19 +81,19 @@ class Module(models.Model):
     @api.model
     def _save_installed_checksums(self):
         checksums = {}
-        installed_modules = self.search([("state", "=", "installed")])
+        installed_modules = self.search(["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")])
         for module in installed_modules:
             checksums[module.name] = module._get_checksum_dir()
         self._save_checksums(checksums)
 
     @api.model
     def _get_modules_partially_installed(self):
-        return self.search([("state", "in", ("to install", "to remove", "to upgrade"))])
+        return self.search(["&", ("state", "in", ["to install", "to remove", "to upgrade"]), ("name", "!=", "studio_customization")])
 
     @api.model
     def _get_modules_with_changed_checksum(self):
         saved_checksums = self._get_saved_checksums()
-        installed_modules = self.search([("state", "=", "installed")])
+        installed_modules = self.search(["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")])
         return installed_modules.filtered(
             lambda r: r._get_checksum_dir() != saved_checksums.get(r.name),
         )

--- a/module_auto_update/models/module.py
+++ b/module_auto_update/models/module.py
@@ -79,10 +79,26 @@ class Module(models.Model):
         Icp.flush_model()
 
     @api.model
+    def _not_imported_domain(self):
+        """Domain excluding modules that only exist in the database.
+
+        Imported modules (Odoo Studio customizations, modules uploaded through
+        the web interface) have no counterpart on the file system, so no
+        checksum can be computed for them.
+
+        The ``imported`` field is added by ``base_import_module``, which is not
+        a dependency of this module. When it is not installed, no module can be
+        imported in the first place, so no filtering is needed.
+        """
+        if "imported" in self._fields:
+            return [("imported", "=", False)]
+        return []
+
+    @api.model
     def _save_installed_checksums(self):
         checksums = {}
         installed_modules = self.search(
-            ["&", ("state", "=", "installed"), ("imported", "=", False)]
+            [("state", "=", "installed"), *self._not_imported_domain()]
         )
         for module in installed_modules:
             checksums[module.name] = module._get_checksum_dir()
@@ -92,9 +108,8 @@ class Module(models.Model):
     def _get_modules_partially_installed(self):
         return self.search(
             [
-                "&",
                 ("state", "in", ["to install", "to remove", "to upgrade"]),
-                ("imported", "=", False),
+                *self._not_imported_domain(),
             ]
         )
 
@@ -102,7 +117,7 @@ class Module(models.Model):
     def _get_modules_with_changed_checksum(self):
         saved_checksums = self._get_saved_checksums()
         installed_modules = self.search(
-            ["&", ("state", "=", "installed"), ("imported", "=", False)]
+            [("state", "=", "installed"), *self._not_imported_domain()]
         )
         return installed_modules.filtered(
             lambda r: r._get_checksum_dir() != saved_checksums.get(r.name),

--- a/module_auto_update/models/module.py
+++ b/module_auto_update/models/module.py
@@ -82,7 +82,7 @@ class Module(models.Model):
     def _save_installed_checksums(self):
         checksums = {}
         installed_modules = self.search(
-            ["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")]
+            ["&", ("state", "=", "installed"), ("imported", "=", False)]
         )
         for module in installed_modules:
             checksums[module.name] = module._get_checksum_dir()
@@ -94,7 +94,7 @@ class Module(models.Model):
             [
                 "&",
                 ("state", "in", ["to install", "to remove", "to upgrade"]),
-                ("name", "!=", "studio_customization"),
+                ("imported", "=", False),
             ]
         )
 
@@ -102,7 +102,7 @@ class Module(models.Model):
     def _get_modules_with_changed_checksum(self):
         saved_checksums = self._get_saved_checksums()
         installed_modules = self.search(
-            ["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")]
+            ["&", ("state", "=", "installed"), ("imported", "=", False)]
         )
         return installed_modules.filtered(
             lambda r: r._get_checksum_dir() != saved_checksums.get(r.name),

--- a/module_auto_update/models/module.py
+++ b/module_auto_update/models/module.py
@@ -31,7 +31,7 @@ def ensure_module_state(env, modules, state):
     if not modules:
         return
     env.cr.execute(
-        "SELECT name FROM ir_module_module " "WHERE id IN %s AND state != %s",
+        "SELECT name FROM ir_module_module WHERE id IN %s AND state != %s",
         (tuple(modules.ids), state),
     )
     names = [r[0] for r in env.cr.fetchall()]
@@ -81,19 +81,29 @@ class Module(models.Model):
     @api.model
     def _save_installed_checksums(self):
         checksums = {}
-        installed_modules = self.search(["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")])
+        installed_modules = self.search(
+            ["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")]
+        )
         for module in installed_modules:
             checksums[module.name] = module._get_checksum_dir()
         self._save_checksums(checksums)
 
     @api.model
     def _get_modules_partially_installed(self):
-        return self.search(["&", ("state", "in", ["to install", "to remove", "to upgrade"]), ("name", "!=", "studio_customization")])
+        return self.search(
+            [
+                "&",
+                ("state", "in", ["to install", "to remove", "to upgrade"]),
+                ("name", "!=", "studio_customization"),
+            ]
+        )
 
     @api.model
     def _get_modules_with_changed_checksum(self):
         saved_checksums = self._get_saved_checksums()
-        installed_modules = self.search(["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")])
+        installed_modules = self.search(
+            ["&", ("state", "=", "installed"), ("name", "!=", "studio_customization")]
+        )
         return installed_modules.filtered(
             lambda r: r._get_checksum_dir() != saved_checksums.get(r.name),
         )

--- a/module_auto_update/tests/test_module.py
+++ b/module_auto_update/tests/test_module.py
@@ -86,8 +86,6 @@ class TestImportedModules(TransactionCase):
         self.Imm = self.env["ir.module.module"]
         # Skip test if base_import_module is not installed (OCB)
         if "imported" not in self.Imm._fields:
-            # the field comes from base_import_module, which is not a
-            # dependency of this module
             self.skipTest("base_import_module is not installed")
         # Modules imported into the database (e.g. Odoo Studio customizations)
         # have no counterpart on the file system, so no checksum can be

--- a/module_auto_update/tests/test_module.py
+++ b/module_auto_update/tests/test_module.py
@@ -80,6 +80,39 @@ class TestModule(TransactionCase):
         self.assertFalse(Imm._get_modules_with_changed_checksum())
 
 
+class TestImportedModules(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.Imm = self.env["ir.module.module"]
+        # Modules imported into the database (e.g. Odoo Studio customizations)
+        # have no counterpart on the file system, so no checksum can be
+        # computed for them.
+        self.imported_module = self.Imm.create(
+            {
+                "name": "test_imported_module",
+                "state": "installed",
+                "imported": True,
+            }
+        )
+
+    def test_save_installed_checksums_skips_imported(self):
+        self.Imm._save_installed_checksums()
+        self.assertNotIn("test_imported_module", self.Imm._get_saved_checksums())
+
+    def test_changed_checksum_skips_imported(self):
+        # no checksum was ever saved for the imported module
+        self.Imm._save_checksums({})
+        self.assertNotIn(
+            self.imported_module, self.Imm._get_modules_with_changed_checksum()
+        )
+
+    def test_partially_installed_skips_imported(self):
+        self.imported_module.state = "to upgrade"
+        self.assertNotIn(
+            self.imported_module, self.Imm._get_modules_partially_installed()
+        )
+
+
 @odoo.tests.tagged("post_install", "-at_install")
 class TestModuleAfterInstall(TransactionCase):
     def setUp(self):

--- a/module_auto_update/tests/test_module.py
+++ b/module_auto_update/tests/test_module.py
@@ -84,6 +84,11 @@ class TestImportedModules(TransactionCase):
     def setUp(self):
         super().setUp()
         self.Imm = self.env["ir.module.module"]
+        # Skip test if base_import_module is not installed (OCB)
+        if "imported" not in self.Imm._fields:
+            # the field comes from base_import_module, which is not a
+            # dependency of this module
+            self.skipTest("base_import_module is not installed")
         # Modules imported into the database (e.g. Odoo Studio customizations)
         # have no counterpart on the file system, so no checksum can be
         # computed for them.


### PR DESCRIPTION
The Odoo Enterprise "Studio" module creates a new module "studio_customization" in the database. Since we're only comparing checksums of modules stored in the file system, skipping the creation and checking of checksums for modules with 'imported = True' fixes the update mechanism on Odoo Enterprise installations and installations with modules imported via Odoo's webinterface.

Fixes #3360.

I've seen @joshkreud's PR #3674, but still want to propose this alternative fix:

Modifying the existing query to exclude imported modules appears cleaner than implementing the function _module_exists_on_disk() + tests and calling it for every module in a for-loop.