### PR TITLE
[FIX] bus_alt_connection: wrong configuration key in documentation

### DIFF
--- a/bus_alt_connection/readme/CONFIGURE.rst
+++ b/bus_alt_connection/readme/CONFIGURE.rst
@@ -2,8 +2,8 @@ You need to define how to connect directly to the database:
 
 * Either by defining environment variables:
 
-    - ``IMDISPATCHER_DB_HOST=db-01``
-    - ``IMDISPATCHER_DB_PORT=5432``
+    - ``ODOO_IMDISPATCHER_DB_HOST=db-01``
+    - ``ODOO_IMDISPATCHER_DB_PORT=5432``
 
 * Or in Odoo's configuration file:
 


### PR DESCRIPTION
Into the code it checks for a prefix like ODOO_IMDISPATCHER_DB_ See: https://github.com/OCA/server-tools/blob/18.0/bus_alt_connection/models/bus.py#L24C32-L24C53

- [x] fix: wrong configuration in documentation

I am currently wondering why we have distinct values given if the configuration is done in config or environment:
`os.environ.get(f"ODOO_IMDISPATCHER_DB_{p.upper()}")` VS `config.get("imdispatcher_db_" + p)`

Wouldn't it be better to have these using the same base name?
