### PR TITLE
[16.0][FIX] upgrade_analysis: prevent dependency on MarkupSafe >= 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cryptography
 dataclasses
 dnspython
 josepy
-mako
+mako<1.4.0
 numpy
 odoo_test_helper
 odoorpc

--- a/upgrade_analysis/__manifest__.py
+++ b/upgrade_analysis/__manifest__.py
@@ -22,7 +22,9 @@
     "installable": True,
     "depends": ["base"],
     "external_dependencies": {
-        "python": ["mako", "dataclasses", "odoorpc", "openupgradelib"],
+        # Keep mako below 1.4.0 as it requires MarkupSafe >= 2.0.0 which
+        # causes dependency hell when running Odoo 16 with Python 3.10
+        "python": ["mako<1.4.0", "dataclasses", "odoorpc", "openupgradelib"],
     },
     "license": "AGPL-3",
 }


### PR DESCRIPTION
This halts test jobs on `could not obtain odoo.addons.__path__ using python` due to the incompatibility of Odoo 16's required version of Jinja2 on Python 3.10

```
++ oca_list_external_dependencies deb
could not obtain odoo.addons.__path__ using python
not found in addons path: base,fs_storage,mail_environment,queue_job,test_performance
```

Avoiding manifestoo obscuring the error with some debug code leads to the following traceback:
```
+ unbuffer /opt/odoo-venv/bin/odoo -d odoo -i account,base,base_import,base_setup,base_sparse_field,bus,crm,fs_storage,iap,mail,mail_environment,purchase,queue_job,sale_management,test_mail,web --http-interface=127.0.0.1 --stop-after-init
Traceback (most recent call last):
  File "/opt/odoo-venv/bin/odoo", line 5, in <module>
    import odoo
  File "/opt/odoo/odoo/__init__.py", line 155, in <module>
    from . import cli
  File "/opt/odoo/odoo/cli/__init__.py", line 11, in <module>
    from . import scaffold
  File "/opt/odoo/odoo/cli/scaffold.py", line 8, in <module>
    import jinja2
  File "/opt/odoo-venv/lib/python3.10/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/opt/odoo-venv/lib/python3.10/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/opt/odoo-venv/lib/python3.10/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/opt/odoo-venv/lib/python3.10/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/odoo-venv/lib/python3.10/site-packages/markupsafe/__init__.py)
```

This points to a compatibility issue with MarkupSafe which has been updated to (currently) 3.0.3 by pip while resolving test dependencies:

<details>
<pre>2026-08-19T12:59:32.8782745Z + env SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE=none WHOOL_POST_VERSION_STRATEGY_OVERRIDE=none pyproject-dependencies --no-isolation --ignore-build-errors ./odoo_test_xmlrunner/pyproject.toml ./setup/_metapackage/setup.py ./setup/attachment_delete_restrict/setup.py ./setup/attachment_logging/setup.py ./setup/attachment_queue/setup.py ./setup/attachment_synchronize/setup.py ./setup/attachment_unindex_content/setup.py ./setup/auditlog/setup.py ./setup/auto_backup/setup.py ./setup/autovacuum_message_attachment/setup.py ./setup/base_changeset/setup.py ./setup/base_conditional_image/setup.py ./setup/base_cron_exclusion/setup.py ./setup/base_domain_inverse_function/setup.py ./setup/base_exception/setup.py ./setup/base_fontawesome/setup.py ./setup/base_force_record_noupdate/setup.py ./setup/base_import_default_enable_tracking/setup.py ./setup/base_import_odoo/setup.py ./setup/base_kanban_stage/setup.py ./setup/base_m2m_custom_field/setup.py ./setup/base_model_restrict_update/setup.py ./setup/base_multi_image/setup.py ./setup/base_name_search_improved/setup.py ./setup/base_partition/setup.py ./setup/base_remote/setup.py ./setup/base_report_auto_create_qweb/setup.py ./setup/base_search_fuzzy/setup.py ./setup/base_sequence_default/setup.py ./setup/base_sequence_option/setup.py ./setup/base_sparse_field_list_support/setup.py ./setup/base_technical_user/setup.py ./setup/base_time_window/setup.py ./setup/base_view_inheritance_extension/setup.py ./setup/bus_alt_connection/setup.py ./setup/cron_daylight_saving_time_resistant/setup.py ./setup/database_cleanup/setup.py ./setup/datetime_formatter/setup.py ./setup/dbfilter_from_header/setup.py ./setup/excel_import_export/setup.py ./setup/excel_import_export_demo/setup.py ./setup/excel_import_export_unidecode/setup.py ./setup/fetchmail_attach_from_folder/setup.py ./setup/fetchmail_notify_error_to_sender/setup.py ./setup/fetchmail_notify_error_to_sender_test/setup.py ./setup/field_vector/setup.py ./setup/html_image_url_extractor/setup.py ./setup/html_text/setup.py ./setup/iap_alternative_provider/setup.py ./setup/jsonifier/setup.py ./setup/letsencrypt/setup.py ./setup/mail_cleanup/setup.py ./setup/mail_template_attachment_i18n/setup.py ./setup/module_analysis/setup.py ./setup/module_auto_update/setup.py ./setup/module_change_auto_install/setup.py ./setup/nsca_client/setup.py ./setup/odoo_test_xmlrunner/setup.py ./setup/onchange_helper/setup.py ./setup/postgres_vacuum/setup.py ./setup/rpc_helper/setup.py ./setup/scheduler_error_mailer/setup.py ./setup/sentry/setup.py ./setup/sequence_python/setup.py ./setup/server_action_logging/setup.py ./setup/session_db/setup.py ./setup/test_auditlog/setup.py ./setup/tracking_manager/setup.py ./setup/upgrade_analysis/setup.py ./setup/url_attachment_search_fuzzy/setup.py
2026-08-19T12:59:46.8299832Z Warning: odoo-addon-odoo-test-xmlrunner already seen, ignoring /__w/server-tools/server-tools/setup/odoo_test_xmlrunner
2026-08-19T12:59:49.7290860Z + cat test-requirements.txt
2026-08-19T12:59:49.7303686Z cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
2026-08-19T12:59:49.7305033Z cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes
2026-08-19T12:59:49.7305922Z odoo_test_helper
2026-08-19T12:59:49.7306532Z acme
2026-08-19T12:59:49.7306843Z astor
2026-08-19T12:59:49.7307161Z cryptography
2026-08-19T12:59:49.7307492Z dataclasses
2026-08-19T12:59:49.7307825Z dnspython
2026-08-19T12:59:49.7308140Z josepy
2026-08-19T12:59:49.7308414Z mako
2026-08-19T12:59:49.7308607Z numpy
2026-08-19T12:59:49.7309090Z odoo-addon-fs_storage<16.1dev,>=16.0dev
2026-08-19T12:59:49.7309538Z odoo-addon-mail_environment<16.1dev,>=16.0dev
2026-08-19T12:59:49.7309992Z odoo-addon-queue_job<16.1dev,>=16.0dev
2026-08-19T12:59:49.7310402Z odoo<16.1dev,>=16.0a
2026-08-19T12:59:49.7310764Z odoo>=16.0a,<16.1dev
2026-08-19T12:59:49.7311147Z odoo_test_helper
2026-08-19T12:59:49.7311499Z odoorpc
2026-08-19T12:59:49.7311811Z openpyxl
2026-08-19T12:59:49.7312128Z openupgradelib
2026-08-19T12:59:49.7312484Z paramiko<4.0.0
2026-08-19T12:59:49.7312856Z pygount
2026-08-19T12:59:49.7313128Z pysftp
2026-08-19T12:59:49.7313460Z sentry_sdk<=1.9.0
2026-08-19T12:59:49.7313838Z unidecode
2026-08-19T12:59:49.7314202Z unittest-xml-reporting
2026-08-19T12:59:49.7327584Z + '[' -e test-constraints.txt ']'
2026-08-19T12:59:49.7328331Z + python -c 'import sys; sys.exit(sys.version_info < (3,6))'
2026-08-19T12:59:49.7438481Z + oca_list_addons_to_test_as_url_reqs
2026-08-19T12:59:49.7761446Z + '[' -n '' ']'
2026-08-19T12:59:49.7765822Z ++ manifestoo --select-addons-dir . --select-exclude database_cleanup,tracking_manager list --separator=,
2026-08-19T12:59:50.8542331Z + ADDONS=attachment_delete_restrict,attachment_logging,attachment_queue,attachment_synchronize,attachment_unindex_content,auditlog,auto_backup,autovacuum_message_attachment,base_changeset,base_conditional_image,base_cron_exclusion,base_domain_inverse_function,base_exception,base_fontawesome,base_force_record_noupdate,base_import_default_enable_tracking,base_import_odoo,base_kanban_stage,base_m2m_custom_field,base_model_restrict_update,base_multi_image,base_name_search_improved,base_partition,base_remote,base_report_auto_create_qweb,base_search_fuzzy,base_sequence_default,base_sequence_option,base_sparse_field_list_support,base_technical_user,base_time_window,base_view_inheritance_extension,bus_alt_connection,cron_daylight_saving_time_resistant,datetime_formatter,dbfilter_from_header,excel_import_export,excel_import_export_demo,excel_import_export_unidecode,fetchmail_attach_from_folder,fetchmail_notify_error_to_sender,fetchmail_notify_error_to_sender_test,field_vector,html_image_url_extractor,html_text,iap_alternative_provider,jsonifier,letsencrypt,mail_cleanup,mail_template_attachment_i18n,module_analysis,module_auto_update,module_change_auto_install,nsca_client,odoo_test_xmlrunner,onchange_helper,postgres_vacuum,rpc_helper,scheduler_error_mailer,sentry,sequence_python,server_action_logging,session_db,test_auditlog,upgrade_analysis,url_attachment_search_fuzzy
2026-08-19T12:59:50.8563852Z + echo attachment_delete_restrict,attachment_logging,attachment_queue,attachment_synchronize,attachment_unindex_content,auditlog,auto_backup,autovacuum_message_attachment,base_changeset,base_conditional_image,base_cron_exclusion,base_domain_inverse_function,base_exception,base_fontawesome,base_force_record_noupdate,base_import_default_enable_tracking,base_import_odoo,base_kanban_stage,base_m2m_custom_field,base_model_restrict_update,base_multi_image,base_name_search_improved,base_partition,base_remote,base_report_auto_create_qweb,base_search_fuzzy,base_sequence_default,base_sequence_option,base_sparse_field_list_support,base_technical_user,base_time_window,base_view_inheritance_extension,bus_alt_connection,cron_daylight_saving_time_resistant,datetime_formatter,dbfilter_from_header,excel_import_export,excel_import_export_demo,excel_import_export_unidecode,fetchmail_attach_from_folder,fetchmail_notify_error_to_sender,fetchmail_notify_error_to_sender_test,field_vector,html_image_url_extractor,html_text,iap_alternative_provider,jsonifier,letsencrypt,mail_cleanup,mail_template_attachment_i18n,module_analysis,module_auto_update,module_change_auto_install,nsca_client,odoo_test_xmlrunner,onchange_helper,postgres_vacuum,rpc_helper,scheduler_error_mailer,sentry,sequence_python,server_action_logging,session_db,test_auditlog,upgrade_analysis,url_attachment_search_fuzzy
2026-08-19T12:59:50.8645219Z + cat test-constraints.txt
2026-08-19T12:59:50.8659856Z odoo-addon-attachment_delete_restrict @ file:///__w/server-tools/server-tools/setup/attachment_delete_restrict
2026-08-19T12:59:50.8661162Z odoo-addon-attachment_logging @ file:///__w/server-tools/server-tools/setup/attachment_logging
2026-08-19T12:59:50.8662292Z odoo-addon-attachment_queue @ file:///__w/server-tools/server-tools/setup/attachment_queue
2026-08-19T12:59:50.8663523Z odoo-addon-attachment_synchronize @ file:///__w/server-tools/server-tools/setup/attachment_synchronize
2026-08-19T12:59:50.8664849Z odoo-addon-attachment_unindex_content @ file:///__w/server-tools/server-tools/setup/attachment_unindex_content
2026-08-19T12:59:50.8665525Z odoo-addon-auditlog @ file:///__w/server-tools/server-tools/setup/auditlog
2026-08-19T12:59:50.8666296Z odoo-addon-auto_backup @ file:///__w/server-tools/server-tools/setup/auto_backup
2026-08-19T12:59:50.8666962Z odoo-addon-autovacuum_message_attachment @ file:///__w/server-tools/server-tools/setup/autovacuum_message_attachment
2026-08-19T12:59:50.8667642Z odoo-addon-base_changeset @ file:///__w/server-tools/server-tools/setup/base_changeset
2026-08-19T12:59:50.8668281Z odoo-addon-base_conditional_image @ file:///__w/server-tools/server-tools/setup/base_conditional_image
2026-08-19T12:59:50.8668947Z odoo-addon-base_cron_exclusion @ file:///__w/server-tools/server-tools/setup/base_cron_exclusion
2026-08-19T12:59:50.8669632Z odoo-addon-base_domain_inverse_function @ file:///__w/server-tools/server-tools/setup/base_domain_inverse_function
2026-08-19T12:59:50.8670292Z odoo-addon-base_exception @ file:///__w/server-tools/server-tools/setup/base_exception
2026-08-19T12:59:50.8670862Z odoo-addon-base_fontawesome @ file:///__w/server-tools/server-tools/setup/base_fontawesome
2026-08-19T12:59:50.8671549Z odoo-addon-base_force_record_noupdate @ file:///__w/server-tools/server-tools/setup/base_force_record_noupdate
2026-08-19T12:59:50.8672345Z odoo-addon-base_import_default_enable_tracking @ file:///__w/server-tools/server-tools/setup/base_import_default_enable_tracking
2026-08-19T12:59:50.8673087Z odoo-addon-base_import_odoo @ file:///__w/server-tools/server-tools/setup/base_import_odoo
2026-08-19T12:59:50.8673669Z odoo-addon-base_kanban_stage @ file:///__w/server-tools/server-tools/setup/base_kanban_stage
2026-08-19T12:59:50.8674281Z odoo-addon-base_m2m_custom_field @ file:///__w/server-tools/server-tools/setup/base_m2m_custom_field
2026-08-19T12:59:50.8674958Z odoo-addon-base_model_restrict_update @ file:///__w/server-tools/server-tools/setup/base_model_restrict_update
2026-08-19T12:59:50.8675877Z odoo-addon-base_multi_image @ file:///__w/server-tools/server-tools/setup/base_multi_image
2026-08-19T12:59:50.8676746Z odoo-addon-base_name_search_improved @ file:///__w/server-tools/server-tools/setup/base_name_search_improved
2026-08-19T12:59:50.8677392Z odoo-addon-base_partition @ file:///__w/server-tools/server-tools/setup/base_partition
2026-08-19T12:59:50.8677927Z odoo-addon-base_remote @ file:///__w/server-tools/server-tools/setup/base_remote
2026-08-19T12:59:50.8678704Z odoo-addon-base_report_auto_create_qweb @ file:///__w/server-tools/server-tools/setup/base_report_auto_create_qweb
2026-08-19T12:59:50.8679373Z odoo-addon-base_search_fuzzy @ file:///__w/server-tools/server-tools/setup/base_search_fuzzy
2026-08-19T12:59:50.8679980Z odoo-addon-base_sequence_default @ file:///__w/server-tools/server-tools/setup/base_sequence_default
2026-08-19T12:59:50.8680609Z odoo-addon-base_sequence_option @ file:///__w/server-tools/server-tools/setup/base_sequence_option
2026-08-19T12:59:50.8681301Z odoo-addon-base_sparse_field_list_support @ file:///__w/server-tools/server-tools/setup/base_sparse_field_list_support
2026-08-19T12:59:50.8681982Z odoo-addon-base_technical_user @ file:///__w/server-tools/server-tools/setup/base_technical_user
2026-08-19T12:59:50.8682560Z odoo-addon-base_time_window @ file:///__w/server-tools/server-tools/setup/base_time_window
2026-08-19T12:59:50.8683231Z odoo-addon-base_view_inheritance_extension @ file:///__w/server-tools/server-tools/setup/base_view_inheritance_extension
2026-08-19T12:59:50.8683920Z odoo-addon-bus_alt_connection @ file:///__w/server-tools/server-tools/setup/bus_alt_connection
2026-08-19T12:59:50.8684642Z odoo-addon-cron_daylight_saving_time_resistant @ file:///__w/server-tools/server-tools/setup/cron_daylight_saving_time_resistant
2026-08-19T12:59:50.8685360Z odoo-addon-datetime_formatter @ file:///__w/server-tools/server-tools/setup/datetime_formatter
2026-08-19T12:59:50.8686173Z odoo-addon-dbfilter_from_header @ file:///__w/server-tools/server-tools/setup/dbfilter_from_header
2026-08-19T12:59:50.8686816Z odoo-addon-excel_import_export @ file:///__w/server-tools/server-tools/setup/excel_import_export
2026-08-19T12:59:50.8687457Z odoo-addon-excel_import_export_demo @ file:///__w/server-tools/server-tools/setup/excel_import_export_demo
2026-08-19T12:59:50.8688170Z odoo-addon-excel_import_export_unidecode @ file:///__w/server-tools/server-tools/setup/excel_import_export_unidecode
2026-08-19T12:59:50.8688909Z odoo-addon-fetchmail_attach_from_folder @ file:///__w/server-tools/server-tools/setup/fetchmail_attach_from_folder
2026-08-19T12:59:50.8689679Z odoo-addon-fetchmail_notify_error_to_sender @ file:///__w/server-tools/server-tools/setup/fetchmail_notify_error_to_sender
2026-08-19T12:59:50.8690512Z odoo-addon-fetchmail_notify_error_to_sender_test @ file:///__w/server-tools/server-tools/setup/fetchmail_notify_error_to_sender_test
2026-08-19T12:59:50.8691209Z odoo-addon-field_vector @ file:///__w/server-tools/server-tools/setup/field_vector
2026-08-19T12:59:50.8691815Z odoo-addon-html_image_url_extractor @ file:///__w/server-tools/server-tools/setup/html_image_url_extractor
2026-08-19T12:59:50.8692396Z odoo-addon-html_text @ file:///__w/server-tools/server-tools/setup/html_text
2026-08-19T12:59:50.8692979Z odoo-addon-iap_alternative_provider @ file:///__w/server-tools/server-tools/setup/iap_alternative_provider
2026-08-19T12:59:50.8693563Z odoo-addon-jsonifier @ file:///__w/server-tools/server-tools/setup/jsonifier
2026-08-19T12:59:50.8694066Z odoo-addon-letsencrypt @ file:///__w/server-tools/server-tools/setup/letsencrypt
2026-08-19T12:59:50.8694591Z odoo-addon-mail_cleanup @ file:///__w/server-tools/server-tools/setup/mail_cleanup
2026-08-19T12:59:50.8695224Z odoo-addon-mail_template_attachment_i18n @ file:///__w/server-tools/server-tools/setup/mail_template_attachment_i18n
2026-08-19T12:59:50.8695886Z odoo-addon-module_analysis @ file:///__w/server-tools/server-tools/setup/module_analysis
2026-08-19T12:59:50.8696718Z odoo-addon-module_auto_update @ file:///__w/server-tools/server-tools/setup/module_auto_update
2026-08-19T12:59:50.8697550Z odoo-addon-module_change_auto_install @ file:///__w/server-tools/server-tools/setup/module_change_auto_install
2026-08-19T12:59:50.8698155Z odoo-addon-nsca_client @ file:///__w/server-tools/server-tools/setup/nsca_client
2026-08-19T12:59:50.8698690Z odoo-addon-odoo_test_xmlrunner @ file:///__w/server-tools/server-tools/odoo_test_xmlrunner
2026-08-19T12:59:50.8699256Z odoo-addon-onchange_helper @ file:///__w/server-tools/server-tools/setup/onchange_helper
2026-08-19T12:59:50.8699938Z odoo-addon-postgres_vacuum @ file:///__w/server-tools/server-tools/setup/postgres_vacuum
2026-08-19T12:59:50.8700476Z odoo-addon-rpc_helper @ file:///__w/server-tools/server-tools/setup/rpc_helper
2026-08-19T12:59:50.8701051Z odoo-addon-scheduler_error_mailer @ file:///__w/server-tools/server-tools/setup/scheduler_error_mailer
2026-08-19T12:59:50.8701611Z odoo-addon-sentry @ file:///__w/server-tools/server-tools/setup/sentry
2026-08-19T12:59:50.8702117Z odoo-addon-sequence_python @ file:///__w/server-tools/server-tools/setup/sequence_python
2026-08-19T12:59:50.8702712Z odoo-addon-server_action_logging @ file:///__w/server-tools/server-tools/setup/server_action_logging
2026-08-19T12:59:50.8703389Z odoo-addon-session_db @ file:///__w/server-tools/server-tools/setup/session_db
2026-08-19T12:59:50.8703946Z odoo-addon-test_auditlog @ file:///__w/server-tools/server-tools/setup/test_auditlog
2026-08-19T12:59:50.8704501Z odoo-addon-upgrade_analysis @ file:///__w/server-tools/server-tools/setup/upgrade_analysis
2026-08-19T12:59:50.8705161Z odoo-addon-url_attachment_search_fuzzy @ file:///__w/server-tools/server-tools/setup/url_attachment_search_fuzzy
2026-08-19T12:59:50.8705773Z + pip install -r test-requirements.txt -c test-constraints.txt
2026-08-19T12:59:51.1109134Z WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
2026-08-19T12:59:51.2528382Z Looking in indexes: https://wheelhouse.odoo-community.org/oca-simple-and-pypi
2026-08-19T12:59:51.2535047Z Ignoring cryptography: markers 'python_version >= "3.12"' don't match your environment
2026-08-19T12:59:51.2542107Z Requirement already satisfied: cryptography==3.4.8 in /opt/odoo-venv/lib/python3.10/site-packages (from -r test-requirements.txt (line 1)) (3.4.8)
2026-08-19T12:59:52.2019825Z Collecting odoo_test_helper (from -r test-requirements.txt (line 3))
2026-08-19T12:59:52.2373771Z   Downloading odoo_test_helper-2.1.3-py3-none-any.whl.metadata (5.5 kB)
2026-08-19T12:59:52.4503431Z Collecting acme (from -r test-requirements.txt (line 4))
2026-08-19T12:59:52.4545599Z   Downloading acme-5.7.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T12:59:52.6442424Z Collecting astor (from -r test-requirements.txt (line 5))
2026-08-19T12:59:52.6482954Z   Downloading astor-0.8.1-py2.py3-none-any.whl.metadata (4.2 kB)
2026-08-19T12:59:52.8359154Z Collecting dataclasses (from -r test-requirements.txt (line 7))
2026-08-19T12:59:52.8391133Z   Downloading dataclasses-0.6-py3-none-any.whl.metadata (3.0 kB)
2026-08-19T12:59:53.0282764Z Collecting dnspython (from -r test-requirements.txt (line 8))
2026-08-19T12:59:53.0317367Z   Downloading dnspython-2.8.0-py3-none-any.whl.metadata (5.7 kB)
2026-08-19T12:59:53.2248562Z Collecting josepy (from -r test-requirements.txt (line 9))
2026-08-19T12:59:53.2288587Z   Downloading josepy-2.2.0-py3-none-any.whl.metadata (1.7 kB)
2026-08-19T12:59:53.4217115Z Collecting mako (from -r test-requirements.txt (line 10))
2026-08-19T12:59:53.4249453Z   Downloading mako-1.4.1-py3-none-any.whl.metadata (2.9 kB)
2026-08-19T12:59:53.8067764Z Collecting numpy (from -r test-requirements.txt (line 11))
2026-08-19T12:59:53.8102615Z   Downloading numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
2026-08-19T12:59:54.1868478Z Collecting odoo-addon-fs_storage<16.1dev,>=16.0dev (from -r test-requirements.txt (line 12))
2026-08-19T12:59:54.5444023Z   Downloading odoo_addon_fs_storage-16.0.2.0.0.4-py3-none-any.whl (62 kB)
2026-08-19T12:59:55.0889034Z Collecting odoo-addon-mail_environment<16.1dev,>=16.0dev (from -r test-requirements.txt (line 13))
2026-08-19T12:59:55.2692817Z   Downloading odoo_addon_mail_environment-16.0.1.0.2.2-py3-none-any.whl (35 kB)
2026-08-19T12:59:55.6503030Z Collecting odoo-addon-queue_job<16.1dev,>=16.0dev (from -r test-requirements.txt (line 14))
2026-08-19T12:59:55.8310292Z   Downloading odoo_addon_queue_job-16.0.3.0.1.4-py3-none-any.whl (336 kB)
2026-08-19T12:59:56.1929813Z Requirement already satisfied: odoo<16.1dev,>=16.0a in /opt/odoo-venv/lib/python3.10/site-packages (from -r test-requirements.txt (line 15)) (16.0)
2026-08-19T12:59:56.4417304Z Collecting odoorpc (from -r test-requirements.txt (line 18))
2026-08-19T12:59:56.4459307Z   Downloading OdooRPC-0.10.1-py2.py3-none-any.whl.metadata (4.8 kB)
2026-08-19T12:59:56.6369359Z Collecting openpyxl (from -r test-requirements.txt (line 19))
2026-08-19T12:59:56.6399791Z   Downloading openpyxl-3.1.5-py2.py3-none-any.whl.metadata (2.5 kB)
2026-08-19T12:59:56.8942901Z Collecting openupgradelib (from -r test-requirements.txt (line 20))
2026-08-19T12:59:56.8980501Z   Downloading openupgradelib-3.13.6-py2.py3-none-any.whl.metadata (10 kB)
2026-08-19T12:59:57.0985220Z Collecting paramiko<4.0.0 (from -r test-requirements.txt (line 21))
2026-08-19T12:59:57.1015477Z   Downloading paramiko-3.5.1-py3-none-any.whl.metadata (4.6 kB)
2026-08-19T12:59:57.2930241Z Collecting pygount (from -r test-requirements.txt (line 22))
2026-08-19T12:59:57.2970357Z   Downloading pygount-3.2.0-py3-none-any.whl.metadata (6.4 kB)
2026-08-19T12:59:57.4838370Z Collecting pysftp (from -r test-requirements.txt (line 23))
2026-08-19T12:59:57.4867273Z   Downloading pysftp-0.2.9.tar.gz (25 kB)
2026-08-19T12:59:57.4964654Z   Installing build dependencies: started
2026-08-19T12:59:58.9932790Z   Installing build dependencies: finished with status 'done'
2026-08-19T12:59:58.9939367Z   Getting requirements to build wheel: started
2026-08-19T12:59:59.2917857Z   Getting requirements to build wheel: finished with status 'done'
2026-08-19T12:59:59.2929318Z   Preparing metadata (pyproject.toml): started
2026-08-19T12:59:59.4672996Z   Preparing metadata (pyproject.toml): finished with status 'done'
2026-08-19T12:59:59.6914447Z Collecting sentry_sdk<=1.9.0 (from -r test-requirements.txt (line 24))
2026-08-19T12:59:59.6959227Z   Downloading sentry_sdk-1.9.0-py2.py3-none-any.whl.metadata (7.8 kB)
2026-08-19T12:59:59.8903684Z Collecting unidecode (from -r test-requirements.txt (line 25))
2026-08-19T12:59:59.8935867Z   Downloading Unidecode-1.4.0-py3-none-any.whl.metadata (13 kB)
2026-08-19T13:00:00.0850301Z Collecting unittest-xml-reporting (from -r test-requirements.txt (line 26))
2026-08-19T13:00:00.0891169Z   Downloading unittest_xml_reporting-4.0.0-py2.py3-none-any.whl.metadata (11 kB)
2026-08-19T13:00:00.0936700Z Requirement already satisfied: cffi>=1.12 in /opt/odoo-venv/lib/python3.10/site-packages (from cryptography==3.4.8->-r test-requirements.txt (line 1)) (2.1.1)
2026-08-19T13:00:00.4562769Z Collecting odoo-addon-fs-storage-environment (from odoo-addon-fs_storage<16.1dev,>=16.0dev->-r test-requirements.txt (line 12))
2026-08-19T13:00:00.8144179Z   Downloading odoo_addon_fs_storage_environment-16.0.1.0.0.4-py3-none-any.whl (25 kB)
2026-08-19T13:00:01.0100678Z Collecting fsspec>=2024.5.0 (from odoo-addon-fs_storage<16.1dev,>=16.0dev->-r test-requirements.txt (line 12))
2026-08-19T13:00:01.0131221Z   Downloading fsspec-2026.7.0-py3-none-any.whl.metadata (10 kB)
2026-08-19T13:00:01.4058826Z Collecting odoo-addon-server-environment<16.1dev,>=16.0dev (from odoo-addon-mail_environment<16.1dev,>=16.0dev->-r test-requirements.txt (line 13))
2026-08-19T13:00:01.5864053Z   Downloading odoo_addon_server_environment-16.0.1.1.2.3-py3-none-any.whl (197 kB)
2026-08-19T13:00:01.9483583Z Requirement already satisfied: requests in /opt/odoo-venv/lib/python3.10/site-packages (from odoo-addon-queue_job<16.1dev,>=16.0dev->-r test-requirements.txt (line 14)) (2.25.1)
2026-08-19T13:00:01.9501787Z Requirement already satisfied: babel>=1.0 in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.9.1)
2026-08-19T13:00:01.9506572Z Requirement already satisfied: chardet in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (4.0.0)
2026-08-19T13:00:01.9511572Z Requirement already satisfied: decorator in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (4.4.2)
2026-08-19T13:00:01.9515035Z Requirement already satisfied: docutils in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.16)
2026-08-19T13:00:01.9519196Z Requirement already satisfied: gevent in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (26.8.0)
2026-08-19T13:00:01.9523780Z Requirement already satisfied: greenlet in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (3.5.5)
2026-08-19T13:00:01.9528547Z Requirement already satisfied: idna in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.10)
2026-08-19T13:00:01.9532929Z Requirement already satisfied: Jinja2 in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.11.3)
2026-08-19T13:00:01.9537647Z Requirement already satisfied: lxml in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (4.6.5)
2026-08-19T13:00:01.9542040Z Requirement already satisfied: libsass in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.20.1)
2026-08-19T13:00:01.9546702Z Requirement already satisfied: MarkupSafe in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.1.1)
2026-08-19T13:00:01.9551100Z Requirement already satisfied: num2words in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.5.9)
2026-08-19T13:00:01.9555018Z Requirement already satisfied: ofxparse in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.21)
2026-08-19T13:00:01.9559444Z Requirement already satisfied: passlib in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.7.4)
2026-08-19T13:00:01.9563954Z Requirement already satisfied: pillow in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (9.0.1)
2026-08-19T13:00:01.9568743Z Requirement already satisfied: polib in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.1.0)
2026-08-19T13:00:01.9573011Z Requirement already satisfied: psutil in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (5.8.0)
2026-08-19T13:00:01.9578183Z Requirement already satisfied: psycopg2>=2.2 in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.9.2)
2026-08-19T13:00:01.9582603Z Requirement already satisfied: pydot in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.4.2)
2026-08-19T13:00:01.9586888Z Requirement already satisfied: pyopenssl in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (20.0.1)
2026-08-19T13:00:01.9591569Z Requirement already satisfied: PyPDF2 in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.26.0)
2026-08-19T13:00:01.9595676Z Requirement already satisfied: pyserial in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (3.5)
2026-08-19T13:00:01.9600258Z Requirement already satisfied: python-dateutil in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.8.1)
2026-08-19T13:00:01.9603877Z Requirement already satisfied: python-stdnum in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.16)
2026-08-19T13:00:01.9608852Z Requirement already satisfied: pytz in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2026.3.post1)
2026-08-19T13:00:01.9613542Z Requirement already satisfied: pyusb>=1.0.0b1 in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.0.2)
2026-08-19T13:00:01.9617625Z Requirement already satisfied: qrcode in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (6.1)
2026-08-19T13:00:01.9621941Z Requirement already satisfied: reportlab in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (3.5.59)
2026-08-19T13:00:01.9626820Z Requirement already satisfied: urllib3 in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.26.5)
2026-08-19T13:00:01.9631274Z Requirement already satisfied: vobject in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.9.6.1)
2026-08-19T13:00:01.9635310Z Requirement already satisfied: werkzeug in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.0.2)
2026-08-19T13:00:01.9639795Z Requirement already satisfied: xlrd in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.2.0)
2026-08-19T13:00:01.9650925Z Requirement already satisfied: xlsxwriter in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.1.2)
2026-08-19T13:00:01.9655091Z Requirement already satisfied: xlwt in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.3.0)
2026-08-19T13:00:01.9659634Z Requirement already satisfied: zeep in /opt/odoo-venv/lib/python3.10/site-packages (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (4.0.0)
2026-08-19T13:00:02.1968986Z Collecting bcrypt>=3.2 (from paramiko<4.0.0->-r test-requirements.txt (line 21))
2026-08-19T13:00:02.2004390Z   Downloading bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl.metadata (10 kB)
2026-08-19T13:00:02.3988666Z Collecting pynacl>=1.5 (from paramiko<4.0.0->-r test-requirements.txt (line 21))
2026-08-19T13:00:02.4017720Z   Downloading pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl.metadata (10.0 kB)
2026-08-19T13:00:02.4050620Z Requirement already satisfied: certifi in /opt/odoo-venv/lib/python3.10/site-packages (from sentry_sdk<=1.9.0->-r test-requirements.txt (line 24)) (2026.7.22)
2026-08-19T13:00:02.7567418Z INFO: pip is looking at multiple versions of acme to determine which version is compatible with other requirements. This could take a while.
2026-08-19T13:00:02.7572983Z Collecting acme (from -r test-requirements.txt (line 4))
2026-08-19T13:00:02.7616499Z   Downloading acme-5.6.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7678612Z   Downloading acme-5.5.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7737320Z   Downloading acme-5.4.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7804418Z   Downloading acme-5.3.1-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7861182Z   Downloading acme-5.3.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7914642Z   Downloading acme-5.2.2-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7972753Z   Downloading acme-5.2.1-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.7991005Z INFO: pip is still looking at multiple versions of acme to determine which version is compatible with other requirements. This could take a while.
2026-08-19T13:00:02.8034799Z   Downloading acme-5.1.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.8089457Z   Downloading acme-5.0.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.8146328Z   Downloading acme-4.2.0-py3-none-any.whl.metadata (1.5 kB)
2026-08-19T13:00:02.8202908Z   Downloading acme-4.1.1-py3-none-any.whl.metadata (1.5 kB)
2026-08-19T13:00:02.8264899Z   Downloading acme-4.1.0-py3-none-any.whl.metadata (1.5 kB)
2026-08-19T13:00:02.8284987Z INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
2026-08-19T13:00:02.8326738Z   Downloading acme-4.0.0-py3-none-any.whl.metadata (1.5 kB)
2026-08-19T13:00:02.8385581Z   Downloading acme-3.3.0-py3-none-any.whl.metadata (1.5 kB)
2026-08-19T13:00:02.8805592Z   Downloading acme-3.2.0-py3-none-any.whl.metadata (1.5 kB)
2026-08-19T13:00:02.9083873Z   Downloading acme-3.1.0-py3-none-any.whl.metadata (1.3 kB)
2026-08-19T13:00:02.9112333Z Collecting josepy (from -r test-requirements.txt (line 9))
2026-08-19T13:00:02.9166019Z   Downloading josepy-1.15.0-py3-none-any.whl.metadata (1.7 kB)
2026-08-19T13:00:03.1035042Z Collecting pyrfc3339 (from acme->-r test-requirements.txt (line 4))
2026-08-19T13:00:03.1063868Z   Downloading pyrfc3339-2.1.0-py3-none-any.whl.metadata (2.8 kB)
2026-08-19T13:00:03.3338071Z Collecting MarkupSafe (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15))
2026-08-19T13:00:03.3372575Z   Downloading markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.7 kB)
2026-08-19T13:00:03.5247727Z Collecting et-xmlfile (from openpyxl->-r test-requirements.txt (line 19))
2026-08-19T13:00:03.5285536Z   Downloading et_xmlfile-2.0.0-py3-none-any.whl.metadata (2.7 kB)
2026-08-19T13:00:03.7173510Z Collecting cssselect (from openupgradelib->-r test-requirements.txt (line 20))
2026-08-19T13:00:03.7202394Z   Downloading cssselect-1.5.0-py3-none-any.whl.metadata (2.4 kB)
2026-08-19T13:00:03.9288484Z Collecting chardet (from odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15))
2026-08-19T13:00:03.9321386Z   Downloading chardet-5.2.0-py3-none-any.whl.metadata (3.4 kB)
2026-08-19T13:00:04.1306382Z Collecting gitpython~=3.1 (from pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:04.1339604Z   Downloading gitpython-3.1.59-py3-none-any.whl.metadata (13 kB)
2026-08-19T13:00:04.3310722Z Collecting pygments<3,>=2 (from pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:04.3341999Z   Downloading pygments-2.21.0-py3-none-any.whl.metadata (2.5 kB)
2026-08-19T13:00:04.5391947Z Collecting rich>=14 (from pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:04.5426126Z   Downloading rich-15.0.0-py3-none-any.whl.metadata (18 kB)
2026-08-19T13:00:04.7333412Z Collecting gitdb<5,>=4.0.1 (from gitpython~=3.1->pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:04.7365809Z   Downloading gitdb-4.0.12-py3-none-any.whl.metadata (1.2 kB)
2026-08-19T13:00:04.9257026Z Collecting smmap<6,>=3.0.1 (from gitdb<5,>=4.0.1->gitpython~=3.1->pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:04.9284928Z   Downloading smmap-5.0.3-py3-none-any.whl.metadata (4.6 kB)
2026-08-19T13:00:04.9411375Z Requirement already satisfied: pycparser in /opt/odoo-venv/lib/python3.10/site-packages (from cffi>=1.12->cryptography==3.4.8->-r test-requirements.txt (line 1)) (3.0)
2026-08-19T13:00:04.9459328Z Requirement already satisfied: six>=1.5.2 in /opt/odoo-venv/lib/python3.10/site-packages (from pyopenssl->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.17.0)
2026-08-19T13:00:04.9504351Z INFO: pip is looking at multiple versions of requests to determine which version is compatible with other requirements. This could take a while.
2026-08-19T13:00:05.1464958Z Collecting requests (from odoo-addon-queue_job<16.1dev,>=16.0dev->-r test-requirements.txt (line 14))
2026-08-19T13:00:05.1495934Z   Downloading requests-2.34.2-py3-none-any.whl.metadata (4.8 kB)
2026-08-19T13:00:05.4595505Z Collecting charset_normalizer<4,>=2 (from requests->odoo-addon-queue_job<16.1dev,>=16.0dev->-r test-requirements.txt (line 14))
2026-08-19T13:00:05.4632734Z   Downloading charset_normalizer-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (45 kB)
2026-08-19T13:00:05.6617694Z Collecting markdown-it-py>=2.2.0 (from rich>=14->pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:05.6648493Z   Downloading markdown_it_py-4.2.0-py3-none-any.whl.metadata (7.4 kB)
2026-08-19T13:00:05.8587210Z Collecting mdurl~=0.1 (from markdown-it-py>=2.2.0->rich>=14->pygount->-r test-requirements.txt (line 22))
2026-08-19T13:00:05.8617888Z   Downloading mdurl-0.1.2-py3-none-any.whl.metadata (1.6 kB)
2026-08-19T13:00:05.8723562Z Requirement already satisfied: zope.event in /opt/odoo-venv/lib/python3.10/site-packages (from gevent->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (6.2)
2026-08-19T13:00:05.8727681Z Requirement already satisfied: zope.interface in /opt/odoo-venv/lib/python3.10/site-packages (from gevent->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (8.5)
2026-08-19T13:00:05.8801622Z Requirement already satisfied: docopt>=0.6.2 in /opt/odoo-venv/lib/python3.10/site-packages (from num2words->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.6.2)
2026-08-19T13:00:05.8837183Z Requirement already satisfied: beautifulsoup4 in /opt/odoo-venv/lib/python3.10/site-packages (from ofxparse->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (4.15.0)
2026-08-19T13:00:05.8858340Z Requirement already satisfied: soupsieve>=1.6.1 in /opt/odoo-venv/lib/python3.10/site-packages (from beautifulsoup4->ofxparse->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.9.2)
2026-08-19T13:00:05.8863099Z Requirement already satisfied: typing-extensions>=4.0.0 in /opt/odoo-venv/lib/python3.10/site-packages (from beautifulsoup4->ofxparse->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (4.16.0)
2026-08-19T13:00:05.8948729Z Requirement already satisfied: pyparsing>=2.1.4 in /opt/odoo-venv/lib/python3.10/site-packages (from pydot->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (3.3.2)
2026-08-19T13:00:05.9118313Z Requirement already satisfied: appdirs>=1.4.0 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.4.4)
2026-08-19T13:00:05.9122659Z Requirement already satisfied: attrs>=17.2.0 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (26.1.0)
2026-08-19T13:00:05.9127403Z Requirement already satisfied: cached-property>=1.3.0 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (2.0.1)
2026-08-19T13:00:05.9132281Z Requirement already satisfied: defusedxml>=0.4.1 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.7.1)
2026-08-19T13:00:05.9136875Z Requirement already satisfied: isodate>=0.5.4 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (0.7.2)
2026-08-19T13:00:05.9144183Z Requirement already satisfied: requests-toolbelt>=0.7.1 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (1.0.0)
2026-08-19T13:00:05.9149561Z Requirement already satisfied: requests-file>=1.5.1 in /opt/odoo-venv/lib/python3.10/site-packages (from zeep->odoo<16.1dev,>=16.0a->-r test-requirements.txt (line 15)) (3.0.1)
2026-08-19T13:00:05.9304784Z Downloading paramiko-3.5.1-py3-none-any.whl (227 kB)
2026-08-19T13:00:05.9350597Z Downloading sentry_sdk-1.9.0-py2.py3-none-any.whl (156 kB)
2026-08-19T13:00:05.9425439Z Downloading odoo_test_helper-2.1.3-py3-none-any.whl (14 kB)
2026-08-19T13:00:05.9461415Z Downloading acme-3.1.0-py3-none-any.whl (95 kB)
2026-08-19T13:00:05.9489975Z Downloading josepy-1.15.0-py3-none-any.whl (32 kB)
2026-08-19T13:00:05.9527329Z Downloading astor-0.8.1-py2.py3-none-any.whl (27 kB)
2026-08-19T13:00:05.9554912Z Downloading dataclasses-0.6-py3-none-any.whl (14 kB)
2026-08-19T13:00:05.9585544Z Downloading dnspython-2.8.0-py3-none-any.whl (331 kB)
2026-08-19T13:00:05.9618293Z Downloading mako-1.4.1-py3-none-any.whl (80 kB)
2026-08-19T13:00:05.9648494Z Downloading numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
2026-08-19T13:00:06.0001542Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.8/16.8 MB 521.9 MB/s  0:00:00
2026-08-19T13:00:06.0044021Z Downloading OdooRPC-0.10.1-py2.py3-none-any.whl (38 kB)
2026-08-19T13:00:06.0075069Z Downloading openpyxl-3.1.5-py2.py3-none-any.whl (250 kB)
2026-08-19T13:00:06.0121108Z Downloading openupgradelib-3.13.6-py2.py3-none-any.whl (87 kB)
2026-08-19T13:00:06.0160626Z Downloading pygount-3.2.0-py3-none-any.whl (30 kB)
2026-08-19T13:00:06.0207413Z Downloading chardet-5.2.0-py3-none-any.whl (199 kB)
2026-08-19T13:00:06.0241796Z Downloading gitpython-3.1.59-py3-none-any.whl (220 kB)
2026-08-19T13:00:06.0273799Z Downloading gitdb-4.0.12-py3-none-any.whl (62 kB)
2026-08-19T13:00:06.0303301Z Downloading pygments-2.21.0-py3-none-any.whl (1.3 MB)
2026-08-19T13:00:06.0351246Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 602.6 MB/s  0:00:00
2026-08-19T13:00:06.0383870Z Downloading smmap-5.0.3-py3-none-any.whl (24 kB)
2026-08-19T13:00:06.0413151Z Downloading Unidecode-1.4.0-py3-none-any.whl (235 kB)
2026-08-19T13:00:06.0456665Z Downloading unittest_xml_reporting-4.0.0-py2.py3-none-any.whl (20 kB)
2026-08-19T13:00:06.0485213Z Downloading bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl (278 kB)
2026-08-19T13:00:06.0520220Z Downloading fsspec-2026.7.0-py3-none-any.whl (206 kB)
2026-08-19T13:00:06.0552897Z Downloading markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (20 kB)
2026-08-19T13:00:06.0585004Z Downloading pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl (1.4 MB)
2026-08-19T13:00:06.0646463Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.4/1.4 MB 564.6 MB/s  0:00:00
2026-08-19T13:00:06.0666706Z Downloading requests-2.34.2-py3-none-any.whl (73 kB)
2026-08-19T13:00:06.0707242Z Downloading charset_normalizer-3.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (261 kB)
2026-08-19T13:00:06.0743677Z Downloading rich-15.0.0-py3-none-any.whl (310 kB)
2026-08-19T13:00:06.0779601Z Downloading markdown_it_py-4.2.0-py3-none-any.whl (91 kB)
2026-08-19T13:00:06.0810221Z Downloading mdurl-0.1.2-py3-none-any.whl (10.0 kB)
2026-08-19T13:00:06.0838544Z Downloading cssselect-1.5.0-py3-none-any.whl (20 kB)
2026-08-19T13:00:06.0866436Z Downloading et_xmlfile-2.0.0-py3-none-any.whl (18 kB)
2026-08-19T13:00:06.0895345Z Downloading pyrfc3339-2.1.0-py3-none-any.whl (6.8 kB)
2026-08-19T13:00:06.2173537Z Building wheels for collected packages: pysftp
2026-08-19T13:00:06.2184076Z   Building wheel for pysftp (pyproject.toml): started
2026-08-19T13:00:06.4167811Z   Building wheel for pysftp (pyproject.toml): finished with status 'done'
2026-08-19T13:00:06.4174738Z   Created wheel for pysftp: filename=pysftp-0.2.9-py3-none-any.whl size=15587 sha256=0f1e0edf7df2889777641a4ccc89c66a93460696fb9bc25f63990de438bdbb40
2026-08-19T13:00:06.4177088Z   Stored in directory: /tmp/pip-ephem-wheel-cache-cw7kuj7t/wheels/64/52/87/2683826a06d053045a9bd11f05850e26bbdbfbf821ee6735f0
2026-08-19T13:00:06.4193371Z Successfully built pysftp
2026-08-19T13:00:06.5178496Z Installing collected packages: odoorpc, dataclasses, unittest-xml-reporting, unidecode, smmap, sentry_sdk, pyrfc3339, pygments, odoo_test_helper, numpy, mdurl, MarkupSafe, fsspec, et-xmlfile, dnspython, cssselect, charset_normalizer, chardet, bcrypt, astor, requests, pynacl, openupgradelib, openpyxl, markdown-it-py, mako, gitdb, rich, paramiko, gitpython, pysftp, pygount, josepy, acme, odoo-addon-server-environment, odoo-addon-queue_job, odoo-addon-mail_environment, odoo-addon-fs-storage-environment, odoo-addon-fs_storage
2026-08-19T13:00:09.0948176Z   Attempting uninstall: MarkupSafe
2026-08-19T13:00:09.0954882Z     Found existing installation: MarkupSafe 1.1.1
2026-08-19T13:00:09.0979356Z     Uninstalling MarkupSafe-1.1.1:
2026-08-19T13:00:09.0991759Z       Successfully uninstalled MarkupSafe-1.1.1
2026-08-19T13:00:09.4585321Z   Attempting uninstall: chardet
2026-08-19T13:00:09.4591315Z     Found existing installation: chardet 4.0.0
2026-08-19T13:00:09.4651968Z     Uninstalling chardet-4.0.0:
2026-08-19T13:00:09.4678156Z       Successfully uninstalled chardet-4.0.0
2026-08-19T13:00:09.6276460Z   Attempting uninstall: requests
2026-08-19T13:00:09.6283044Z     Found existing installation: requests 2.25.1
2026-08-19T13:00:09.6317939Z     Uninstalling requests-2.25.1:
2026-08-19T13:00:09.6330610Z       Successfully uninstalled requests-2.25.1
</pre>
</details>

Example of PR demonstrating the issue: https://github.com/OCA/server-tools/pull/3698
Example of failed run with debug info: https://github.com/OCA/server-tools/actions/runs/32255125804/job/96074931556
