### PR TITLE
Allow muting the startup message

### DIFF
--- a/sentry/README.rst
+++ b/sentry/README.rst
@@ -98,6 +98,7 @@ options:
    sentry_environment = production
    sentry_release = 1.3.2
    sentry_odoo_dir = /home/odoo/odoo/
+   sentry_startup_message = true
 
 Usage
 =====
@@ -158,6 +159,7 @@ Contributors
 - Jon Ashton <jon@monkeyinferno.com>
 - Mark Schuit <mark@gig.solutions>
 - Atchuthan <atchuthan@sodexis.com>
+- Koert van der Veer <info@ondergetekende.nl>
 
 Other credits
 -------------

--- a/sentry/hooks.py
+++ b/sentry/hooks.py
@@ -179,9 +179,10 @@ def initialize_sentry(config):
 
         odoo.http.Application.__call__ = sentry_application_call
 
-    with sentry_sdk.new_scope() as scope:
-        scope.set_extra("debug", False)
-        sentry_sdk.capture_message("Starting Odoo Server", "info")
+    if config.get("sentry_startup_message", True) not in (False, "False", "false"):
+        with sentry_sdk.new_scope() as scope:
+            scope.set_extra("debug", False)
+            sentry_sdk.capture_message("Starting Odoo Server", "info")
 
     return client
 

--- a/sentry/readme/CONFIGURE.md
+++ b/sentry/readme/CONFIGURE.md
@@ -32,3 +32,4 @@ options:
     sentry_environment = production
     sentry_release = 1.3.2
     sentry_odoo_dir = /home/odoo/odoo/
+    sentry_startup_message = true

--- a/sentry/readme/CONTRIBUTORS.md
+++ b/sentry/readme/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - Jon Ashton \<<jon@monkeyinferno.com>\>
 - Mark Schuit \<<mark@gig.solutions>\>
 - Atchuthan \<<atchuthan@sodexis.com>\>
+- Koert van der Veer \<<info@ondergetekende.nl>\>

--- a/sentry/static/description/index.html
+++ b/sentry/static/description/index.html
@@ -445,6 +445,7 @@ sentry_include_context = true
 sentry_environment = production
 sentry_release = 1.3.2
 sentry_odoo_dir = /home/odoo/odoo/
+sentry_startup_message = true
 </pre>
 </div>
 </div>
@@ -501,6 +502,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Jon Ashton &lt;<a class="reference external" href="mailto:jon&#64;monkeyinferno.com">jon&#64;monkeyinferno.com</a>&gt;</li>
 <li>Mark Schuit &lt;<a class="reference external" href="mailto:mark&#64;gig.solutions">mark&#64;gig.solutions</a>&gt;</li>
 <li>Atchuthan &lt;<a class="reference external" href="mailto:atchuthan&#64;sodexis.com">atchuthan&#64;sodexis.com</a>&gt;</li>
+<li>Koert van der Veer &lt;<a class="reference external" href="mailto:info&#64;ondergetekende.nl">info&#64;ondergetekende.nl</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/sentry/tests/test_client.py
+++ b/sentry/tests/test_client.py
@@ -270,6 +270,17 @@ class TestClientSetup(TransactionCase):
             "Failed to use 'sentry_release' parameter appropriately",
         )
 
+    @patch("odoo.addons.sentry.hooks.sentry_sdk.capture_message")
+    def test_sentry_startup_message_toggle(self, capture_message):
+        self.patch_config({"sentry_startup_message": False})
+        initialize_sentry(sentry_hooks.sentry_config)
+        capture_message.assert_not_called()
+
+        capture_message.reset_mock()
+        self.patch_config({"sentry_startup_message": True})
+        initialize_sentry(sentry_hooks.sentry_config)
+        capture_message.assert_called_once_with("Starting Odoo Server", "info")
+
     def test_initialize_sentry_patches_application_call_when_server_missing(self):
         original_root = odoo.http.root
         original_application = odoo.http.Application


### PR DESCRIPTION
Odoo.sh loads the application quite frequently during normal operation (even when not restarting the server). Each time it does, sentry get reinitialized. This sends to a substantial number of messages to Sentry, draining a non-trivial portion of monitoring budget when using SaaS Sentry.

Giving users a way to mute this message will allow them to cut this noise.