### PR TITLE
[17.0][FIX] upgrade_analysis: update documentation link

### DIFF
--- a/upgrade_analysis/readme/DESCRIPTION.md
+++ b/upgrade_analysis/readme/DESCRIPTION.md
@@ -5,7 +5,7 @@ modules are included in the OpenUpgrade distribution so as a migration
 script developer you will not usually need to use this tool yourself. If
 you do need to run your analysis of a custom set of modules, please
 refer to the documentation here:
-<https://doc.therp.nl/openupgrade/analysis.html>
+<https://oca.github.io/OpenUpgrade/070_migration_files.html#generate-the-difference-analysis-files>
 
 This module is just a tool, a continuation of the old
 openupgrade_records in OpenUpgrade in previous versions. It's not


### PR DESCRIPTION
The OpenUpgrade documentation link in `upgrade_analysis` is no longer available

This updates it to the current OpenUpgrade documentation page

Follow-up to #3710