### PR TITLE
[18][base_exception] FIX: undetected deadlock on installation with demo data

### DIFF
--- a/base_exception/models/base_exception_method.py
+++ b/base_exception/models/base_exception_method.py
@@ -90,9 +90,16 @@ class BaseExceptionMethod(models.AbstractModel):
         # table
         # and the "to add" part generates one INSERT (with unnest) per rule.
         raise_exception = False
-        test_mode = config["test_enable"] and not self.env.context.get(
-            "test_base_exception"
-        )
+        # The registry is not ready yet when modules are being installed or
+        # updated: the ongoing transaction holds exclusive locks on the tables
+        # it has just modified (ALTER TABLE ...), so any query made through a
+        # second connection would wait forever on those locks (and the locks
+        # cannot be released, as the current thread is the one waiting).
+        # Use the current cursor in that case, as already done when running
+        # tests.
+        test_mode = (
+            config["test_enable"] or not self.env.registry.ready
+        ) and not self.env.context.get("test_base_exception")
         # Write exceptions in a new transaction to be committed so that we can
         #  rollback the ongoing one while keeping the exceptions stored
         with self.env.registry.cursor() as new_cr:


### PR DESCRIPTION
What happen is that during the installation or update of a module, the `init_models` set a hard lock (ACCESS EXCLUSIVE) on the tables. And during this same transaction, the demo data is loaded, which may call `action_confirm` on a sale order, which open a new cursor which will try a Select on the sale_order table... which is locked. So we kind of got a deadlock, but postgre won't detect it because the first lock (ACCESS EXCLUSIVE) is not waiting on the second lock

 Note: Odoo already protects the installation session itself with SET SESSION lock_timeout = '15s' (odoo/modules/loading.py), but the second connection does not inherit it, which is why the hang is not turned into an error after 15 seconds.

To reproduce the issue : 
create a new database this way, WITH demo data : odoo -i sale_stock,sale_exception
Odoo will hang for ever during the loading of sale_stock demo data which confirm a sale order.

I guess a similar problem could happen in because of https://github.com/OCA/sale-workflow/blob/18.0/sale_exception/models/sale_order_line.py#L63
But let's wait a fix on this one before doing it in sale_exception (and maybe purchase_exception, I did not check but probably the same).

@simahawk @grindtildeath @rousseldenis 
FYI @hparfr 