### PR TITLE
[16.0][FIX] upgrade_analysis: update documentation link

### DIFF
--- a/upgrade_analysis/readme/DESCRIPTION.rst
+++ b/upgrade_analysis/readme/DESCRIPTION.rst
@@ -3,7 +3,7 @@ how the Odoo data model and module data have changed between two versions of Odo
 Database analysis files for the core modules are included in the OpenUpgrade
 distribution so as a migration script developer you will not usually need to use
 this tool yourself. If you do need to run your analysis of a custom set of modules,
-please refer to the documentation here: https://doc.therp.nl/openupgrade/analysis.html
+please refer to the documentation here: https://oca.github.io/OpenUpgrade/070_migration_files.html#generate-the-difference-analysis-files
 
 This module is just a tool, a continuation of the old openupgrade_records in
 OpenUpgrade in previous versions. It's not recommended to have this module in a


### PR DESCRIPTION
The OpenUpgrade documentation link in `upgrade_analysis` is no longer available.

This updates it to the current OpenUpgrade documentation page.

Closes #3102