### PR TITLE
[IMP] bus_alt_connection: redirect cron LISTEN connections

### DIFF
--- a/bus_alt_connection/README.rst
+++ b/bus_alt_connection/README.rst
@@ -67,9 +67,9 @@ instances.
 It allows you to define how resources should be shared, according to
 your priorities, e.g. :
 
-- key odoo instance on host A can open up to 30 connections
-- while odoo instance on host B, dedicated to reports, can open up to 10
-  connections only
+-  key odoo instance on host A can open up to 30 connections
+-  while odoo instance on host B, dedicated to reports, can open up to
+   10 connections only
 
 And most importantly, it helps you to ensure that ``max_connections``
 will never be reached on pg server side.
@@ -80,8 +80,8 @@ Why is this module needed?
 When configuring PgBouncer, you can choose between 2 transaction pooling
 modes:
 
-- pool_mode = session
-- pool_mode = transaction
+-  pool_mode = session
+-  pool_mode = transaction
 
 If we choose pool_mode = session, then one server connection will be
 tied to a given odoo process until its death, which is exactly what
@@ -108,6 +108,18 @@ That's what this module implements, by overriding the relevant method of
 the
 `Dispatcher <https://github.com/odoo/odoo/blob/12.0/addons/bus/models/bus.py#L105>`__.
 
+What about cron workers?
+------------------------
+
+Since the cron workers were reworked to be woken up through
+``LISTEN cron_trigger``, they also keep a long-lived listening
+connection to the ``postgres`` database, with the same PgBouncer
+limitation as the bus dispatcher.
+
+This module also redirects those cron LISTEN connections to the
+alternate host/port, while the connections actually processing the jobs
+keep going through the regular ``db_host``/``db_port`` (i.e. PgBouncer).
+
 **Table of contents**
 
 .. contents::
@@ -120,8 +132,8 @@ You don't need to install this module in the database(s) to enable it.
 
 But you need to load it server-wide:
 
-- By starting Odoo with ``--load=web,bus_alt_connection``
-- Or by updating its configuration file:
+-  By starting Odoo with ``--load=web,bus_alt_connection``
+-  Or by updating its configuration file:
 
 .. code:: ini
 
@@ -134,12 +146,12 @@ Configuration
 
 You need to define how to connect directly to the database:
 
-- Either by defining environment variables:
+-  Either by defining environment variables:
 
-     - ``IMDISPATCHER_DB_HOST=db-01``
-     - ``IMDISPATCHER_DB_PORT=5432``
+      -  ``IMDISPATCHER_DB_HOST=db-01``
+      -  ``IMDISPATCHER_DB_PORT=5432``
 
-- Or in Odoo's configuration file:
+-  Or in Odoo's configuration file:
 
 .. code:: ini
 
@@ -147,6 +159,23 @@ You need to define how to connect directly to the database:
    (...)
    imdispatcher_db_host = db-01
    imdispatcher_db_port = 5432
+
+The cron LISTEN connections use the same settings by default. If you
+need a different host/port for them, you can override it:
+
+-  Either by defining environment variables:
+
+      -  ``ODOO_CRON_DB_HOST=db-01``
+      -  ``ODOO_CRON_DB_PORT=5432``
+
+-  Or in Odoo's configuration file:
+
+.. code:: ini
+
+   [options]
+   (...)
+   cron_db_host = db-01
+   cron_db_port = 5432
 
 Bug Tracker
 ===========
@@ -169,7 +198,8 @@ Authors
 Contributors
 ------------
 
-- Nils Hamerlinck <nils@trobz.com>
+-  Nils Hamerlinck <nils@trobz.com>
+-  Moisés López <moylop260@vauxoo.com>
 
 Maintainers
 -----------

--- a/bus_alt_connection/models/__init__.py
+++ b/bus_alt_connection/models/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2019 Trobz <https://trobz.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import bus
+from . import cron

--- a/bus_alt_connection/models/cron.py
+++ b/bus_alt_connection/models/cron.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Vauxoo <https://www.vauxoo.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+import os
+import threading
+
+import odoo.service.server
+import odoo.sql_db
+from odoo.tools import config
+
+_logger = logging.getLogger(__name__)
+
+# Cron workers/threads keep a long-lived "LISTEN cron_trigger" connection
+# to the "postgres" database, which is not compatible with PgBouncer in
+# transaction pooling mode (same limitation as the bus dispatcher).
+#
+# There is no hook to alter only that connection: both entry points call
+# ``sql_db.db_connect("postgres")`` directly. So we flag the cron threads
+# (and the cron worker processes) and redirect their connections to the
+# "postgres" database to the alternate host/port.
+_cron_context = threading.local()
+
+
+def _cron_db_config(param):
+    """Return the alternate connection parameter for cron connections.
+
+    Falls back to the imdispatcher (bus) settings, so a single
+    configuration can redirect both LISTEN/NOTIFY connections.
+    """
+    return (
+        os.environ.get(f"ODOO_CRON_DB_{param.upper()}")
+        or config.get("cron_db_" + param)
+        or os.environ.get(f"ODOO_IMDISPATCHER_DB_{param.upper()}")
+        or config.get("imdispatcher_db_" + param)
+    )
+
+
+_orig_connection_info_for = odoo.sql_db.connection_info_for
+
+
+def connection_info_for(db_or_uri, *args, **kwargs):
+    db_name, connection_info = _orig_connection_info_for(db_or_uri, *args, **kwargs)
+    if db_or_uri == "postgres" and getattr(_cron_context, "redirect", False):
+        for p in ("host", "port"):
+            cfg = _cron_db_config(p)
+            if cfg:
+                connection_info[p] = cfg
+        _logger.debug(
+            "Cron connection to db postgres via %s:%s",
+            connection_info.get("host"),
+            connection_info.get("port"),
+        )
+    return db_name, connection_info
+
+
+_orig_worker_cron_start = odoo.service.server.WorkerCron.start
+
+
+def _worker_cron_start(self):
+    _cron_context.redirect = True
+    return _orig_worker_cron_start(self)
+
+
+_orig_cron_thread = odoo.service.server.ThreadedServer.cron_thread
+
+
+def _cron_thread(self, number):
+    _cron_context.redirect = True
+    return _orig_cron_thread(self, number)
+
+
+odoo.sql_db.connection_info_for = connection_info_for
+odoo.service.server.WorkerCron.start = _worker_cron_start
+odoo.service.server.ThreadedServer.cron_thread = _cron_thread
+
+if _cron_db_config("host") or _cron_db_config("port"):
+    _logger.info(
+        "Cron LISTEN connections will be redirected via %s:%s",
+        _cron_db_config("host") or config.get("db_host") or "<default>",
+        _cron_db_config("port") or config.get("db_port") or "<default>",
+    )

--- a/bus_alt_connection/readme/CONFIGURE.md
+++ b/bus_alt_connection/readme/CONFIGURE.md
@@ -13,3 +13,20 @@ You need to define how to connect directly to the database:
 imdispatcher_db_host = db-01
 imdispatcher_db_port = 5432
 ```
+
+The cron LISTEN connections use the same settings by default. If you
+need a different host/port for them, you can override it:
+
+- Either by defining environment variables:
+
+  > - `ODOO_CRON_DB_HOST=db-01`
+  > - `ODOO_CRON_DB_PORT=5432`
+
+- Or in Odoo's configuration file:
+
+``` ini
+[options]
+(...)
+cron_db_host = db-01
+cron_db_port = 5432
+```

--- a/bus_alt_connection/readme/CONTRIBUTORS.md
+++ b/bus_alt_connection/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Nils Hamerlinck \<<nils@trobz.com>\>
+- Moisés López \<<moylop260@vauxoo.com>\>

--- a/bus_alt_connection/readme/DESCRIPTION.md
+++ b/bus_alt_connection/readme/DESCRIPTION.md
@@ -69,3 +69,14 @@ we need odoo to connect directly to the pg server, bypassing PgBouncer.
 That's what this module implements, by overriding the relevant method of
 the
 [Dispatcher](https://github.com/odoo/odoo/blob/12.0/addons/bus/models/bus.py#L105).
+
+## What about cron workers?
+
+Since the cron workers were reworked to be woken up through `LISTEN
+cron_trigger`, they also keep a long-lived listening connection to the
+`postgres` database, with the same PgBouncer limitation as the bus
+dispatcher.
+
+This module also redirects those cron LISTEN connections to the
+alternate host/port, while the connections actually processing the jobs
+keep going through the regular `db_host`/`db_port` (i.e. PgBouncer).

--- a/bus_alt_connection/static/description/index.html
+++ b/bus_alt_connection/static/description/index.html
@@ -404,8 +404,8 @@ instances.</p>
 your priorities, e.g. :</p>
 <ul class="simple">
 <li>key odoo instance on host A can open up to 30 connections</li>
-<li>while odoo instance on host B, dedicated to reports, can open up to 10
-connections only</li>
+<li>while odoo instance on host B, dedicated to reports, can open up to
+10 connections only</li>
 </ul>
 <p>And most importantly, it helps you to ensure that <tt class="docutils literal">max_connections</tt>
 will never be reached on pg server side.</p>
@@ -438,6 +438,16 @@ we need odoo to connect directly to the pg server, bypassing PgBouncer.</p>
 <p>That’s what this module implements, by overriding the relevant method of
 the
 <a class="reference external" href="https://github.com/odoo/odoo/blob/12.0/addons/bus/models/bus.py#L105">Dispatcher</a>.</p>
+</div>
+<div class="section" id="what-about-cron-workers">
+<h2>What about cron workers?</h2>
+<p>Since the cron workers were reworked to be woken up through
+<tt class="docutils literal">LISTEN cron_trigger</tt>, they also keep a long-lived listening
+connection to the <tt class="docutils literal">postgres</tt> database, with the same PgBouncer
+limitation as the bus dispatcher.</p>
+<p>This module also redirects those cron LISTEN connections to the
+alternate host/port, while the connections actually processing the jobs
+keep going through the regular <tt class="docutils literal">db_host</tt>/<tt class="docutils literal">db_port</tt> (i.e. PgBouncer).</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -482,6 +492,26 @@ the
 </span><span class="na">imdispatcher_db_host</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">db-01</span><span class="w">
 </span><span class="na">imdispatcher_db_port</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">5432</span>
 </pre>
+<p>The cron LISTEN connections use the same settings by default. If you
+need a different host/port for them, you can override it:</p>
+<ul>
+<li><p class="first">Either by defining environment variables:</p>
+<blockquote>
+<ul class="simple">
+<li><tt class="docutils literal"><span class="pre">ODOO_CRON_DB_HOST=db-01</span></tt></li>
+<li><tt class="docutils literal">ODOO_CRON_DB_PORT=5432</tt></li>
+</ul>
+</blockquote>
+</li>
+<li><p class="first">Or in Odoo’s configuration file:</p>
+</li>
+</ul>
+<pre class="code ini literal-block">
+<span class="k">[options]</span><span class="w">
+</span><span class="na">(...)</span><span class="w">
+</span><span class="na">cron_db_host</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">db-01</span><span class="w">
+</span><span class="na">cron_db_port</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="s">5432</span>
+</pre>
 </div>
 <div class="section" id="bug-tracker">
 <h3><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h3>
@@ -505,6 +535,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2>Contributors</h2>
 <ul class="simple">
 <li>Nils Hamerlinck &lt;<a class="reference external" href="mailto:nils&#64;trobz.com">nils&#64;trobz.com</a>&gt;</li>
+<li>Moisés López &lt;<a class="reference external" href="mailto:moylop260&#64;vauxoo.com">moylop260&#64;vauxoo.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Since the cron workers are woken up through LISTEN cron_trigger, they also keep a long-lived listening connection to the "postgres" database, which is not compatible with PgBouncer in transaction pooling mode, the same limitation this module already solves for the bus dispatcher.

There is no hook to alter only that connection: both WorkerCron.start (prefork) and ThreadedServer.cron_thread (threaded) call sql_db.db_connect("postgres") directly. So flag the cron entry points with a thread-local and redirect their connections to the "postgres" database to the alternate host/port, while the connections actually processing the jobs keep going through the regular db_host/db_port (i.e. PgBouncer).

The new ODOO_CRON_DB_HOST/PORT (or cron_db_host/port) settings fall back to the existing imdispatcher ones, so a single configuration covers both LISTEN/NOTIFY connections.