### PR TITLE
[FIX] tracking_manager: display booleans as Yes/No

### DIFF
--- a/tracking_manager/models/models.py
+++ b/tracking_manager/models/models.py
@@ -6,7 +6,7 @@
 
 from collections import defaultdict
 
-from odoo import Command, api, models, tools
+from odoo import Command, _, api, models, tools
 from odoo.exceptions import AccessError
 
 from ..tools import format_m2m
@@ -73,6 +73,10 @@ class Base(models.AbstractModel):
                 elif field.type == "many2one":
                     old = before.display_name
                     new = self[field_name]["display_name"]
+                elif field.type == "boolean":
+                    # a falsy value would be rendered as an empty string
+                    old = _("Yes") if before else _("No")
+                    new = _("Yes") if self[field_name] else _("No")
                 else:
                     old = before
                     new = self[field_name]

--- a/tracking_manager/tests/test_tracking_manager.py
+++ b/tracking_manager/tests/test_tracking_manager.py
@@ -271,3 +271,17 @@ class TestTrackingManager(TransactionCase):
         )
         child.write({"parent_id": False})
         self.assertEqual(len(self.messages), 1)
+
+    def test_o2m_update_boolean(self):
+        self.env.ref("base.field_res_partner__child_ids").custom_tracking = True
+        self.env.ref("base.field_res_partner__is_company").custom_tracking = True
+        child = self.env["res.partner"].create(
+            {"name": "Test child", "parent_id": self.partner.id}
+        )
+        self.flush_tracking()
+        self.partner.message_ids.unlink()
+        child.write({"is_company": True})
+        self.assertEqual(len(self.messages), 1)
+        body = " ".join(self.messages.body.split())
+        self.assertIn("Is a Company : No", body)
+        self.assertIn("Yes", body)


### PR DESCRIPTION
A boolean was rendered by the message template as its python value, so a change to `False` showed nothing at all: `Archived : True -> `. Render both values the way the web client renders native tracking values.