### PR TITLE
[19.0][FIX] auditlog: flush pending recomputations before swapping the cache

### DIFF
--- a/auditlog/models/auditlog_rule.py
+++ b/auditlog/models/auditlog_rule.py
@@ -70,6 +70,7 @@ class ThrowAwayCache:
     ]
 
     def __init__(self, env):
+        self._env = env
         self._transaction = env.transaction
 
     def __enter__(self):
@@ -80,6 +81,12 @@ class ThrowAwayCache:
         to the cursor, so if we want to keep using the same cursor, we need to
         patch out these properties.
         """
+        # Flush any pending updates and recomputations first. If the cache is
+        # set aside while recomputations of stored computed fields are still
+        # pending, they end up being consumed after the swap/read/restore
+        # cycle without ever being persisted, leaving NULL columns in the
+        # database (see OCA/server-tools#3635).
+        self._env.flush_all()
         for attribute in self.transaction_attributes:
             instance = getattr(self._transaction, attribute)
             setattr(

--- a/test_auditlog/tests/__init__.py
+++ b/test_auditlog/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_account_bank_statement_line
 from . import test_account_move_reverse
 from . import test_product_tax_multicompany
 from . import test_account_reentrancy
+from . import test_payment_residual

--- a/test_auditlog/tests/test_payment_residual.py
+++ b/test_auditlog/tests/test_payment_residual.py
@@ -1,0 +1,57 @@
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.auditlog.tests.common import AuditLogRuleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentResidual(AccountTestInvoicingCommon, AuditLogRuleCommon):
+    def setUp(self):
+        super().setUp()
+        self.rule = self.env["auditlog.rule"].create(
+            {
+                "name": __name__,
+                "model_id": self.env.ref("account.model_account_move").id,
+                "log_read": True,
+                "log_create": True,
+                "log_write": True,
+                "log_unlink": True,
+                "log_type": "full",
+            }
+        )
+        self.rule.set_to_confirmed()
+
+    def test_register_payment_computes_residual(self):
+        """Payment lines keep their stored computed values with a full rule.
+
+        With a full-log rule on account.move, the swapped-cache reads of the
+        log diff must not cause the pending recomputations of the payment
+        lines' stored computed fields to be lost, or those columns end up
+        NULL in the database (issue #3635: the payment is then never offered
+        as an outstanding credit on the invoice).
+        """
+        invoice = self.init_invoice("out_invoice", products=self.product_a, post=True)
+        wizard = (
+            self.env["account.payment.register"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"journal_id": self.company_data["default_journal_bank"].id})
+        )
+        payments = wizard._create_payments()
+        self.env.flush_all()
+        self.env.cr.execute(
+            """
+            SELECT id, amount_residual, amount_residual_currency, reconciled
+            FROM account_move_line
+            WHERE move_id = %s
+            """,
+            (payments.move_id.id,),
+        )
+        rows = self.env.cr.fetchall()
+        self.assertTrue(rows)
+        for line_id, residual, residual_currency, reconciled in rows:
+            self.assertIsNotNone(residual, f"line {line_id}: amount_residual is NULL")
+            self.assertIsNotNone(
+                residual_currency,
+                f"line {line_id}: amount_residual_currency is NULL",
+            )
+            self.assertIsNotNone(reconciled, f"line {line_id}: reconciled is NULL")


### PR DESCRIPTION
Fixes #3635.

With a full-log rule on `account.move`, registering a payment leaves the payment's liquidity move line with `amount_residual` / `amount_residual_currency` / `reconciled` set to NULL in the database. The outstanding-credits widget domain (`_compute_payments_widget_to_reconcile_info`) ends in `'|', ('amount_residual', '!=', 0.0), ('amount_residual_currency', '!=', 0.0)`; with both columns NULL neither leg matches, so the payment is never proposed as an outstanding credit on the invoice. We hit this in production and reproduced it on a virgin database with only `account` (demo data) + `auditlog`.

What the trace shows (instrumenting the transaction state around `ThrowAwayCache` and peeking at the database at each step):

1. When `write_full()` performs the old-values read inside `ThrowAwayCache`, the payment's move lines still have pending recomputations of their stored computed fields in `transaction.tocompute`.
2. The context manager itself restores `tocompute` intact on exit. But after this swap/read/restore cycle, those pending recomputations are consumed during the subsequent `write.origin` + `flush_recordset()` without being persisted: they leave `tocompute`, never appear in `field_dirty`, and the database columns remain NULL.
3. The receivable counterpart line happens to be healed later by the reconciliation's own recompute; the liquidity line is never recomputed again, so its columns stay NULL forever.

With a *Fast log* rule (no `ThrowAwayCache`) the very same flow marks the lines dirty and they reach the database.

The fix makes the swap safe by flushing everything still pending right before setting the cache aside, in `ThrowAwayCache.__enter__`: with nothing pending, there is nothing the swap can lose, and the values read for the log are read after the pending state is persisted. `env.flush_all()` is broader than the strict minimum, but this is a correctness fix and the flushed work is work the transaction had to do anyway.

Includes a regression test (post an invoice → register a payment with a full-log rule on `account.move` → assert the payment lines' stored computed columns are not NULL). It fails on current 19.0 with `AssertionError: unexpectedly None : line ...: amount_residual is NULL` and passes with the fix; the whole `auditlog` + `test_auditlog` suite is green (58 tests).

May also be related to #3638 (same disposable-cache family); not verified.
