### PR TITLE
[19.0] dbfilter_from_header: tests, maintainer

### DIFF
--- a/dbfilter_from_header/README.rst
+++ b/dbfilter_from_header/README.rst
@@ -132,6 +132,14 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-hbrunn| image:: https://github.com/hbrunn.png?size=40px
+    :target: https://github.com/hbrunn
+    :alt: hbrunn
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-hbrunn| 
+
 This module is part of the `OCA/server-tools <https://github.com/OCA/server-tools/tree/19.0/dbfilter_from_header>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/dbfilter_from_header/__manifest__.py
+++ b/dbfilter_from_header/__manifest__.py
@@ -12,6 +12,7 @@
     "license": "AGPL-3",
     "category": "Tools",
     "depends": ["web"],
+    "maintainers": ["hbrunn"],
     "auto_install": False,
     "installable": True,
 }

--- a/dbfilter_from_header/static/description/index.html
+++ b/dbfilter_from_header/static/description/index.html
@@ -471,6 +471,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/hbrunn"><img alt="hbrunn" src="https://github.com/hbrunn.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/server-tools/tree/19.0/dbfilter_from_header">OCA/server-tools</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/dbfilter_from_header/tests/__init__.py
+++ b/dbfilter_from_header/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dbfilter_from_header

--- a/dbfilter_from_header/tests/test_dbfilter_from_header.py
+++ b/dbfilter_from_header/tests/test_dbfilter_from_header.py
@@ -1,0 +1,58 @@
+import importlib
+
+from odoo import http
+from odoo.tests.common import TransactionCase
+from odoo.tools import config
+
+from odoo.addons.http_routing.tests.common import MockRequest
+
+from .. import override
+
+
+class TestDbfilterFromHeader(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.config_org = {}
+        for key in ("proxy_mode", "server_wide_modules", "dbfilter", "db_name"):
+            self.config_org[key] = config[key]
+        self.db_filter_org = http.db_filter
+        config["dbfilter"] = "^db1|db2$"
+        config["proxy_mode"] = True
+        config["server_wide_modules"] = "dbfilter_from_header"
+        importlib.reload(override)
+
+    def test_dbfilter_with_header(self):
+        """
+        Test that with a dbfilter set in config, it restricts what is selectable
+        via the header
+        """
+        with MockRequest(self.env) as mock_request:
+            mock_request.httprequest.environ["HTTP_X_ODOO_DBFILTER"] = "^db2|db3$"
+            filtered_dbs = http.db_filter(["db1", "db2", "db3"])
+        self.assertEqual(filtered_dbs, ["db2"])
+
+    def test_dbfilter_without_header(self):
+        """
+        Test that with a dbfilter set in config and no header added, standard behavior
+        is applied
+        """
+        with MockRequest(self.env):
+            filtered_dbs = http.db_filter(["db1", "db2", "db3"])
+        self.assertEqual(filtered_dbs, ["db1", "db2"])
+
+    def test_no_dbfilter_with_header(self):
+        """
+        Test that with no dbfilter set in config, filter from header is unrestricted
+        """
+        config["dbfilter"] = ""
+        config["db_name"] = ""
+        with MockRequest(self.env) as mock_request:
+            mock_request.httprequest.environ["HTTP_X_ODOO_DBFILTER"] = "^db2|db3$"
+            filtered_dbs = http.db_filter(["db1", "db2", "db3"])
+        self.assertEqual(filtered_dbs, ["db2", "db3"])
+
+    def tearDown(self):
+        super().tearDown()
+        for key, value in self.config_org.items():
+            config[key] = value
+        http.db_filter = self.db_filter_org


### PR DESCRIPTION
as there's been some [confusion](https://github.com/OCA/server-tools/pull/3694#pullrequestreview-4875691553) about how this addon should work, I think it's important to enshrine correct behavior in tests. Will backport this to relevant versions.